### PR TITLE
revert: stop.sh container name display

### DIFF
--- a/stop.sh
+++ b/stop.sh
@@ -69,26 +69,7 @@ set -o allexport
 source "${FILE_PATH}/.env"
 set +o allexport
 
-PROJECT="${DOCKER_HUB_USER}-${IMAGE_NAME}"
-
-# Show containers being stopped
-containers=$(docker compose -p "${PROJECT}" \
-  -f "${FILE_PATH}/compose.yaml" \
-  --env-file "${FILE_PATH}/.env" \
-  ps -q 2>/dev/null)
-
-if [[ -n "${containers}" ]]; then
-  echo "Stopping containers:"
-  docker compose -p "${PROJECT}" \
-    -f "${FILE_PATH}/compose.yaml" \
-    --env-file "${FILE_PATH}/.env" \
-    ps --format "  {{.Name}}"
-else
-  echo "No running containers."
-  exit 0
-fi
-
-docker compose -p "${PROJECT}" \
+docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" \
   -f "${FILE_PATH}/compose.yaml" \
   --env-file "${FILE_PATH}/.env" \
   down "$@"

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -164,7 +164,7 @@ setup() {
 }
 
 @test "stop.sh uses -p for compose project name" {
-    run grep -E '\-p.*PROJECT' /source/stop.sh
+    run grep -E '\-p.*DOCKER_HUB_USER.*IMAGE_NAME' /source/stop.sh
     assert_success
 }
 


### PR DESCRIPTION
Revert PR #30 — docker compose down already shows container names.

Generated with Claude Code