### PR TITLE
feat: add APT_MIRROR_UBUNTU / APT_MIRROR_DEBIAN to .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Or directly:
 
 ## Tests
 
-- **132** template self-tests (`test/unit/`)
+- **136** template self-tests (`test/unit/`)
 - **27** shared smoke tests (`test/smoke/`)
 
 See [TEST.md](doc/test/TEST.md) for details.

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.5.0] - 2026-03-31
+
+### Added
+- `setup.sh`: add `APT_MIRROR_UBUNTU` and `APT_MIRROR_DEBIAN` to `.env`
+  - Default: `tw.archive.ubuntu.com` (Ubuntu), `mirror.twds.com.tw` (Debian)
+  - Preserves existing values from `.env` on re-run
+- 4 new tests (136 total)
+
 ## [v0.4.2] - 2026-03-30
 
 ### Fixed

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # CI ターゲット表示
 
 ## テスト
 
-- **132** テンプレート自身のテスト（`test/unit/`）
+- **136** テンプレート自身のテスト（`test/unit/`）
 - **27** 共有 smoke tests（`test/smoke/`）
 
 詳細は [TEST.md](../test/TEST.md) を参照。

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # 显示 CI 命令
 
 ## 测试
 
-- **132** 个 template 自身测试（`test/unit/`）
+- **136** 个 template 自身测试（`test/unit/`）
 - **27** 个共用 smoke tests（`test/smoke/`）
 
 详见 [TEST.md](../test/TEST.md)。

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # 顯示 CI 指令
 
 ## 測試
 
-- **132** 個 template 自身測試（`test/unit/`）
+- **136** 個 template 自身測試（`test/unit/`）
 - **27** 個共用 smoke tests（`test/smoke/`）
 
 詳見 [TEST.md](../test/TEST.md)。

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **132 tests** total.
+Template self-tests: **136 tests** total.
 
 ## Test Files
 
-### test/setup_spec.bats (42)
+### test/setup_spec.bats (46)
 
 | Test | Description |
 |------|-------------|
@@ -30,6 +30,8 @@ Template self-tests: **132 tests** total.
 | `detect_ws_path strategy 2: finds _ws component in path` | Path traversal |
 | `detect_ws_path strategy 3: falls back to parent directory` | Parent fallback |
 | `write_env creates .env with all required variables` | .env generation |
+| `write_env includes APT_MIRROR_UBUNTU` | APT mirror in .env |
+| `write_env includes APT_MIRROR_DEBIAN` | APT mirror in .env |
 | `main creates .env when it does not exist` | Fresh .env |
 | `main sources existing .env and reuses valid WS_PATH` | WS_PATH reuse |
 | `main re-detects WS_PATH when path in .env no longer exists` | Stale WS_PATH |
@@ -37,6 +39,8 @@ Template self-tests: **132 tests** total.
 | `default _base_path resolves to repo root, not script dir` | Regression test |
 | `main returns error on unknown argument` | Error handling |
 | `main returns error when --base-path value is missing` | Missing value |
+| `main sets APT_MIRROR defaults in fresh .env` | Default mirrors |
+| `main preserves existing APT_MIRROR values from .env` | Mirror preservation |
 | `_msg returns English messages by default` | i18n English |
 | `_msg returns Chinese messages when _LANG=zh` | i18n Chinese |
 | `_msg returns Simplified Chinese messages when _LANG=zh-CN` | i18n Simplified Chinese |

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -228,7 +228,9 @@ write_env() {
   local _docker_hub_user="${1}"; shift
   local _gpu_enabled="${1}"; shift
   local _image_name="${1}"; shift
-  local _ws_path="${1}"
+  local _ws_path="${1}"; shift
+  local _apt_mirror_ubuntu="${1}"; shift
+  local _apt_mirror_debian="${1}"
 
   local _comment=""
   _comment="$(_msg env_comment)"
@@ -248,6 +250,10 @@ IMAGE_NAME=${_image_name}
 
 # ── Workspace ────────────────────────────────
 WS_PATH=${_ws_path}
+
+# ── APT Mirror ───────────────────────────────
+APT_MIRROR_UBUNTU=${_apt_mirror_ubuntu}
+APT_MIRROR_DEBIAN=${_apt_mirror_debian}
 EOF
 }
 
@@ -296,6 +302,8 @@ main() {
   local user_name="" user_group="" user_uid="" user_gid=""
   local hardware="" docker_hub_user="" gpu_enabled="" image_name=""
   local ws_path="${WS_PATH:-}"
+  local apt_mirror_ubuntu="${APT_MIRROR_UBUNTU:-tw.archive.ubuntu.com}"
+  local apt_mirror_debian="${APT_MIRROR_DEBIAN:-mirror.twds.com.tw}"
 
   detect_user_info       user_name user_group user_uid user_gid
   detect_hardware        hardware
@@ -323,7 +331,8 @@ main() {
   write_env "${_env_file}" \
     "${user_name}" "${user_group}" "${user_uid}" "${user_gid}" \
     "${hardware}" "${docker_hub_user}" "${gpu_enabled}" \
-    "${image_name}" "${ws_path}"
+    "${image_name}" "${ws_path}" \
+    "${apt_mirror_ubuntu}" "${apt_mirror_debian}"
 
   printf "[setup] %s\n" "$(_msg env_done)"
   printf "[setup] USER=%s (%s:%s)  GPU=%s  IMAGE=%s  WS=%s\n" \

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -214,7 +214,8 @@ esac'
     write_env "${_env_file}" \
         "testuser" "testgroup" "1001" "1001" \
         "x86_64" "dockerhub" "false" \
-        "ros_noetic" "/workspace"
+        "ros_noetic" "/workspace" \
+        "tw.archive.ubuntu.com" "mirror.twds.com.tw"
 
     assert [ -f "${_env_file}" ]
     run grep "USER_NAME=testuser"        "${_env_file}"; assert_success
@@ -226,6 +227,24 @@ esac'
     run grep "GPU_ENABLED=false"         "${_env_file}"; assert_success
     run grep "IMAGE_NAME=ros_noetic"     "${_env_file}"; assert_success
     run grep "WS_PATH=/workspace"        "${_env_file}"; assert_success
+}
+
+@test "write_env includes APT_MIRROR_UBUNTU" {
+    local _env_file="${TEMP_DIR}/.env"
+    write_env "${_env_file}" \
+        "u" "g" "1000" "1000" "x86_64" "hub" "false" "img" "/ws" \
+        "tw.archive.ubuntu.com" "mirror.twds.com.tw"
+    run grep "APT_MIRROR_UBUNTU=tw.archive.ubuntu.com" "${_env_file}"
+    assert_success
+}
+
+@test "write_env includes APT_MIRROR_DEBIAN" {
+    local _env_file="${TEMP_DIR}/.env"
+    write_env "${_env_file}" \
+        "u" "g" "1000" "1000" "x86_64" "hub" "false" "img" "/ws" \
+        "tw.archive.ubuntu.com" "mirror.twds.com.tw"
+    run grep "APT_MIRROR_DEBIAN=mirror.twds.com.tw" "${_env_file}"
+    assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -336,6 +355,40 @@ EOF
 @test "main returns error when --base-path value is missing" {
     run bash -c "source /source/script/setup.sh; main --base-path"
     assert_failure
+}
+
+@test "main sets APT_MIRROR defaults in fresh .env" {
+    local _ws="${TEMP_DIR}/test_ws"
+    mkdir -p "${_ws}"
+    run bash -c "
+        source /source/script/setup.sh
+        detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
+        main --base-path '${TEMP_DIR}'
+    "
+    assert_success
+    run grep "APT_MIRROR_UBUNTU=tw.archive.ubuntu.com" "${TEMP_DIR}/.env"
+    assert_success
+    run grep "APT_MIRROR_DEBIAN=mirror.twds.com.tw" "${TEMP_DIR}/.env"
+    assert_success
+}
+
+@test "main preserves existing APT_MIRROR values from .env" {
+    local _ws="${TEMP_DIR}/existing_ws"
+    mkdir -p "${_ws}"
+    cat > "${TEMP_DIR}/.env" << EOF
+WS_PATH=${_ws}
+APT_MIRROR_UBUNTU=us.archive.ubuntu.com
+APT_MIRROR_DEBIAN=deb.debian.org
+EOF
+    run bash -c "
+        source /source/script/setup.sh
+        main --base-path '${TEMP_DIR}'
+    "
+    assert_success
+    run grep "APT_MIRROR_UBUNTU=us.archive.ubuntu.com" "${TEMP_DIR}/.env"
+    assert_success
+    run grep "APT_MIRROR_DEBIAN=deb.debian.org" "${TEMP_DIR}/.env"
+    assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- `setup.sh` writes `APT_MIRROR_UBUNTU` and `APT_MIRROR_DEBIAN` to `.env`
- Default: `tw.archive.ubuntu.com` / `mirror.twds.com.tw`
- Preserves existing values on re-run (same as WS_PATH)
- 4 new tests (TDD), 136 total, 100% coverage

## Test plan
- [x] 136 tests passed
- [x] 100% coverage
- [x] CHANGELOG, TEST.md, README (4 langs) updated

Generated with Claude Code