### PR TITLE
fix: migrate.sh base_dir path and version

### DIFF
--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 TEMPLATE_REPO="git@github.com:ycpss91255-docker/docker_template.git"
-TEMPLATE_VERSION="v0.2.0"
+TEMPLATE_VERSION="v0.3.0"
 DRY_RUN=false
 
 # ── Repo registry ────────────────────────────────────────────────────────────
@@ -462,7 +462,7 @@ EOF
 
 main() {
     local cmd=""
-    local base_dir="${SCRIPT_DIR}/.."
+    local base_dir="${SCRIPT_DIR}/../.."
 
     while [[ $# -gt 0 ]]; do
         case "$1" in


### PR DESCRIPTION
## Summary
- Fix `--list` showing wrong paths (`docker_template/env/...` → `env/...`)
- Fix `TEMPLATE_VERSION`: v0.2.0 → v0.3.0

## Root cause
After moving migrate.sh to `scripts/`, `SCRIPT_DIR/..` resolves to `docker_template/` instead of `docker/`. Changed to `SCRIPT_DIR/../..`.

## Test plan
- [x] `./scripts/migrate.sh --list` shows correct paths and versions
- [x] 124 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)