### PR TITLE
feat: warn on unknown IMAGE_NAME, remove .env.example fallback

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `setup.sh`: add `APT_MIRROR_UBUNTU` and `APT_MIRROR_DEBIAN` to `.env`
   - Default: `tw.archive.ubuntu.com` (Ubuntu), `mirror.twds.com.tw` (Debian)
   - Preserves existing values from `.env` on re-run
+- `setup.sh`: warn when `IMAGE_NAME` cannot be detected (prints WARNING, uses `unknown`)
 - 4 new tests (136 total)
+
+### Removed
+- `setup.sh`: remove `.env.example` fallback for `IMAGE_NAME` (replaced by warning)
 
 ## [v0.4.2] - 2026-03-30
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -35,6 +35,7 @@ Template self-tests: **136 tests** total.
 | `main creates .env when it does not exist` | Fresh .env |
 | `main sources existing .env and reuses valid WS_PATH` | WS_PATH reuse |
 | `main re-detects WS_PATH when path in .env no longer exists` | Stale WS_PATH |
+| `main warns when IMAGE_NAME is unknown` | Unknown IMAGE_NAME warning |
 | `main uses BASH_SOURCE fallback when --base-path not given` | Fallback path |
 | `default _base_path resolves to repo root, not script dir` | Regression test |
 | `main returns error on unknown argument` | Error handling |

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -311,16 +311,8 @@ main() {
   detect_gpu             gpu_enabled
   detect_image_name      image_name "${_base_path}"
 
-  # Fallback: read IMAGE_NAME from .env.example if detection returned unknown
   if [[ "${image_name}" == "unknown" ]]; then
-    local _env_example="${_base_path}/.env.example"
-    if [[ -f "${_env_example}" ]]; then
-      local _example_name=""
-      _example_name="$(grep -m1 '^IMAGE_NAME=' "${_env_example}" | cut -d= -f2)"
-      if [[ -n "${_example_name}" && "${_example_name}" != "unknown" ]]; then
-        image_name="${_example_name}"
-      fi
-    fi
+    printf "[setup] WARNING: IMAGE_NAME could not be detected. Using 'unknown'.\n" >&2
   fi
 
   if [[ -z "${ws_path}" ]] || [[ ! -d "${ws_path}" ]]; then

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -294,13 +294,10 @@ EOF
     assert_success
 }
 
-@test "main reads IMAGE_NAME from .env.example when detection returns unknown" {
+@test "main warns when IMAGE_NAME is unknown" {
     local _ws="${TEMP_DIR}/test_ws"
     local _proj="${TEMP_DIR}/my_generic_project"
     mkdir -p "${_ws}" "${_proj}"
-
-    # Create .env.example with IMAGE_NAME
-    echo "IMAGE_NAME=my_custom_image" > "${_proj}/.env.example"
 
     run bash -c "
         source /source/script/setup.sh
@@ -308,7 +305,8 @@ EOF
         main --base-path '${_proj}'
     "
     assert_success
-    run grep 'IMAGE_NAME=my_custom_image' "${_proj}/.env"
+    assert_line --partial "WARNING"
+    run grep 'IMAGE_NAME=unknown' "${_proj}/.env"
     assert_success
 }
 


### PR DESCRIPTION
## Summary
- setup.sh prints WARNING when IMAGE_NAME is unknown (was silent fallback to .env.example)
- Remove .env.example reading logic
- .env.example no longer needed in repos

## Test plan
- [x] 136 tests, 100% coverage
- [x] CHANGELOG, TEST.md updated

Generated with Claude Code