### PR TITLE
fix: update display_env.bats for tmpfs + Wayland socket pattern

### DIFF
--- a/test/smoke_test/display_env.bats
+++ b/test/smoke_test/display_env.bats
@@ -21,10 +21,15 @@ setup() {
     assert_success
 }
 
-# -------------------- compose.yaml: Wayland volume mounts --------------------
+# -------------------- compose.yaml: display mounts --------------------
 
-@test "compose.yaml mounts XDG_RUNTIME_DIR volume" {
-    run grep -E 'XDG_RUNTIME_DIR.*:.*XDG_RUNTIME_DIR' /lint/compose.yaml
+@test "compose.yaml has XDG_RUNTIME_DIR tmpfs" {
+    run grep -E 'XDG_RUNTIME_DIR.*uid=' /lint/compose.yaml
+    assert_success
+}
+
+@test "compose.yaml mounts Wayland socket" {
+    run grep -E 'WAYLAND_DISPLAY.*:.*WAYLAND_DISPLAY' /lint/compose.yaml
     assert_success
 }
 


### PR DESCRIPTION
## Summary
- Replace `XDG_RUNTIME_DIR` volume mount test with tmpfs test
- Add Wayland socket bind mount test
- New pattern: tmpfs for runtime dir (writable, container-isolated) + separate Wayland socket mount

## Test plan
- [x] 124 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)