### PR TITLE
feat: CHANGELOG in release notes + remove README changelog links

### DIFF
--- a/.github/workflows/release-worker.yaml
+++ b/.github/workflows/release-worker.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          body_path: doc/changelog/CHANGELOG.md
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |

--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -55,6 +55,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           body_path: doc/changelog/CHANGELOG.md
+          generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             docker_template-*.tar.gz

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -203,10 +203,6 @@ make help        # 全ターゲット表示
 
 詳細は [TEST.md](../test/TEST.md) を参照。
 
-## 変更履歴
-
-[CHANGELOG.md](../changelog/CHANGELOG.md) を参照。
-
 ## ディレクトリ構造
 
 ```

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -203,10 +203,6 @@ make help        # 显示所有可用命令
 
 详见 [TEST.md](../test/TEST.md)。
 
-## 变更记录
-
-详见 [CHANGELOG.md](../changelog/CHANGELOG.md)。
-
 ## 目录结构
 
 ```

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -203,10 +203,6 @@ make help        # 顯示所有可用指令
 
 詳見 [TEST.md](../test/TEST.md)。
 
-## 變更記錄
-
-詳見 [CHANGELOG.md](../changelog/CHANGELOG.md)。
-
 ## 目錄結構
 
 ```


### PR DESCRIPTION
Release workflow now uses CHANGELOG.md as body + GitHub auto-generated notes.