### PR TITLE
fix: restore .env.example fallback for IMAGE_NAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Or directly:
 
 ## Tests
 
-- **136** template self-tests (`test/unit/`)
+- **137** template self-tests (`test/unit/`)
 - **27** shared smoke tests (`test/smoke/`)
 
 See [TEST.md](doc/test/TEST.md) for details.

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -11,11 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `setup.sh`: add `APT_MIRROR_UBUNTU` and `APT_MIRROR_DEBIAN` to `.env`
   - Default: `tw.archive.ubuntu.com` (Ubuntu), `mirror.twds.com.tw` (Debian)
   - Preserves existing values from `.env` on re-run
-- `setup.sh`: warn when `IMAGE_NAME` cannot be detected (prints WARNING, uses `unknown`)
-- 4 new tests (136 total)
-
-### Removed
-- `setup.sh`: remove `.env.example` fallback for `IMAGE_NAME` (replaced by warning)
+- `setup.sh`: warn when `IMAGE_NAME` cannot be detected and `.env.example` not found
+- `display_env.bats`: auto-skip GUI tests for headless repos
+- 5 new tests (137 total)
 
 ## [v0.4.2] - 2026-03-30
 

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # CI ターゲット表示
 
 ## テスト
 
-- **136** テンプレート自身のテスト（`test/unit/`）
+- **137** テンプレート自身のテスト（`test/unit/`）
 - **27** 共有 smoke tests（`test/smoke/`）
 
 詳細は [TEST.md](../test/TEST.md) を参照。

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # 显示 CI 命令
 
 ## 测试
 
-- **136** 个 template 自身测试（`test/unit/`）
+- **137** 个 template 自身测试（`test/unit/`）
 - **27** 个共用 smoke tests（`test/smoke/`）
 
 详见 [TEST.md](../test/TEST.md)。

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # 顯示 CI 指令
 
 ## 測試
 
-- **136** 個 template 自身測試（`test/unit/`）
+- **137** 個 template 自身測試（`test/unit/`）
 - **27** 個共用 smoke tests（`test/smoke/`）
 
 詳見 [TEST.md](../test/TEST.md)。

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **136 tests** total.
+Template self-tests: **137 tests** total.
 
 ## Test Files
 
-### test/setup_spec.bats (46)
+### test/setup_spec.bats (47)
 
 | Test | Description |
 |------|-------------|

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -311,6 +311,18 @@ main() {
   detect_gpu             gpu_enabled
   detect_image_name      image_name "${_base_path}"
 
+  # Fallback: read IMAGE_NAME from .env.example
+  if [[ "${image_name}" == "unknown" ]]; then
+    local _env_example="${_base_path}/.env.example"
+    if [[ -f "${_env_example}" ]]; then
+      local _example_name=""
+      _example_name="$(grep -m1 '^IMAGE_NAME=' "${_env_example}" | cut -d= -f2)"
+      if [[ -n "${_example_name}" && "${_example_name}" != "unknown" ]]; then
+        image_name="${_example_name}"
+      fi
+    fi
+  fi
+
   if [[ "${image_name}" == "unknown" ]]; then
     printf "[setup] WARNING: IMAGE_NAME could not be detected. Using 'unknown'.\n" >&2
   fi

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -294,7 +294,24 @@ EOF
     assert_success
 }
 
-@test "main warns when IMAGE_NAME is unknown" {
+@test "main reads IMAGE_NAME from .env.example when detection returns unknown" {
+    local _ws="${TEMP_DIR}/test_ws"
+    local _proj="${TEMP_DIR}/my_generic_project"
+    mkdir -p "${_ws}" "${_proj}"
+
+    echo "IMAGE_NAME=my_custom_image" > "${_proj}/.env.example"
+
+    run bash -c "
+        source /source/script/setup.sh
+        detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
+        main --base-path '${_proj}'
+    "
+    assert_success
+    run grep 'IMAGE_NAME=my_custom_image' "${_proj}/.env"
+    assert_success
+}
+
+@test "main warns when IMAGE_NAME is unknown and no .env.example" {
     local _ws="${TEMP_DIR}/test_ws"
     local _proj="${TEMP_DIR}/my_generic_project"
     mkdir -p "${_ws}" "${_proj}"


### PR DESCRIPTION
## Summary
- Restore .env.example reading when detect_image_name returns unknown
- WARNING only when both detection and .env.example fail
- .env.example only needs `IMAGE_NAME=<name>` (one line)
- 137 tests, 100% coverage

## Test plan
- [x] With .env.example: IMAGE_NAME reads from it
- [x] Without .env.example: prints WARNING, uses unknown
- [x] 137 tests, 100% coverage

Generated with Claude Code