### PR TITLE
feat: add Makefile.consumer for consumer repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage/
 .env
+multi_run/

--- a/Makefile.consumer
+++ b/Makefile.consumer
@@ -1,0 +1,32 @@
+.PHONY: build run run-detach test runtime exec stop help
+
+build: ## Build devel image
+	./build.sh
+
+run: ## Run container (interactive)
+	./run.sh
+
+run-detach: ## Run container in background
+	./run.sh -d
+
+test: ## Build and run smoke tests
+	./build.sh test
+
+runtime: ## Build runtime image
+	./build.sh runtime
+
+exec: ## Exec into running container (default: bash)
+	./exec.sh
+
+stop: ## Stop and remove containers
+	./stop.sh
+
+upgrade: ## Upgrade docker_template subtree
+	./docker_template/script/upgrade.sh
+
+upgrade-check: ## Check for docker_template updates
+	./docker_template/script/upgrade.sh --check
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*##"}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -47,3 +47,22 @@ services:
 ~~方案 B：使用 Docker Compose `include` 合併多個 compose.yaml。~~
 
 **結論**：compose include 會合併同名 service（YAML key 層面），`-p` project name 無法解決。改用 `docker compose config` 展開 + Python 重命名 service 的方式已實作並通過測試。
+
+## v3.0.0 BREAKING CHANGE 待辦
+
+### docker_template → template 改名
+- 所有 consumer repo subtree prefix `docker_template/` → `template/`
+- 腳本路徑引用全部更新
+- CLAUDE.md、README、CI workflows 更新
+
+### setup.sh 移至 script/
+- `docker_template/setup.sh` → `docker_template/script/setup.sh`
+- build.sh/run.sh 呼叫路徑更新
+- 15 個 consumer repo Dockerfile CONFIG_SRC 路徑更新
+
+### config/ 移至 script/
+- 如果 config/ 也不是 user 直接使用的，一併移入 script/
+
+### Consumer repo Makefile
+- 在 docker_template 提供 Makefile 模板（build/run/test/stop/exec）
+- Consumer repo 透過 symlink 或 subtree 取得

--- a/script/init.sh
+++ b/script/init.sh
@@ -46,6 +46,7 @@ _symlink "${TEMPLATE_REL}/build.sh" "build.sh"
 _symlink "${TEMPLATE_REL}/run.sh" "run.sh"
 _symlink "${TEMPLATE_REL}/exec.sh" "exec.sh"
 _symlink "${TEMPLATE_REL}/stop.sh" "stop.sh"
+_symlink "${TEMPLATE_REL}/Makefile.consumer" "Makefile"
 
 # .hadolint.yaml: only symlink if no custom version exists
 if [[ ! -f .hadolint.yaml ]] || diff -q .hadolint.yaml "${TEMPLATE_REL}/.hadolint.yaml" >/dev/null 2>&1; then


### PR DESCRIPTION
Consumer repos get make build/run/test/stop/exec via symlink. init.sh auto-creates the symlink.