### PR TITLE
docs: update CHANGELOG for v0.3.0 + v0.4.0

### DIFF
--- a/doc/changelog/CHANGELOG.ja.md
+++ b/doc/changelog/CHANGELOG.ja.md
@@ -1,67 +1,81 @@
 # 変更履歴
 
-本ファイルにはすべての重要な変更を記録します。
+本ファイルはすべての重要な変更を記録します。
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) に基づき、
-バージョン番号は [セマンティックバージョニング](https://semver.org/spec/v2.0.0.html) に準拠しています。
+バージョン番号は [セマンティックバージョニング](https://semver.org/spec/v2.0.0.html) に従います。
 
-## [未リリース]
-
-### 追加
-- `script/init.sh`：consumer repo のワンコマンド symlink セットアップ
-- `Makefile`：統一コマンドエントリ（`make test`、`make lint`、`make migrate` 等）
+## [v0.4.0] - 2026-03-29
 
 ### 変更
-- 管理スクリプトを `script/` に移動（ci.sh、migrate.sh、init.sh）— ユーザー向けスクリプトと分離
-- `Makefile` と `compose.yaml` はルートに残置（ユーザー操作用）
-- `test/` の再構成：`test/unit/`（自体テスト）+ `test/smoke_test/`（consumer 共有テスト）
-- `doc/` の再構成：`doc/readme/`、`doc/test/`、`doc/changelog/`（ファイルタイプ別、i18n 対応）
-- README：テスト/変更履歴セクションを簡素化、詳細ドキュメントへのリンクに変更
+- `config/` を `script/config/` からルートに戻す（v0.3.0 で移動、設定ファイルは script/ に置くべきではない）
+- `self-test.yaml` release archive 修正：存在しないルート `setup.sh` 参照を削除
+- mermaid アーキテクチャ図修正：`setup.sh` を正しい `script/` ボックスに表示
+- zh-TW / zh-CN README に目次（Table of Contents）を追加
+- 翻訳同期：「含まれるもの」テーブルに `Makefile.ci` エントリを追加
+- 翻訳同期：「ローカルテスト実行」を正しい `make -f Makefile.ci` コマンドに修正
+
+## [v0.3.0] - 2026-03-29
+
+### 変更
+- **破壊的変更**: Repo リネーム `docker_template` → `template`
+- **破壊的変更**: `setup.sh` → `script/setup.sh` に移動
+- **破壊的変更**: `config/` → `script/config/` に移動（v0.4.0 で戻す）
+- すべてのシェルスクリプトに Google Shell Style Guide を適用
+- `Makefile` を `Makefile`（repo 用）+ `Makefile.ci`（CI 用）に分割
+- ドキュメントのディレクトリ構造、テスト数、bashrc スタイルを修正
 - 132 テスト（旧 124）
+
+### 移行注意事項
+- Other repos: subtree prefix を `docker_template/` から `template/` に変更
+- Dockerfile `CONFIG_SRC` パス: `docker_template/config` → `template/config`
+- Symlinks: `docker_template/*.sh` → `template/*.sh`
 
 ## [v0.2.0] - 2026-03-28
 
 ### 追加
-- `script/ci.sh`：CI パイプラインスクリプト（ローカル + リモート）
-- `Makefile`：統一コマンドエントリ
-- `test/unit/` と `test/smoke_test/` の再構成
-- `doc/` の再構成（i18n 対応：readme/、test/、changelog/）
-- coverage 権限修正（HOST_UID/HOST_GID による chown）
+- `script/ci.sh`: CI パイプラインスクリプト（ローカル + リモート）
+- `Makefile`: 統一コマンドエントリ
+- `test/unit/` と `test/smoke_test/` を再構成
+- `doc/` を再構成（i18n 対応: readme/、test/、changelog/）
+- カバレッジ権限の修正（HOST_UID/HOST_GID で chown）
 
 ### 変更
-- `smoke_test/` を `test/smoke_test/` に移動（**破壊的変更**：consumer Dockerfile COPY パス変更）
-- `compose.yaml` が `script/ci.sh --ci` を呼び出すよう変更（inline bash を置換）
-- `self-test.yaml` が `script/ci.sh` を呼び出すよう変更（docker compose 直接呼び出しを置換）
+- `smoke_test/` を `test/smoke_test/` に移動（**破壊的変更**: Dockerfile COPY パス変更）
+- `compose.yaml` が `script/ci.sh --ci` を呼び出すように変更（inline bash の代替）
+- `self-test.yaml` が `script/ci.sh` を呼び出すように変更（docker compose 直接呼び出しの代替）
 
 ## [v0.1.0] - 2026-03-28
 
 ### 追加
-- **共有シェルスクリプト**：`build.sh`、`run.sh`（X11/Wayland サポート付き）、`exec.sh`、`stop.sh`
-- **setup.sh**：`.env` ジェネレータ、`docker_setup_helper` から統合（UID/GID、GPU、ワークスペースパス、イメージ名の自動検出）
-- **設定ファイル**：bashrc、tmux、terminator、pip 設定（`docker_setup_helper` より）
-- **共有 Smoke Tests**（`smoke_test/`）：
-  - `script_help.bats` — 16 件のスクリプト help/usage テスト
-  - `display_env.bats` — 10 件の X11/Wayland 環境テスト（GUI repos）
+- **共有シェルスクリプト**: `build.sh`、`run.sh`（X11/Wayland 対応）、`exec.sh`、`stop.sh`
+- **setup.sh**: `.env` ジェネレータ（`docker_setup_helper` から統合、UID/GID・GPU・ワークスペースパス・イメージ名の自動検出）
+- **設定ファイル**: bashrc、tmux、terminator、pip 設定（`docker_setup_helper` から）
+- **共有 Smoke Tests**（`smoke_test/`）:
+  - `script_help.bats` — 16 スクリプト help/usage テスト
+  - `display_env.bats` — 10 X11/Wayland 環境テスト（GUI repos）
   - `test_helper.bash` — 統一 bats ローダー
-- **テンプレート自体のテスト**（`test/`）：114 件のテスト（ShellCheck + Bats + Kcov カバレッジ）
-- **CI 再利用可能な Workflows**：
-  - `build-worker.yaml` — パラメータ化された Docker build + smoke test
-  - `release-worker.yaml` — パラメータ化された GitHub Release
-  - `self-test.yaml` — テンプレート自体の CI
-- **`migrate.sh`**：バッチ移行スクリプト（`docker_setup_helper` から `template` への変換）
-- `.hadolint.yaml`：共有 Hadolint ルール
-- `.codecov.yaml`：カバレッジ設定
-- ドキュメント：README（英語）、README.zh-TW.md、README.zh-CN.md、README.ja.md、TEST.md
+- **テンプレート自身のテスト**（`test/`）: 114 テスト（ShellCheck + Bats + Kcov カバレッジ）
+- **CI 再利用可能 Workflows**:
+  - `build-worker.yaml` — パラメータ化 Docker build + smoke test
+  - `release-worker.yaml` — パラメータ化 GitHub Release
+  - `self-test.yaml` — テンプレート自身の CI
+- **`migrate.sh`**: バッチ移行スクリプト（`docker_setup_helper` から `template` への変換）
+- `.hadolint.yaml`: 共有 Hadolint ルール
+- `.codecov.yaml`: カバレッジ設定
+- ドキュメント: README（英語）、README.zh-TW.md、README.zh-CN.md、README.ja.md、TEST.md
 
 ### 変更
-- `setup.sh` デフォルト `_base_path` が 1 レベル上（`/..`）に変更、旧 2 レベル（`/../..`）を置換、新しい `template/setup.sh` の配置に対応
+- `setup.sh` デフォルト `_base_path` を 1 レベル上（`/..`）に変更（新しい `template/setup.sh` の位置に合わせる）
 
-### 移行に関する注意事項
-- Consumer repos は `docker_setup_helper/` subtree を `template/` subtree に置換
-- ルートのシェルスクリプトは `template/` への symlinks に変更
-- ローカル `build-worker.yaml` / `release-worker.yaml` は `main.yaml` 内の再利用可能な workflow 呼び出しに置換
-- Dockerfile `CONFIG_SRC` パス変更：`docker_setup_helper/src/config` → `template/config`
-- 共有 smoke tests は Dockerfile `COPY template/test/smoke_test/` で読み込み（symlinks ではない — Docker COPY は symlinks を追跡しない）
+### 移行注意事項
+- `docker_setup_helper/` subtree を `template/` subtree に置換
+- ルートのシェルスクリプトを `template/` への symlinks に変更
+- ローカル `build-worker.yaml` / `release-worker.yaml` を `main.yaml` の再利用可能 workflow 呼び出しに置換
+- Dockerfile `CONFIG_SRC` パス: `docker_setup_helper/src/config` → `template/config`
+- 共有 smoke tests は Dockerfile `COPY template/test/smoke_test/` で読み込み（symlinks ではない）
 
-[未リリース]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...HEAD
+[v0.4.0]: https://github.com/ycpss91255-docker/template/compare/v0.3.0...v0.4.0
+[v0.3.0]: https://github.com/ycpss91255-docker/template/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...v0.2.0
 [v0.1.0]: https://github.com/ycpss91255-docker/template/releases/tag/v0.1.0

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,19 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-- `script/init.sh`: one-command symlink setup for consumer repos
-- `Makefile`: unified entry point (`make test`, `make lint`, `make migrate`, etc.)
+## [v0.4.0] - 2026-03-29
 
 ### Changed
-- Move management scripts to `script/` (ci.sh, migrate.sh, init.sh) — separate from user-facing Docker scripts
-- `Makefile` and `compose.yaml` stay at root (user-facing)
-- Restructure `test/`: `test/unit/` (self-tests) + `test/smoke_test/` (consumer shared tests)
-- Restructure `doc/`: `doc/readme/`, `doc/test/`, `doc/changelog/` (by file type, with i18n)
-- README: simplify test/changelog sections with links to detailed docs
+- Move `config/` back to root level (was `script/config/` in v0.3.0) — configs are not scripts
+- Fix `self-test.yaml` release archive: remove stale root `setup.sh` reference
+- Fix mermaid architecture diagrams: `setup.sh` shown in correct `script/` box
+- Add Table of Contents to zh-TW and zh-CN READMEs
+- Add `Makefile.ci` entry to "What's included" table (all translations)
+- Fix "Running Tests" section to use `make -f Makefile.ci` (all translations)
+
+## [v0.3.0] - 2026-03-29
+
+### Changed
+- **BREAKING**: Rename repo `docker_template` → `template`
+- **BREAKING**: Move `setup.sh` → `script/setup.sh`
+- **BREAKING**: Move `config/` → `script/config/` (reverted in v0.4.0)
+- Apply Google Shell Style Guide to all shell scripts
+- Split `Makefile` into `Makefile` (repo entry) + `Makefile.ci` (CI entry)
+- Fix directory structure, test counts, bashrc style in documentation
 - 132 tests (was 124)
+
+### Migration notes
+- Other repos: subtree prefix changes from `docker_template/` to `template/`
+- `CONFIG_SRC` path in Dockerfile: `docker_template/config` → `template/config`
+- Symlinks: `docker_template/*.sh` → `template/*.sh`
 
 ## [v0.2.0] - 2026-03-28
 
@@ -29,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Coverage permissions fix (chown with HOST_UID/HOST_GID)
 
 ### Changed
-- `smoke_test/` moved to `test/smoke_test/` (**BREAKING**: consumer Dockerfile COPY path change)
+- `smoke_test/` moved to `test/smoke_test/` (**BREAKING**: Dockerfile COPY path change)
 - `compose.yaml` calls `script/ci.sh --ci` instead of inline bash
 - `self-test.yaml` calls `script/ci.sh` instead of docker compose directly
 
@@ -57,11 +69,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `setup.sh` default `_base_path` traverses 1 level up (`/..`) instead of 2 (`/../..`) to match new `template/setup.sh` location
 
 ### Migration notes
-- Consumer repos replace `docker_setup_helper/` subtree with `template/` subtree
+- Replace `docker_setup_helper/` subtree with `template/` subtree
 - Shell scripts at root become symlinks to `template/`
 - Local `build-worker.yaml` / `release-worker.yaml` replaced by reusable workflow calls in `main.yaml`
-- Dockerfile `CONFIG_SRC` path changes: `docker_setup_helper/src/config` → `template/config`
-- Shared smoke tests loaded via `COPY template/smoke_test/` in Dockerfile (not symlinks — Docker COPY does not follow symlinks)
+- Dockerfile `CONFIG_SRC` path: `docker_setup_helper/src/config` → `template/config`
+- Shared smoke tests loaded via `COPY template/smoke_test/` in Dockerfile (not symlinks)
 
-[Unreleased]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...HEAD
+[v0.4.0]: https://github.com/ycpss91255-docker/template/compare/v0.3.0...v0.4.0
+[v0.3.0]: https://github.com/ycpss91255-docker/template/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...v0.2.0
 [v0.1.0]: https://github.com/ycpss91255-docker/template/releases/tag/v0.1.0

--- a/doc/changelog/CHANGELOG.zh-CN.md
+++ b/doc/changelog/CHANGELOG.zh-CN.md
@@ -5,19 +5,31 @@
 格式基于 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)，
 版本号遵循 [语义化版本](https://semver.org/spec/v2.0.0.html)。
 
-## [未发布]
-
-### 新增
-- `script/init.sh`：一键为 consumer repo 创建 symlinks
-- `Makefile`：统一命令入口（`make test`、`make lint`、`make migrate` 等）
+## [v0.4.0] - 2026-03-29
 
 ### 变更
-- 管理脚本移至 `script/`（ci.sh、migrate.sh、init.sh）— 与用户操作脚本分离
-- `Makefile` 和 `compose.yaml` 留在根目录（用户操作用）
-- 重整 `test/`：`test/unit/`（自身测试）+ `test/smoke_test/`（consumer 共用测试）
-- 重整 `doc/`：`doc/readme/`、`doc/test/`、`doc/changelog/`（按文件类型分，含 i18n）
-- README：简化测试/变更记录章节，改为链接至详细文档
+- `config/` 从 `script/config/` 搬回根目录（v0.3.0 时移入，配置文件不应放在 script/）
+- 修正 `self-test.yaml` release archive：移除不存在的 root `setup.sh` 引用
+- 修正 mermaid 架构图：`setup.sh` 显示在正确的 `script/` 区块
+- zh-TW / zh-CN README 补上目录（Table of Contents）
+- 翻译同步：「包含内容」表格补上 `Makefile.ci` 条目
+- 翻译同步：「本地运行测试」改为正确的 `make -f Makefile.ci` 命令
+
+## [v0.3.0] - 2026-03-29
+
+### 变更
+- **破坏性变更**：Repo 更名 `docker_template` → `template`
+- **破坏性变更**：`setup.sh` 移至 `script/setup.sh`
+- **破坏性变更**：`config/` 移至 `script/config/`（v0.4.0 已搬回）
+- 所有 Shell 脚本套用 Google Shell Style Guide
+- `Makefile` 拆分为 `Makefile`（repo 用）+ `Makefile.ci`（CI 用）
+- 修正文档中的目录结构、测试数量、bashrc style
 - 132 个测试（原 124 个）
+
+### 迁移注意事项
+- Other repos：subtree prefix 从 `docker_template/` 改为 `template/`
+- Dockerfile `CONFIG_SRC` 路径：`docker_template/config` → `template/config`
+- Symlinks：`docker_template/*.sh` → `template/*.sh`
 
 ## [v0.2.0] - 2026-03-28
 
@@ -29,9 +41,9 @@
 - 修复 coverage 权限（使用 HOST_UID/HOST_GID 的 chown）
 
 ### 变更
-- `smoke_test/` 移至 `test/smoke_test/`（**破坏性变更**：consumer Dockerfile COPY 路径变更）
-- `compose.yaml` 改为调用 `script/ci.sh --ci`（替代 inline bash）
-- `self-test.yaml` 改为调用 `script/ci.sh`（替代直接调用 docker compose）
+- `smoke_test/` 移至 `test/smoke_test/`（**破坏性变更**：Dockerfile COPY 路径变更）
+- `compose.yaml` 改为调用 `script/ci.sh --ci`（取代 inline bash）
+- `self-test.yaml` 改为调用 `script/ci.sh`（取代直接调用 docker compose）
 
 ## [v0.1.0] - 2026-03-28
 
@@ -54,14 +66,16 @@
 - 文档：README（英文）、README.zh-TW.md、README.zh-CN.md、README.ja.md、TEST.md
 
 ### 变更
-- `setup.sh` 默认 `_base_path` 改为向上 1 层（`/..`），替代原本的 2 层（`/../..`），以匹配新的 `template/setup.sh` 位置
+- `setup.sh` 默认 `_base_path` 改为向上 1 层（`/..`），以符合新的 `template/setup.sh` 位置
 
 ### 迁移注意事项
-- Consumer repos 将 `docker_setup_helper/` subtree 替换为 `template/` subtree
+- 将 `docker_setup_helper/` subtree 替换为 `template/` subtree
 - 根目录的 Shell 脚本改为指向 `template/` 的 symlinks
 - 本地 `build-worker.yaml` / `release-worker.yaml` 替换为 `main.yaml` 中的可重用 workflow 调用
-- Dockerfile `CONFIG_SRC` 路径变更：`docker_setup_helper/src/config` → `template/config`
-- 共用 smoke tests 通过 Dockerfile `COPY template/test/smoke_test/` 加载（非 symlinks — Docker COPY 不 follow symlinks）
+- Dockerfile `CONFIG_SRC` 路径：`docker_setup_helper/src/config` → `template/config`
+- 共用 smoke tests 通过 Dockerfile `COPY template/test/smoke_test/` 加载（非 symlinks）
 
-[未发布]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...HEAD
+[v0.4.0]: https://github.com/ycpss91255-docker/template/compare/v0.3.0...v0.4.0
+[v0.3.0]: https://github.com/ycpss91255-docker/template/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...v0.2.0
 [v0.1.0]: https://github.com/ycpss91255-docker/template/releases/tag/v0.1.0

--- a/doc/changelog/CHANGELOG.zh-TW.md
+++ b/doc/changelog/CHANGELOG.zh-TW.md
@@ -5,19 +5,31 @@
 格式基於 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)，
 版本號遵循 [語意化版本](https://semver.org/spec/v2.0.0.html)。
 
-## [未發布]
-
-### 新增
-- `script/init.sh`：一鍵為 consumer repo 建立 symlinks
-- `Makefile`：統一指令入口（`make test`、`make lint`、`make migrate` 等）
+## [v0.4.0] - 2026-03-29
 
 ### 變更
-- 管理腳本移至 `script/`（ci.sh、migrate.sh、init.sh）— 與使用者操作腳本分離
-- `Makefile` 和 `compose.yaml` 留在根目錄（使用者操作用）
-- 重整 `test/`：`test/unit/`（自身測試）+ `test/smoke_test/`（consumer 共用測試）
-- 重整 `doc/`：`doc/readme/`、`doc/test/`、`doc/changelog/`（依檔案類型分，含 i18n）
-- README：簡化測試/變更記錄章節，改為連結至詳細文件
-- 132 個測試（原 124 ��）
+- `config/` 從 `script/config/` 搬回根目錄（v0.3.0 時移入，設定檔不應放在 script/）
+- 修正 `self-test.yaml` release archive：移除不存在的 root `setup.sh` 引用
+- 修正 mermaid 架構圖：`setup.sh` 顯示在正確的 `script/` 區塊
+- zh-TW / zh-CN README 補上目錄（Table of Contents）
+- 翻譯同步：「包含內容」表格補上 `Makefile.ci` 條目
+- 翻譯同步：「��地執行測試」改為正確的 `make -f Makefile.ci` 指令
+
+## [v0.3.0] - 2026-03-29
+
+### 變更
+- **破壞性變更**：Repo 更名 `docker_template` → `template`
+- **破壞性變更**：`setup.sh` 移至 `script/setup.sh`
+- **破壞性變更**：`config/` 移至 `script/config/`（v0.4.0 已搬回）
+- 所有 Shell 腳本套用 Google Shell Style Guide
+- `Makefile` 拆分為 `Makefile`（repo 用）+ `Makefile.ci`（CI 用）
+- 修正文件中的目錄結構、測試數量、bashrc style
+- 132 個測試（原 124 個）
+
+### 遷���注意事項
+- Other repos：subtree prefix 從 `docker_template/` 改為 `template/`
+- Dockerfile `CONFIG_SRC` 路徑：`docker_template/config` → `template/config`
+- Symlinks：`docker_template/*.sh` → `template/*.sh`
 
 ## [v0.2.0] - 2026-03-28
 
@@ -29,7 +41,7 @@
 - 修復 coverage 權限（使用 HOST_UID/HOST_GID 的 chown）
 
 ### 變更
-- `smoke_test/` 移至 `test/smoke_test/`（**破壞性變更**：consumer Dockerfile COPY 路徑變更）
+- `smoke_test/` 移至 `test/smoke_test/`（**破壞性變更**：Dockerfile COPY 路徑變更）
 - `compose.yaml` 改為呼叫 `script/ci.sh --ci`（取代 inline bash）
 - `self-test.yaml` 改為呼叫 `script/ci.sh`（取代直接呼叫 docker compose）
 
@@ -54,14 +66,16 @@
 - 文件：README（英文）、README.zh-TW.md、README.zh-CN.md、README.ja.md、TEST.md
 
 ### 變更
-- `setup.sh` 預設 `_base_path` 改為向上 1 層（`/..`），取代原本的 2 層（`/../..`），以符合新的 `template/setup.sh` 位置
+- `setup.sh` 預設 `_base_path` 改為向上 1 層（`/..`），以符合新的 `template/setup.sh` 位置
 
 ### 遷移注意事項
-- Consumer repos 將 `docker_setup_helper/` subtree 替換為 `template/` subtree
+- 將 `docker_setup_helper/` subtree 替換為 `template/` subtree
 - 根目錄的 Shell 腳本改為指向 `template/` 的 symlinks
 - 本地 `build-worker.yaml` / `release-worker.yaml` 替換為 `main.yaml` 中的可重用 workflow 呼叫
-- Dockerfile `CONFIG_SRC` 路徑變更：`docker_setup_helper/src/config` → `template/config`
-- 共用 smoke tests 透過 Dockerfile `COPY template/test/smoke_test/` 載入（非 symlinks — Docker COPY 不 follow symlinks）
+- Dockerfile `CONFIG_SRC` 路徑：`docker_setup_helper/src/config` → `template/config`
+- 共用 smoke tests 透過 Dockerfile `COPY template/test/smoke_test/` 載入（非 symlinks）
 
-[未發布]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...HEAD
+[v0.4.0]: https://github.com/ycpss91255-docker/template/compare/v0.3.0...v0.4.0
+[v0.3.0]: https://github.com/ycpss91255-docker/template/compare/v0.2.0...v0.3.0
+[v0.2.0]: https://github.com/ycpss91255-docker/template/compare/v0.1.0...v0.2.0
 [v0.1.0]: https://github.com/ycpss91255-docker/template/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary
- Add missing v0.3.0 entry (rename, Google Style, Makefile split, breaking changes)
- Add v0.4.0 entry (config/ move back to root, docs fixes)
- Update comparison links for all versions
- All 4 languages (EN, zh-TW, zh-CN, ja)

Preparing for v0.4.0 tag.

## Test plan
- [x] CHANGELOG structure consistent across 4 languages
- [x] Comparison links point to correct version ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)