### PR TITLE
feat!: rename docker_template → template (v0.4.0)

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -25,17 +25,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check docker_template version
+      - name: Check template version
         run: |
-          if [ -f .docker_template_version ]; then
-            LOCAL_VER=$(cat .docker_template_version)
+          if [ -f .template_version ]; then
+            LOCAL_VER=$(cat .template_version)
             LATEST_VER=$(git ls-remote --tags --sort=-v:refname \
-              https://github.com/ycpss91255-docker/docker_template.git \
+              https://github.com/ycpss91255-docker/template.git \
               | grep -oP 'refs/tags/v\d+\.\d+\.\d+$' | head -1 | sed 's|refs/tags/||')
             if [ -n "${LATEST_VER}" ] && [ "${LOCAL_VER}" != "${LATEST_VER}" ]; then
-              echo "::warning::docker_template ${LOCAL_VER} → ${LATEST_VER} available"
+              echo "::warning::template ${LOCAL_VER} → ${LATEST_VER} available"
             else
-              echo "docker_template is up to date (${LOCAL_VER})"
+              echo "template is up to date (${LOCAL_VER})"
             fi
           fi
 

--- a/.github/workflows/release-worker.yaml
+++ b/.github/workflows/release-worker.yaml
@@ -31,7 +31,7 @@ jobs:
           cp -r Dockerfile compose.yaml \
                 build.sh run.sh exec.sh stop.sh \
                 script/ .env.example .hadolint.yaml test/smoke_test/ \
-                docker_template/ \
+                template/ \
                 README.md doc/ "${ARCHIVE_NAME}/"
 
           # Copy extra repo-specific files if specified

--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Create release archive
         run: |
           VERSION="${GITHUB_REF_NAME}"
-          ARCHIVE_NAME="docker_template-${VERSION}"
+          ARCHIVE_NAME="template-${VERSION}"
 
           mkdir -p "${ARCHIVE_NAME}"
           cp -r build.sh run.sh exec.sh stop.sh setup.sh \
@@ -58,5 +58,5 @@ jobs:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
-            docker_template-*.tar.gz
-            docker_template-*.zip
+            template-*.tar.gz
+            template-*.zip

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ exec: ## Exec into running container (default: bash)
 stop: ## Stop and remove containers
 	./stop.sh
 
-upgrade: ## Upgrade docker_template subtree
-	./docker_template/script/upgrade.sh
+upgrade: ## Upgrade template subtree
+	./template/script/upgrade.sh
 
-upgrade-check: ## Check for docker_template updates
-	./docker_template/script/upgrade.sh --check
+upgrade-check: ## Check for template updates
+	./template/script/upgrade.sh --check
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -19,15 +19,15 @@ clean: ## Remove coverage reports
 init: ## Initialize symlinks for consumer repo (first-time setup)
 	./script/init.sh
 
-upgrade: ## Upgrade docker_template subtree to latest version
+upgrade: ## Upgrade template subtree to latest version
 	./script/upgrade.sh
 
-upgrade-check: ## Check if a newer docker_template version is available
+upgrade-check: ## Check if a newer template version is available
 	./script/upgrade.sh --check
 
 # ── Batch management (template repo only) ────────────────────────────────────
 
-migrate: ## Migrate all repos from docker_setup_helper to docker_template
+migrate: ## Migrate all repos from docker_setup_helper to template
 	./script/migrate.sh --all
 
 migrate-list: ## List repos and their migration status

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# docker_template
+# template
 
-[![Self Test](https://github.com/ycpss91255-docker/docker_template/actions/workflows/self-test.yaml/badge.svg)](https://github.com/ycpss91255-docker/docker_template/actions/workflows/self-test.yaml)
-[![codecov](https://codecov.io/gh/ycpss91255-docker/docker_template/branch/main/graph/badge.svg)](https://codecov.io/gh/ycpss91255-docker/docker_template)
+[![Self Test](https://github.com/ycpss91255-docker/template/actions/workflows/self-test.yaml/badge.svg)](https://github.com/ycpss91255-docker/template/actions/workflows/self-test.yaml)
+[![codecov](https://codecov.io/gh/ycpss91255-docker/template/branch/main/graph/badge.svg)](https://codecov.io/gh/ycpss91255-docker/template)
 
 ![Language](https://img.shields.io/badge/Language-Bash-blue?style=flat-square)
 ![Testing](https://img.shields.io/badge/Testing-Bats-orange?style=flat-square)
@@ -31,9 +31,9 @@ Shared template for Docker container repos in the [ycpss91255-docker](https://gi
 
 ```bash
 # New repo: add subtree + init
-git subtree add --prefix=docker_template \
-    git@github.com:ycpss91255-docker/docker_template.git main --squash
-./docker_template/script/init.sh
+git subtree add --prefix=template \
+    git@github.com:ycpss91255-docker/template.git main --squash
+./template/script/init.sh
 
 # Upgrade to latest
 make upgrade-check   # check
@@ -52,7 +52,7 @@ This repo consolidates shared scripts, tests, and CI workflows used across all D
 
 ```mermaid
 graph TB
-    subgraph docker_template["docker_template (shared repo)"]
+    subgraph template["template (shared repo)"]
         scripts["build.sh / run.sh / exec.sh / stop.sh<br/>setup.sh / .hadolint.yaml"]
         smoke["test/smoke_test/<br/>script_help.bats<br/>display_env.bats"]
         config["config/<br/>bashrc / tmux / terminator / pip"]
@@ -61,13 +61,13 @@ graph TB
     end
 
     subgraph consumer["Docker Repo (e.g. ros_noetic)"]
-        symlinks["build.sh → docker_template/build.sh<br/>run.sh → docker_template/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
+        symlinks["build.sh → template/build.sh<br/>run.sh → template/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
         dockerfile["Dockerfile<br/>compose.yaml<br/>.env.example<br/>script/entrypoint.sh"]
         repo_test["test/smoke_test/<br/>ros_env.bats (repo-specific)"]
         main_yaml["main.yaml<br/>→ calls reusable workflows"]
     end
 
-    docker_template -- "git subtree" --> consumer
+    template -- "git subtree" --> consumer
     scripts -. symlink .-> symlinks
     smoke -. "Dockerfile COPY" .-> repo_test
     workflows -. "@tag reference" .-> main_yaml
@@ -89,8 +89,8 @@ flowchart LR
     end
 
     subgraph github["GitHub Actions"]
-        build_worker["build-worker.yaml<br/>(from docker_template)"]
-        release_worker["release-worker.yaml<br/>(from docker_template)"]
+        build_worker["build-worker.yaml<br/>(from template)"]
+        release_worker["release-worker.yaml<br/>(from template)"]
     end
 
     build_test --> ci_container
@@ -137,11 +137,11 @@ flowchart LR
 
 ```bash
 # 1. Add subtree
-git subtree add --prefix=docker_template \
-    git@github.com:ycpss91255-docker/docker_template.git main --squash
+git subtree add --prefix=template \
+    git@github.com:ycpss91255-docker/template.git main --squash
 
 # 2. Initialize symlinks (one command)
-./docker_template/script/init.sh
+./template/script/init.sh
 ```
 
 ### Updating
@@ -154,7 +154,7 @@ make upgrade-check
 make upgrade
 
 # Or specify a version
-./docker_template/script/upgrade.sh v0.3.0
+./template/script/upgrade.sh v0.3.0
 ```
 
 ## CI Reusable Workflows
@@ -165,7 +165,7 @@ Repos replace local `build-worker.yaml` / `release-worker.yaml` with calls to th
 # .github/workflows/main.yaml
 jobs:
   call-docker-build:
-    uses: ycpss91255-docker/docker_template/.github/workflows/build-worker.yaml@v1
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v1
     with:
       image_name: ros_noetic
       build_args: |
@@ -176,7 +176,7 @@ jobs:
   call-release:
     needs: call-docker-build
     if: startsWith(github.ref, 'refs/tags/')
-    uses: ycpss91255-docker/docker_template/.github/workflows/release-worker.yaml@v1
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@v1
     with:
       archive_name_prefix: ros_noetic
 ```
@@ -216,7 +216,7 @@ Or directly:
 ## Directory Structure
 
 ```
-docker_template/
+template/
 ├── build.sh                          # Shared build script
 ├── run.sh                            # Shared run script (X11/Wayland)
 ├── exec.sh                           # Shared exec script

--- a/build.sh
+++ b/build.sh
@@ -102,7 +102,7 @@ done
 
 # Generate / refresh .env
 if [[ "${SKIP_ENV}" == false ]]; then
-    "${FILE_PATH}/docker_template/script/setup.sh" --base-path "${FILE_PATH}" --lang "${_LANG}"
+    "${FILE_PATH}/template/script/setup.sh" --base-path "${FILE_PATH}" --lang "${_LANG}"
 fi
 
 # Load .env for project name

--- a/doc/changelog/CHANGELOG.ja.md
+++ b/doc/changelog/CHANGELOG.ja.md
@@ -48,20 +48,20 @@
   - `build-worker.yaml` — パラメータ化された Docker build + smoke test
   - `release-worker.yaml` — パラメータ化された GitHub Release
   - `self-test.yaml` — テンプレート自体の CI
-- **`migrate.sh`**：バッチ移行スクリプト（`docker_setup_helper` から `docker_template` への変換）
+- **`migrate.sh`**：バッチ移行スクリプト（`docker_setup_helper` から `template` への変換）
 - `.hadolint.yaml`：共有 Hadolint ルール
 - `.codecov.yaml`：カバレッジ設定
 - ドキュメント：README（英語）、README.zh-TW.md、README.zh-CN.md、README.ja.md、TEST.md
 
 ### 変更
-- `setup.sh` デフォルト `_base_path` が 1 レベル上（`/..`）に変更、旧 2 レベル（`/../..`）を置換、新しい `docker_template/setup.sh` の配置に対応
+- `setup.sh` デフォルト `_base_path` が 1 レベル上（`/..`）に変更、旧 2 レベル（`/../..`）を置換、新しい `template/setup.sh` の配置に対応
 
 ### 移行に関する注意事項
-- Consumer repos は `docker_setup_helper/` subtree を `docker_template/` subtree に置換
-- ルートのシェルスクリプトは `docker_template/` への symlinks に変更
+- Consumer repos は `docker_setup_helper/` subtree を `template/` subtree に置換
+- ルートのシェルスクリプトは `template/` への symlinks に変更
 - ローカル `build-worker.yaml` / `release-worker.yaml` は `main.yaml` 内の再利用可能な workflow 呼び出しに置換
-- Dockerfile `CONFIG_SRC` パス変更：`docker_setup_helper/src/config` → `docker_template/config`
-- 共有 smoke tests は Dockerfile `COPY docker_template/test/smoke_test/` で読み込み（symlinks ではない — Docker COPY は symlinks を追跡しない）
+- Dockerfile `CONFIG_SRC` パス変更：`docker_setup_helper/src/config` → `template/config`
+- 共有 smoke tests は Dockerfile `COPY template/test/smoke_test/` で読み込み（symlinks ではない — Docker COPY は symlinks を追跡しない）
 
-[未リリース]: https://github.com/ycpss91255-docker/docker_template/compare/v0.1.0...HEAD
-[v0.1.0]: https://github.com/ycpss91255-docker/docker_template/releases/tag/v0.1.0
+[未リリース]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/ycpss91255-docker/template/releases/tag/v0.1.0

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -48,20 +48,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `build-worker.yaml` — parameterized Docker build + smoke test
   - `release-worker.yaml` — parameterized GitHub Release
   - `self-test.yaml` — template's own CI
-- **`migrate.sh`**: batch migration script for converting repos from `docker_setup_helper` to `docker_template`
+- **`migrate.sh`**: batch migration script for converting repos from `docker_setup_helper` to `template`
 - `.hadolint.yaml`: shared Hadolint rules
 - `.codecov.yaml`: coverage configuration
 - Documentation: README (English), README.zh-TW.md, README.zh-CN.md, README.ja.md, TEST.md
 
 ### Changed
-- `setup.sh` default `_base_path` traverses 1 level up (`/..`) instead of 2 (`/../..`) to match new `docker_template/setup.sh` location
+- `setup.sh` default `_base_path` traverses 1 level up (`/..`) instead of 2 (`/../..`) to match new `template/setup.sh` location
 
 ### Migration notes
-- Consumer repos replace `docker_setup_helper/` subtree with `docker_template/` subtree
-- Shell scripts at root become symlinks to `docker_template/`
+- Consumer repos replace `docker_setup_helper/` subtree with `template/` subtree
+- Shell scripts at root become symlinks to `template/`
 - Local `build-worker.yaml` / `release-worker.yaml` replaced by reusable workflow calls in `main.yaml`
-- Dockerfile `CONFIG_SRC` path changes: `docker_setup_helper/src/config` → `docker_template/config`
-- Shared smoke tests loaded via `COPY docker_template/smoke_test/` in Dockerfile (not symlinks — Docker COPY does not follow symlinks)
+- Dockerfile `CONFIG_SRC` path changes: `docker_setup_helper/src/config` → `template/config`
+- Shared smoke tests loaded via `COPY template/smoke_test/` in Dockerfile (not symlinks — Docker COPY does not follow symlinks)
 
-[Unreleased]: https://github.com/ycpss91255-docker/docker_template/compare/v0.1.0...HEAD
-[v0.1.0]: https://github.com/ycpss91255-docker/docker_template/releases/tag/v0.1.0
+[Unreleased]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/ycpss91255-docker/template/releases/tag/v0.1.0

--- a/doc/changelog/CHANGELOG.zh-CN.md
+++ b/doc/changelog/CHANGELOG.zh-CN.md
@@ -48,20 +48,20 @@
   - `build-worker.yaml` — 参数化 Docker build + smoke test
   - `release-worker.yaml` — 参数化 GitHub Release
   - `self-test.yaml` — 模板自身 CI
-- **`migrate.sh`**：批量迁移脚本（从 `docker_setup_helper` 转换至 `docker_template`）
+- **`migrate.sh`**：批量迁移脚本（从 `docker_setup_helper` 转换至 `template`）
 - `.hadolint.yaml`：共用 Hadolint 规则
 - `.codecov.yaml`：覆盖率配置
 - 文档：README（英文）、README.zh-TW.md、README.zh-CN.md、README.ja.md、TEST.md
 
 ### 变更
-- `setup.sh` 默认 `_base_path` 改为向上 1 层（`/..`），替代原本的 2 层（`/../..`），以匹配新的 `docker_template/setup.sh` 位置
+- `setup.sh` 默认 `_base_path` 改为向上 1 层（`/..`），替代原本的 2 层（`/../..`），以匹配新的 `template/setup.sh` 位置
 
 ### 迁移注意事项
-- Consumer repos 将 `docker_setup_helper/` subtree 替换为 `docker_template/` subtree
-- 根目录的 Shell 脚本改为指向 `docker_template/` 的 symlinks
+- Consumer repos 将 `docker_setup_helper/` subtree 替换为 `template/` subtree
+- 根目录的 Shell 脚本改为指向 `template/` 的 symlinks
 - 本地 `build-worker.yaml` / `release-worker.yaml` 替换为 `main.yaml` 中的可重用 workflow 调用
-- Dockerfile `CONFIG_SRC` 路径变更：`docker_setup_helper/src/config` → `docker_template/config`
-- 共用 smoke tests 通过 Dockerfile `COPY docker_template/test/smoke_test/` 加载（非 symlinks — Docker COPY 不 follow symlinks）
+- Dockerfile `CONFIG_SRC` 路径变更：`docker_setup_helper/src/config` → `template/config`
+- 共用 smoke tests 通过 Dockerfile `COPY template/test/smoke_test/` 加载（非 symlinks — Docker COPY 不 follow symlinks）
 
-[未发布]: https://github.com/ycpss91255-docker/docker_template/compare/v0.1.0...HEAD
-[v0.1.0]: https://github.com/ycpss91255-docker/docker_template/releases/tag/v0.1.0
+[未发布]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/ycpss91255-docker/template/releases/tag/v0.1.0

--- a/doc/changelog/CHANGELOG.zh-TW.md
+++ b/doc/changelog/CHANGELOG.zh-TW.md
@@ -48,20 +48,20 @@
   - `build-worker.yaml` — 參數化 Docker build + smoke test
   - `release-worker.yaml` — 參數化 GitHub Release
   - `self-test.yaml` — 模板自身 CI
-- **`migrate.sh`**：批次遷移腳本（從 `docker_setup_helper` 轉換至 `docker_template`）
+- **`migrate.sh`**：批次遷移腳本（從 `docker_setup_helper` 轉換至 `template`）
 - `.hadolint.yaml`：共用 Hadolint 規則
 - `.codecov.yaml`：覆蓋率設定
 - 文件：README（英文）、README.zh-TW.md、README.zh-CN.md、README.ja.md、TEST.md
 
 ### 變更
-- `setup.sh` 預設 `_base_path` 改為向上 1 層（`/..`），取代原本的 2 層（`/../..`），以符合新的 `docker_template/setup.sh` 位置
+- `setup.sh` 預設 `_base_path` 改為向上 1 層（`/..`），取代原本的 2 層（`/../..`），以符合新的 `template/setup.sh` 位置
 
 ### 遷移注意事項
-- Consumer repos 將 `docker_setup_helper/` subtree 替換為 `docker_template/` subtree
-- 根目錄的 Shell 腳本改為指向 `docker_template/` 的 symlinks
+- Consumer repos 將 `docker_setup_helper/` subtree 替換為 `template/` subtree
+- 根目錄的 Shell 腳本改為指向 `template/` 的 symlinks
 - 本地 `build-worker.yaml` / `release-worker.yaml` 替換為 `main.yaml` 中的可重用 workflow 呼叫
-- Dockerfile `CONFIG_SRC` 路徑變更：`docker_setup_helper/src/config` → `docker_template/config`
-- 共用 smoke tests 透過 Dockerfile `COPY docker_template/test/smoke_test/` 載入（非 symlinks — Docker COPY 不 follow symlinks）
+- Dockerfile `CONFIG_SRC` 路徑變更：`docker_setup_helper/src/config` → `template/config`
+- 共用 smoke tests 透過 Dockerfile `COPY template/test/smoke_test/` 載入（非 symlinks — Docker COPY 不 follow symlinks）
 
-[未發布]: https://github.com/ycpss91255-docker/docker_template/compare/v0.1.0...HEAD
-[v0.1.0]: https://github.com/ycpss91255-docker/docker_template/releases/tag/v0.1.0
+[未發布]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/ycpss91255-docker/template/releases/tag/v0.1.0

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -1,7 +1,7 @@
-# docker_template
+# template
 
-[![Self Test](https://github.com/ycpss91255-docker/docker_template/actions/workflows/self-test.yaml/badge.svg)](https://github.com/ycpss91255-docker/docker_template/actions/workflows/self-test.yaml)
-[![codecov](https://codecov.io/gh/ycpss91255-docker/docker_template/branch/main/graph/badge.svg)](https://codecov.io/gh/ycpss91255-docker/docker_template)
+[![Self Test](https://github.com/ycpss91255-docker/template/actions/workflows/self-test.yaml/badge.svg)](https://github.com/ycpss91255-docker/template/actions/workflows/self-test.yaml)
+[![codecov](https://codecov.io/gh/ycpss91255-docker/template/branch/main/graph/badge.svg)](https://codecov.io/gh/ycpss91255-docker/template)
 
 ![Language](https://img.shields.io/badge/Language-Bash-blue?style=flat-square)
 ![Testing](https://img.shields.io/badge/Testing-Bats-orange?style=flat-square)
@@ -31,9 +31,9 @@
 
 ```bash
 # 新規 repo：subtree 追加 + 初期化
-git subtree add --prefix=docker_template \
-    git@github.com:ycpss91255-docker/docker_template.git main --squash
-./docker_template/script/init.sh
+git subtree add --prefix=template \
+    git@github.com:ycpss91255-docker/template.git main --squash
+./template/script/init.sh
 
 # 最新版にアップグレード
 make upgrade-check   # 確認
@@ -52,7 +52,7 @@ make help            # 全コマンド表示
 
 ```mermaid
 graph TB
-    subgraph docker_template["docker_template（共有 repo）"]
+    subgraph template["template（共有 repo）"]
         scripts["build.sh / run.sh / exec.sh / stop.sh<br/>setup.sh / .hadolint.yaml"]
         smoke["test/smoke_test/<br/>script_help.bats<br/>display_env.bats"]
         config["config/<br/>bashrc / tmux / terminator / pip"]
@@ -61,13 +61,13 @@ graph TB
     end
 
     subgraph consumer["Docker Repo（例: ros_noetic）"]
-        symlinks["build.sh → docker_template/build.sh<br/>run.sh → docker_template/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
+        symlinks["build.sh → template/build.sh<br/>run.sh → template/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
         dockerfile["Dockerfile<br/>compose.yaml<br/>.env.example<br/>script/entrypoint.sh"]
         repo_test["test/smoke_test/<br/>ros_env.bats（repo 固有）"]
         main_yaml["main.yaml<br/>→ 再利用可能な workflows を呼び出し"]
     end
 
-    docker_template -- "git subtree" --> consumer
+    template -- "git subtree" --> consumer
     scripts -. "symlink" .-> symlinks
     smoke -. "Dockerfile COPY" .-> repo_test
     workflows -. "@tag 参照" .-> main_yaml
@@ -89,8 +89,8 @@ flowchart LR
     end
 
     subgraph github["GitHub Actions"]
-        build_worker["build-worker.yaml<br/>（docker_template より）"]
-        release_worker["release-worker.yaml<br/>（docker_template より）"]
+        build_worker["build-worker.yaml<br/>（template より）"]
+        release_worker["release-worker.yaml<br/>（template より）"]
     end
 
     build_test --> ci_container
@@ -136,11 +136,11 @@ flowchart LR
 
 ```bash
 # 1. subtree 追加
-git subtree add --prefix=docker_template \
-    git@github.com:ycpss91255-docker/docker_template.git main --squash
+git subtree add --prefix=template \
+    git@github.com:ycpss91255-docker/template.git main --squash
 
 # 2. symlink 初期化（ワンコマンド）
-./docker_template/script/init.sh
+./template/script/init.sh
 ```
 
 ### アップグレード
@@ -153,7 +153,7 @@ make upgrade-check
 make upgrade
 
 # バージョン指定
-./docker_template/script/upgrade.sh v0.3.0
+./template/script/upgrade.sh v0.3.0
 ```
 
 ## CI Reusable Workflows
@@ -164,7 +164,7 @@ make upgrade
 # .github/workflows/main.yaml
 jobs:
   call-docker-build:
-    uses: ycpss91255-docker/docker_template/.github/workflows/build-worker.yaml@v1
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v1
     with:
       image_name: ros_noetic
       build_args: |
@@ -175,7 +175,7 @@ jobs:
   call-release:
     needs: call-docker-build
     if: startsWith(github.ref, 'refs/tags/')
-    uses: ycpss91255-docker/docker_template/.github/workflows/release-worker.yaml@v1
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@v1
     with:
       archive_name_prefix: ros_noetic
 ```
@@ -220,7 +220,7 @@ make help        # 全ターゲット表示
 ## ディレクトリ構造
 
 ```
-docker_template/
+template/
 ├── build.sh                          # 共有ビルドスクリプト
 ├── run.sh                            # 共有実行スクリプト（X11/Wayland）
 ├── exec.sh                           # 共有 exec スクリプト

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -1,7 +1,7 @@
-# docker_template
+# template
 
-[![Self Test](https://github.com/ycpss91255-docker/docker_template/actions/workflows/self-test.yaml/badge.svg)](https://github.com/ycpss91255-docker/docker_template/actions/workflows/self-test.yaml)
-[![codecov](https://codecov.io/gh/ycpss91255-docker/docker_template/branch/main/graph/badge.svg)](https://codecov.io/gh/ycpss91255-docker/docker_template)
+[![Self Test](https://github.com/ycpss91255-docker/template/actions/workflows/self-test.yaml/badge.svg)](https://github.com/ycpss91255-docker/template/actions/workflows/self-test.yaml)
+[![codecov](https://codecov.io/gh/ycpss91255-docker/template/branch/main/graph/badge.svg)](https://codecov.io/gh/ycpss91255-docker/template)
 
 ![Language](https://img.shields.io/badge/Language-Bash-blue?style=flat-square)
 ![Testing](https://img.shields.io/badge/Testing-Bats-orange?style=flat-square)
@@ -17,9 +17,9 @@
 
 ```bash
 # 新 repo：添加 subtree + 初始化
-git subtree add --prefix=docker_template \
-    git@github.com:ycpss91255-docker/docker_template.git main --squash
-./docker_template/script/init.sh
+git subtree add --prefix=template \
+    git@github.com:ycpss91255-docker/template.git main --squash
+./template/script/init.sh
 
 # 升级到最新版
 make upgrade-check   # 检查
@@ -38,7 +38,7 @@ make help            # 显示所有命令
 
 ```mermaid
 graph TB
-    subgraph docker_template["docker_template（共用 repo）"]
+    subgraph template["template（共用 repo）"]
         scripts["build.sh / run.sh / exec.sh / stop.sh<br/>setup.sh / .hadolint.yaml"]
         smoke["test/smoke_test/<br/>script_help.bats<br/>display_env.bats"]
         config["config/<br/>bashrc / tmux / terminator / pip"]
@@ -47,13 +47,13 @@ graph TB
     end
 
     subgraph consumer["Docker Repo（如 ros_noetic）"]
-        symlinks["build.sh → docker_template/build.sh<br/>run.sh → docker_template/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
+        symlinks["build.sh → template/build.sh<br/>run.sh → template/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
         dockerfile["Dockerfile<br/>compose.yaml<br/>.env.example<br/>script/entrypoint.sh"]
         repo_test["test/smoke_test/<br/>ros_env.bats（repo 专属）"]
         main_yaml["main.yaml<br/>→ 调用可重用 workflows"]
     end
 
-    docker_template -- "git subtree" --> consumer
+    template -- "git subtree" --> consumer
     scripts -. "symlink" .-> symlinks
     smoke -. "Dockerfile COPY" .-> repo_test
     workflows -. "@tag 引用" .-> main_yaml
@@ -75,8 +75,8 @@ flowchart LR
     end
 
     subgraph github["GitHub Actions"]
-        build_worker["build-worker.yaml<br/>（来自 docker_template）"]
-        release_worker["release-worker.yaml<br/>（来自 docker_template）"]
+        build_worker["build-worker.yaml<br/>（来自 template）"]
+        release_worker["release-worker.yaml<br/>（来自 template）"]
     end
 
     build_test --> ci_container
@@ -122,11 +122,11 @@ flowchart LR
 
 ```bash
 # 1. 添加 subtree
-git subtree add --prefix=docker_template \
-    git@github.com:ycpss91255-docker/docker_template.git main --squash
+git subtree add --prefix=template \
+    git@github.com:ycpss91255-docker/template.git main --squash
 
 # 2. 初始化 symlinks（一个命令搞定）
-./docker_template/script/init.sh
+./template/script/init.sh
 ```
 
 ### 升级
@@ -139,7 +139,7 @@ make upgrade-check
 make upgrade
 
 # 或指定版本
-./docker_template/script/upgrade.sh v0.3.0
+./template/script/upgrade.sh v0.3.0
 ```
 
 ## CI Reusable Workflows
@@ -150,7 +150,7 @@ make upgrade
 # .github/workflows/main.yaml
 jobs:
   call-docker-build:
-    uses: ycpss91255-docker/docker_template/.github/workflows/build-worker.yaml@v1
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v1
     with:
       image_name: ros_noetic
       build_args: |
@@ -161,7 +161,7 @@ jobs:
   call-release:
     needs: call-docker-build
     if: startsWith(github.ref, 'refs/tags/')
-    uses: ycpss91255-docker/docker_template/.github/workflows/release-worker.yaml@v1
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@v1
     with:
       archive_name_prefix: ros_noetic
 ```
@@ -206,7 +206,7 @@ make help        # 显示所有可用命令
 ## 目录结构
 
 ```
-docker_template/
+template/
 ├── build.sh                          # 共用构建脚本
 ├── run.sh                            # 共用运行脚本（X11/Wayland）
 ├── exec.sh                           # 共用 exec 脚本

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -1,7 +1,7 @@
-# docker_template
+# template
 
-[![Self Test](https://github.com/ycpss91255-docker/docker_template/actions/workflows/self-test.yaml/badge.svg)](https://github.com/ycpss91255-docker/docker_template/actions/workflows/self-test.yaml)
-[![codecov](https://codecov.io/gh/ycpss91255-docker/docker_template/branch/main/graph/badge.svg)](https://codecov.io/gh/ycpss91255-docker/docker_template)
+[![Self Test](https://github.com/ycpss91255-docker/template/actions/workflows/self-test.yaml/badge.svg)](https://github.com/ycpss91255-docker/template/actions/workflows/self-test.yaml)
+[![codecov](https://codecov.io/gh/ycpss91255-docker/template/branch/main/graph/badge.svg)](https://codecov.io/gh/ycpss91255-docker/template)
 
 ![Language](https://img.shields.io/badge/Language-Bash-blue?style=flat-square)
 ![Testing](https://img.shields.io/badge/Testing-Bats-orange?style=flat-square)
@@ -17,9 +17,9 @@
 
 ```bash
 # 新 repo：加入 subtree + 初始化
-git subtree add --prefix=docker_template \
-    git@github.com:ycpss91255-docker/docker_template.git main --squash
-./docker_template/script/init.sh
+git subtree add --prefix=template \
+    git@github.com:ycpss91255-docker/template.git main --squash
+./template/script/init.sh
 
 # 升級到最新版
 make upgrade-check   # 檢查
@@ -38,7 +38,7 @@ make help            # 顯示所有指令
 
 ```mermaid
 graph TB
-    subgraph docker_template["docker_template（共用 repo）"]
+    subgraph template["template（共用 repo）"]
         scripts["build.sh / run.sh / exec.sh / stop.sh<br/>setup.sh / .hadolint.yaml"]
         smoke["test/smoke_test/<br/>script_help.bats<br/>display_env.bats"]
         config["config/<br/>bashrc / tmux / terminator / pip"]
@@ -47,13 +47,13 @@ graph TB
     end
 
     subgraph consumer["Docker Repo（如 ros_noetic）"]
-        symlinks["build.sh → docker_template/build.sh<br/>run.sh → docker_template/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
+        symlinks["build.sh → template/build.sh<br/>run.sh → template/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
         dockerfile["Dockerfile<br/>compose.yaml<br/>.env.example<br/>script/entrypoint.sh"]
         repo_test["test/smoke_test/<br/>ros_env.bats（repo 專屬）"]
         main_yaml["main.yaml<br/>→ 呼叫可重用 workflows"]
     end
 
-    docker_template -- "git subtree" --> consumer
+    template -- "git subtree" --> consumer
     scripts -. "symlink" .-> symlinks
     smoke -. "Dockerfile COPY" .-> repo_test
     workflows -. "@tag 引用" .-> main_yaml
@@ -75,8 +75,8 @@ flowchart LR
     end
 
     subgraph github["GitHub Actions"]
-        build_worker["build-worker.yaml<br/>（來自 docker_template）"]
-        release_worker["release-worker.yaml<br/>（來自 docker_template）"]
+        build_worker["build-worker.yaml<br/>（來自 template）"]
+        release_worker["release-worker.yaml<br/>（來自 template）"]
     end
 
     build_test --> ci_container
@@ -122,11 +122,11 @@ flowchart LR
 
 ```bash
 # 1. 加入 subtree
-git subtree add --prefix=docker_template \
-    git@github.com:ycpss91255-docker/docker_template.git main --squash
+git subtree add --prefix=template \
+    git@github.com:ycpss91255-docker/template.git main --squash
 
 # 2. 初始化 symlinks（一個指令搞定）
-./docker_template/script/init.sh
+./template/script/init.sh
 ```
 
 ### 升級
@@ -139,7 +139,7 @@ make upgrade-check
 make upgrade
 
 # 或指定版本
-./docker_template/script/upgrade.sh v0.3.0
+./template/script/upgrade.sh v0.3.0
 ```
 
 ## CI Reusable Workflows
@@ -150,7 +150,7 @@ make upgrade
 # .github/workflows/main.yaml
 jobs:
   call-docker-build:
-    uses: ycpss91255-docker/docker_template/.github/workflows/build-worker.yaml@v1
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v1
     with:
       image_name: ros_noetic
       build_args: |
@@ -161,7 +161,7 @@ jobs:
   call-release:
     needs: call-docker-build
     if: startsWith(github.ref, 'refs/tags/')
-    uses: ycpss91255-docker/docker_template/.github/workflows/release-worker.yaml@v1
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@v1
     with:
       archive_name_prefix: ros_noetic
 ```
@@ -206,7 +206,7 @@ make help        # 顯示所有可用指令
 ## 目錄結構
 
 ```
-docker_template/
+template/
 ├── build.sh                          # 共用建置腳本
 ├── run.sh                            # 共用執行腳本（X11/Wayland）
 ├── exec.sh                           # 共用 exec 腳本

--- a/doc/test/TEST.ja.md
+++ b/doc/test/TEST.ja.md
@@ -72,8 +72,8 @@
 | `doc/readme/ directory exists` | ディレクトリ構造 |
 | `doc/test/ directory exists` | ディレクトリ構造 |
 | `doc/changelog/ directory exists` | ディレクトリ構造 |
-| `build.sh references docker_template/setup.sh` | パス参照 |
-| `run.sh references docker_template/setup.sh` | パス参照 |
+| `build.sh references template/setup.sh` | パス参照 |
+| `run.sh references template/setup.sh` | パス参照 |
 | `build.sh uses set -euo pipefail` | シェル規約 |
 | `run.sh uses set -euo pipefail` | シェル規約 |
 | `exec.sh uses set -euo pipefail` | シェル規約 |

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -72,8 +72,8 @@ Template self-tests: **132 tests** total.
 | `doc/readme/ directory exists` | Directory structure |
 | `doc/test/ directory exists` | Directory structure |
 | `doc/changelog/ directory exists` | Directory structure |
-| `build.sh references docker_template/setup.sh` | Path reference |
-| `run.sh references docker_template/setup.sh` | Path reference |
+| `build.sh references template/setup.sh` | Path reference |
+| `run.sh references template/setup.sh` | Path reference |
 | `build.sh uses set -euo pipefail` | Shell convention |
 | `run.sh uses set -euo pipefail` | Shell convention |
 | `exec.sh uses set -euo pipefail` | Shell convention |

--- a/doc/test/TEST.zh-CN.md
+++ b/doc/test/TEST.zh-CN.md
@@ -72,8 +72,8 @@
 | `doc/readme/ directory exists` | 目录结构 |
 | `doc/test/ directory exists` | 目录结构 |
 | `doc/changelog/ directory exists` | 目录结构 |
-| `build.sh references docker_template/setup.sh` | 路径引用 |
-| `run.sh references docker_template/setup.sh` | 路径引用 |
+| `build.sh references template/setup.sh` | 路径引用 |
+| `run.sh references template/setup.sh` | 路径引用 |
 | `build.sh uses set -euo pipefail` | Shell 惯例 |
 | `run.sh uses set -euo pipefail` | Shell 惯例 |
 | `exec.sh uses set -euo pipefail` | Shell 惯例 |

--- a/doc/test/TEST.zh-TW.md
+++ b/doc/test/TEST.zh-TW.md
@@ -72,8 +72,8 @@
 | `doc/readme/ directory exists` | 目錄結構 |
 | `doc/test/ directory exists` | 目錄結構 |
 | `doc/changelog/ directory exists` | 目錄結構 |
-| `build.sh references docker_template/setup.sh` | 路徑引用 |
-| `run.sh references docker_template/setup.sh` | 路徑引用 |
+| `build.sh references template/setup.sh` | 路徑引用 |
+| `run.sh references template/setup.sh` | 路徑引用 |
 | `build.sh uses set -euo pipefail` | Shell 慣例 |
 | `run.sh uses set -euo pipefail` | Shell 慣例 |
 | `exec.sh uses set -euo pipefail` | Shell 慣例 |

--- a/run.sh
+++ b/run.sh
@@ -108,7 +108,7 @@ done
 
 # Generate / refresh .env
 if [[ "${SKIP_ENV}" == false ]]; then
-    "${FILE_PATH}/docker_template/script/setup.sh" --base-path "${FILE_PATH}" --lang "${_LANG}"
+    "${FILE_PATH}/template/script/setup.sh" --base-path "${FILE_PATH}" --lang "${_LANG}"
 fi
 
 # Load .env for xhost

--- a/script/init.sh
+++ b/script/init.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# init.sh - Initialize a repo with docker_template symlinks
+# init.sh - Initialize a repo with template symlinks
 #
 # Run from the repo root after git subtree add:
-#   ./docker_template/script/init.sh
+#   ./template/script/init.sh
 #
 # Creates symlinks for shared scripts and removes old docker_setup_helper
 # artifacts if present.
@@ -12,7 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 TEMPLATE_DIR="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
 REPO_ROOT="$(cd -- "${TEMPLATE_DIR}/.." && pwd -P)"
-TEMPLATE_REL="docker_template"
+TEMPLATE_REL="template"
 
 cd "${REPO_ROOT}"
 
@@ -55,7 +55,7 @@ else
     _log "  Keeping custom .hadolint.yaml (differs from template)"
 fi
 
-# ── Remove old shared smoke tests (now provided by docker_template) ──────────
+# ── Remove old shared smoke tests (now provided by template) ──────────
 
 for f in test/smoke_test/test_helper.bash test/smoke_test/script_help.bats test/smoke_test/display_env.bats; do
     if [[ -f "${f}" ]] && [[ -L "${f}" || ! -s "${f}" ]]; then
@@ -81,16 +81,16 @@ if [[ -f "${TEMPLATE_DIR}/script/migrate.sh" ]]; then
 else
     ver="v0.2.0"
 fi
-echo "${ver}" > .docker_template_version
-_log "Created .docker_template_version (${ver})"
+echo "${ver}" > .template_version
+_log "Created .template_version (${ver})"
 
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 _log ""
 _log "Done! Next steps:"
-_log "  1. Update Dockerfile CONFIG_SRC: docker_setup_helper/src/config → docker_template/config"
+_log "  1. Update Dockerfile CONFIG_SRC: docker_setup_helper/src/config → template/config"
 _log "  2. Update Dockerfile smoke test COPY:"
-_log "       COPY docker_template/test/smoke_test/ /smoke_test/"
+_log "       COPY template/test/smoke_test/ /smoke_test/"
 _log "       COPY test/smoke_test/ /smoke_test/"
 _log "  3. Update .github/workflows/main.yaml to use reusable workflows"
 _log "  4. git add -A && git commit"

--- a/script/migrate.sh
+++ b/script/migrate.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# migrate.sh - Migrate Docker container repos to use docker_template
+# migrate.sh - Migrate Docker container repos to use template
 #
 # Usage:
 #   ./migrate.sh <repo_path>          # migrate a single repo
@@ -9,8 +9,8 @@
 #
 # This script:
 #   1. Removes docker_setup_helper subtree and old CI workflows
-#   2. Adds docker_template as git subtree
-#   3. Replaces shell scripts with symlinks to docker_template/
+#   2. Adds template as git subtree
+#   3. Replaces shell scripts with symlinks to template/
 #   4. Updates Dockerfile (CONFIG_SRC path, smoke test COPY)
 #   5. Generates main.yaml with reusable workflow calls
 #   6. Commits changes and creates a PR
@@ -18,7 +18,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-TEMPLATE_REPO="git@github.com:ycpss91255-docker/docker_template.git"
+TEMPLATE_REPO="git@github.com:ycpss91255-docker/template.git"
 TEMPLATE_VERSION="v0.3.0"
 DRY_RUN=false
 
@@ -94,8 +94,8 @@ _check_preconditions() {
 
     [[ -d "${repo_path}/.git" ]] || _error "${repo_path} is not a git repository"
 
-    if [[ -f "${repo_path}/.docker_template_version" ]]; then
-        _warn "${repo_path} already has .docker_template_version — skipping"
+    if [[ -f "${repo_path}/.template_version" ]]; then
+        _warn "${repo_path} already has .template_version — skipping"
         return 1
     fi
 
@@ -131,7 +131,7 @@ _remove_old_subtree() {
     git -C "${repo_path}" commit -m "$(cat <<'COMMIT'
 refactor: remove docker_setup_helper subtree and local CI workflows
 
-Preparation for docker_template migration.
+Preparation for template migration.
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 COMMIT
@@ -140,10 +140,10 @@ COMMIT
 
 _add_template_subtree() {
     local repo_path="$1"
-    _log "Adding docker_template subtree (${TEMPLATE_VERSION})"
+    _log "Adding template subtree (${TEMPLATE_VERSION})"
 
     git -C "${repo_path}" subtree add \
-        --prefix=docker_template "${TEMPLATE_REPO}" "${TEMPLATE_VERSION}" --squash
+        --prefix=template "${TEMPLATE_REPO}" "${TEMPLATE_VERSION}" --squash
 }
 
 _create_symlinks() {
@@ -156,15 +156,15 @@ _create_symlinks() {
     git rm -f build.sh run.sh exec.sh stop.sh 2>/dev/null || true
 
     # Create symlinks for scripts
-    ln -sf docker_template/build.sh build.sh
-    ln -sf docker_template/run.sh run.sh
-    ln -sf docker_template/exec.sh exec.sh
-    ln -sf docker_template/stop.sh stop.sh
+    ln -sf template/build.sh build.sh
+    ln -sf template/run.sh run.sh
+    ln -sf template/exec.sh exec.sh
+    ln -sf template/stop.sh stop.sh
 
     # .hadolint.yaml: symlink for GUI repos, keep custom for repos with extra rules
-    if [[ ! -f .hadolint.yaml ]] || diff -q .hadolint.yaml docker_template/.hadolint.yaml >/dev/null 2>&1; then
+    if [[ ! -f .hadolint.yaml ]] || diff -q .hadolint.yaml template/.hadolint.yaml >/dev/null 2>&1; then
         git rm -f .hadolint.yaml 2>/dev/null || true
-        ln -sf docker_template/.hadolint.yaml .hadolint.yaml
+        ln -sf template/.hadolint.yaml .hadolint.yaml
     else
         _log "Keeping custom .hadolint.yaml (has extra rules)"
     fi
@@ -185,16 +185,16 @@ _update_dockerfile() {
     [[ -f "${dockerfile}" ]] || return 0
 
     # Update CONFIG_SRC path
-    sed -i 's|docker_setup_helper/src/config|docker_template/config|g' "${dockerfile}"
+    sed -i 's|docker_setup_helper/src/config|template/config|g' "${dockerfile}"
 
-    # Ensure smoke tests are copied from docker_template
-    if ! grep -q "docker_template/test/smoke_test" "${dockerfile}"; then
+    # Ensure smoke tests are copied from template
+    if ! grep -q "template/test/smoke_test" "${dockerfile}"; then
         if [[ "${has_gui}" == "true" ]]; then
             # GUI repos: copy all shared smoke tests (including display_env.bats)
-            sed -i '/COPY test\/smoke_test\//i COPY docker_template/test/smoke_test/ /smoke_test/' "${dockerfile}"
+            sed -i '/COPY test\/smoke_test\//i COPY template/test/smoke_test/ /smoke_test/' "${dockerfile}"
         else
             # Non-GUI repos: copy only script_help + test_helper (skip display_env.bats)
-            sed -i '/COPY test\/smoke_test\//i COPY docker_template/test/smoke_test/test_helper.bash /smoke_test/test_helper.bash\nCOPY docker_template/test/smoke_test/script_help.bats /smoke_test/script_help.bats' "${dockerfile}"
+            sed -i '/COPY test\/smoke_test\//i COPY template/test/smoke_test/test_helper.bash /smoke_test/test_helper.bash\nCOPY template/test/smoke_test/script_help.bats /smoke_test/script_help.bats' "${dockerfile}"
         fi
     fi
 
@@ -208,7 +208,7 @@ _update_dockerfile() {
 
 _update_readmes() {
     local repo_path="$1"
-    _log "Updating READMEs (docker_setup_helper → docker_template)"
+    _log "Updating READMEs (docker_setup_helper → template)"
 
     for f in "${repo_path}/README.md" "${repo_path}"/doc/README.*.md; do
         [[ -f "${f}" ]] || continue
@@ -216,14 +216,14 @@ _update_readmes() {
         # Replace escaped markdown: docker\_setup\_helper → docker\_template
         sed -i 's/docker\\_setup\\_helper/docker\\_template/g' "${f}"
 
-        # Replace plain text: docker_setup_helper → docker_template
-        sed -i 's/docker_setup_helper/docker_template/g' "${f}"
+        # Replace plain text: docker_setup_helper → template
+        sed -i 's/docker_setup_helper/template/g' "${f}"
 
-        # Fix GitHub org URL: ycpss91255/docker_template → ycpss91255-docker/docker_template
-        sed -i 's|ycpss91255/docker_template|ycpss91255-docker/docker_template|g' "${f}"
+        # Fix GitHub org URL: ycpss91255/template → ycpss91255-docker/template
+        sed -i 's|ycpss91255/template|ycpss91255-docker/template|g' "${f}"
 
         # Update subtree git URL version
-        sed -i "s|docker_template\.git v[0-9.]*|docker_template.git ${TEMPLATE_VERSION}|g" "${f}"
+        sed -i "s|template\.git v[0-9.]*|template.git ${TEMPLATE_VERSION}|g" "${f}"
 
         # Update version in directory tree comment
         sed -i "s|git subtree (v[0-9.]*)|git subtree (${TEMPLATE_VERSION})|g" "${f}"
@@ -233,14 +233,14 @@ _update_readmes() {
 
         # Remove old build-worker/release-worker from directory tree
         sed -i '/│   ├── build-worker.yaml/d' "${f}"
-        sed -i 's|│   └── release-worker.yaml.*|│   └── main.yaml                # CI/CD (docker_template reusable workflows)|' "${f}"
+        sed -i 's|│   └── release-worker.yaml.*|│   └── main.yaml                # CI/CD (template reusable workflows)|' "${f}"
 
         # Remove old shared test files from directory tree
         sed -i '/│       ├── script_help.bats/d' "${f}"
         sed -i '/│       └── test_helper.bash/d' "${f}"
 
-        # Update .docker_setup_helper_version → .docker_template_version
-        sed -i 's/\.docker_setup_helper_version/.docker_template_version/g' "${f}"
+        # Update .docker_setup_helper_version → .template_version
+        sed -i 's/\.docker_setup_helper_version/.template_version/g' "${f}"
     done
 
     git -C "${repo_path}" add README.md doc/ 2>/dev/null || true
@@ -287,7 +287,7 @@ jobs:
   call-docker-build:
     permissions:
       contents: read
-    uses: ycpss91255-docker/docker_template/.github/workflows/build-worker.yaml@${TEMPLATE_VERSION}
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@${TEMPLATE_VERSION}
     with:
       image_name: ${image_name}${args_yaml}${runtime_yaml}
 
@@ -296,7 +296,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
-    uses: ycpss91255-docker/docker_template/.github/workflows/release-worker.yaml@${TEMPLATE_VERSION}
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@${TEMPLATE_VERSION}
     with:
       archive_name_prefix: ${image_name}
     secrets: inherit
@@ -307,9 +307,9 @@ YAML
 
 _add_version_file() {
     local repo_path="$1"
-    _log "Adding .docker_template_version"
-    echo "${TEMPLATE_VERSION}" > "${repo_path}/.docker_template_version"
-    git -C "${repo_path}" add .docker_template_version
+    _log "Adding .template_version"
+    echo "${TEMPLATE_VERSION}" > "${repo_path}/.template_version"
+    git -C "${repo_path}" add .template_version
 }
 
 _commit_migration() {
@@ -318,16 +318,16 @@ _commit_migration() {
 
     git -C "${repo_path}" add -A
     git -C "${repo_path}" commit -m "$(cat <<'COMMIT'
-feat: migrate from docker_setup_helper to docker_template
+feat: migrate from docker_setup_helper to template
 
-BREAKING CHANGE: replaces docker_setup_helper subtree with docker_template.
+BREAKING CHANGE: replaces docker_setup_helper subtree with template.
 
-- Replace shell scripts with symlinks to docker_template/ subtree
-- Replace .hadolint.yaml with symlink to docker_template/.hadolint.yaml
-- Update Dockerfile CONFIG_SRC path to docker_template/config
-- Merge shared smoke tests from docker_template/test/smoke_test/ in Dockerfile
-- Replace local CI workflows with reusable workflows from docker_template
-- Fixes X11/Wayland support via docker_template's run.sh
+- Replace shell scripts with symlinks to template/ subtree
+- Replace .hadolint.yaml with symlink to template/.hadolint.yaml
+- Update Dockerfile CONFIG_SRC path to template/config
+- Merge shared smoke tests from template/test/smoke_test/ in Dockerfile
+- Replace local CI workflows with reusable workflows from template
+- Fixes X11/Wayland support via template's run.sh
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 COMMIT
@@ -343,13 +343,13 @@ _push_and_pr() {
     local pr_url
     pr_url=$(gh pr create \
         --repo "ycpss91255-docker/${image_name}" \
-        --title "feat: migrate to docker_template (v2.0.0)" \
+        --title "feat: migrate to template (v2.0.0)" \
         --body "$(cat <<PR_BODY
 ## Summary
 
-- Replace \`docker_setup_helper\` subtree with \`docker_template\` subtree
-- Shell scripts (build.sh, run.sh, exec.sh, stop.sh) are now symlinks to \`docker_template/\`
-- Local CI workflows replaced with reusable workflows from \`docker_template\`
+- Replace \`docker_setup_helper\` subtree with \`template\` subtree
+- Shell scripts (build.sh, run.sh, exec.sh, stop.sh) are now symlinks to \`template/\`
+- Local CI workflows replaced with reusable workflows from \`template\`
 - Fixes X11/Wayland support
 
 ## BREAKING CHANGE
@@ -424,8 +424,8 @@ _list_repos() {
     for repo_path in "${!REPO_REGISTRY[@]}"; do
         _parse_entry "${REPO_REGISTRY["${repo_path}"]}"
         local status="pending"
-        if [[ -f "${repo_path}/.docker_template_version" ]]; then
-            status="migrated ($(cat "${repo_path}/.docker_template_version"))"
+        if [[ -f "${repo_path}/.template_version" ]]; then
+            status="migrated ($(cat "${repo_path}/.template_version"))"
         elif [[ ! -d "${repo_path}" ]]; then
             status="not found"
         fi
@@ -438,7 +438,7 @@ _usage() {
     cat >&2 <<'EOF'
 Usage: migrate.sh [OPTIONS] <repo_path|--all|--list>
 
-Migrate Docker container repos from docker_setup_helper to docker_template.
+Migrate Docker container repos from docker_setup_helper to template.
 
 Commands:
   <repo_path>     Migrate a single repo

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -279,7 +279,7 @@ main() {
     done
 
     if [[ -z "${_base_path}" ]]; then
-        # setup.sh is at docker_template/script/setup.sh, repo root is ../../
+        # setup.sh is at template/script/setup.sh, repo root is ../../
         _base_path="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")/../.." && pwd -P)"
     fi
 

--- a/script/upgrade.sh
+++ b/script/upgrade.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-# upgrade.sh - Upgrade docker_template subtree to the latest version
+# upgrade.sh - Upgrade template subtree to the latest version
 #
 # Run from the repo root:
-#   ./docker_template/script/upgrade.sh              # upgrade to latest tag
-#   ./docker_template/script/upgrade.sh v0.3.0       # upgrade to specific version
-#   ./docker_template/script/upgrade.sh --check      # check if update available
+#   ./template/script/upgrade.sh              # upgrade to latest tag
+#   ./template/script/upgrade.sh v0.3.0       # upgrade to specific version
+#   ./template/script/upgrade.sh --check      # check if update available
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd -P)"
-TEMPLATE_REMOTE="git@github.com:ycpss91255-docker/docker_template.git"
-VERSION_FILE="${REPO_ROOT}/.docker_template_version"
+TEMPLATE_REMOTE="git@github.com:ycpss91255-docker/template.git"
+VERSION_FILE="${REPO_ROOT}/.template_version"
 
 cd "${REPO_ROOT}"
 
@@ -74,12 +74,12 @@ _upgrade() {
 
     # Step 1: subtree pull
     _log "Step 1/3: git subtree pull"
-    git subtree pull --prefix=docker_template \
+    git subtree pull --prefix=template \
         "${TEMPLATE_REMOTE}" "${target_ver}" --squash \
-        -m "chore: upgrade docker_template subtree to ${target_ver}"
+        -m "chore: upgrade template subtree to ${target_ver}"
 
     # Step 2: update version file
-    _log "Step 2/3: update .docker_template_version"
+    _log "Step 2/3: update .template_version"
     echo "${target_ver}" > "${VERSION_FILE}"
     git add "${VERSION_FILE}"
 
@@ -88,7 +88,7 @@ _upgrade() {
     local main_yaml="${REPO_ROOT}/.github/workflows/main.yaml"
     if [[ -f "${main_yaml}" ]]; then
         # Replace @vX.Y.Z with new version in reusable workflow references
-        sed -i "s|docker_template/\.github/workflows/.*@v[0-9.]*|docker_template/.github/workflows/build-worker.yaml@${target_ver}|" "${main_yaml}"
+        sed -i "s|template/\.github/workflows/.*@v[0-9.]*|template/.github/workflows/build-worker.yaml@${target_ver}|" "${main_yaml}"
         sed -i "s|build-worker\.yaml@v[0-9.]*|build-worker.yaml@${target_ver}|" "${main_yaml}"
         sed -i "s|release-worker\.yaml@v[0-9.]*|release-worker.yaml@${target_ver}|" "${main_yaml}"
         git add "${main_yaml}"
@@ -96,9 +96,9 @@ _upgrade() {
 
     # Commit version + workflow updates
     git commit -m "$(cat <<COMMIT
-chore: update docker_template references to ${target_ver}
+chore: update template references to ${target_ver}
 
-- .docker_template_version: ${local_ver} → ${target_ver}
+- .template_version: ${local_ver} → ${target_ver}
 - main.yaml: workflow @tag updated to ${target_ver}
 
 Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
@@ -116,9 +116,9 @@ COMMIT
 
 _usage() {
     cat >&2 <<'EOF'
-Usage: ./docker_template/script/upgrade.sh [VERSION|--check]
+Usage: ./template/script/upgrade.sh [VERSION|--check]
 
-Upgrade docker_template subtree to the latest (or specified) version.
+Upgrade template subtree to the latest (or specified) version.
 
 Arguments:
   VERSION       Target version (e.g. v0.3.0). Defaults to latest tag.
@@ -126,9 +126,9 @@ Arguments:
   -h, --help    Show this help
 
 Examples:
-  ./docker_template/script/upgrade.sh              # upgrade to latest
-  ./docker_template/script/upgrade.sh v0.3.0       # upgrade to specific version
-  ./docker_template/script/upgrade.sh --check      # check only
+  ./template/script/upgrade.sh              # upgrade to latest
+  ./template/script/upgrade.sh v0.3.0       # upgrade to specific version
+  ./template/script/upgrade.sh --check      # check only
 EOF
     exit 0
 }
@@ -136,7 +136,7 @@ EOF
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 main() {
-    [[ ! -d docker_template ]] && _error "docker_template/ not found. Run from repo root."
+    [[ ! -d template ]] && _error "template/ not found. Run from repo root."
 
     case "${1:-}" in
         -h|--help) _usage ;;

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -302,11 +302,11 @@ EOF
 }
 
 @test "default _base_path resolves to repo root, not script dir" {
-    # Regression: setup.sh lives at docker_template/script/setup.sh
+    # Regression: setup.sh lives at template/script/setup.sh
     # Default _base_path must go up 2 levels to repo root
     local _repo_root="${TEMP_DIR}/docker_myapp"
-    mkdir -p "${_repo_root}/docker_template/script"
-    cp /source/script/setup.sh "${_repo_root}/docker_template/script/setup.sh"
+    mkdir -p "${_repo_root}/template/script"
+    cp /source/script/setup.sh "${_repo_root}/template/script/setup.sh"
 
     # Create .env.example as fallback for IMAGE_NAME
     echo "IMAGE_NAME=myapp" > "${_repo_root}/.env.example"
@@ -316,12 +316,12 @@ EOF
     mkdir -p "${_ws}"
 
     # Run setup.sh directly (no --base-path), simulating user calling it
-    run bash -c "cd '${_repo_root}' && bash docker_template/script/setup.sh"
+    run bash -c "cd '${_repo_root}' && bash template/script/setup.sh"
     assert_success
 
-    # .env should be at repo root, not in docker_template/script/
+    # .env should be at repo root, not in template/script/
     assert [ -f "${_repo_root}/.env" ]
-    assert [ ! -f "${_repo_root}/docker_template/.env" ]
+    assert [ ! -f "${_repo_root}/template/.env" ]
 
     # IMAGE_NAME should derive from repo root dir (docker_myapp → myapp)
     run grep "IMAGE_NAME=myapp" "${_repo_root}/.env"

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -107,16 +107,16 @@ setup() {
 }
 
 # ════════════════════════════════════════════════════════════════════
-# Path reference: scripts call docker_template/script/setup.sh
+# Path reference: scripts call template/script/setup.sh
 # ════════════════════════════════════════════════════════════════════
 
-@test "build.sh references docker_template/script/setup.sh" {
-    run grep "docker_template/script/setup.sh" /source/build.sh
+@test "build.sh references template/script/setup.sh" {
+    run grep "template/script/setup.sh" /source/build.sh
     assert_success
 }
 
-@test "run.sh references docker_template/script/setup.sh" {
-    run grep "docker_template/script/setup.sh" /source/run.sh
+@test "run.sh references template/script/setup.sh" {
+    run grep "template/script/setup.sh" /source/run.sh
     assert_success
 }
 
@@ -202,7 +202,7 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "setup.sh default _base_path uses /.." {
-    # In docker_template, setup.sh is at docker_template/script/setup.sh
+    # In template, setup.sh is at template/script/setup.sh
     # So it should go up 1 level (/..) to reach repo root
     run grep -E '\.\./\.\.' /source/script/setup.sh
     assert_success  # Should have ../../ ../../ (that was old docker_setup_helper/src/ pattern)


### PR DESCRIPTION
## BREAKING CHANGE

- GitHub repo: `docker_template` → `template`
- All internal references updated
- `.docker_template_version` → `.template_version`

Other repos need:
1. Remove old subtree: `git rm -r docker_template/`
2. Add new: `git subtree add --prefix=template git@github.com:ycpss91255-docker/template.git main --squash`
3. Update all symlinks and Dockerfile paths

## Test plan
- [x] 132 tests pass
- [x] 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)