### PR TITLE
feat: add Dockerfile.test-tools + Dockerfile.example

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
 
       - name: Generate .env
         run: |
@@ -57,6 +59,13 @@ jobs:
           EOF
           mkdir -p /tmp/workspace
 
+      - name: Build test-tools image
+        run: |
+          if [ -f template/dockerfile/Dockerfile.test-tools ]; then
+            docker build -t test-tools:local \
+              -f template/dockerfile/Dockerfile.test-tools .
+          fi
+
       - name: Build test stage (includes smoke tests)
         uses: docker/build-push-action@v6
         with:
@@ -70,8 +79,6 @@ jobs:
             GID=1000
             HARDWARE=x86_64
             ${{ inputs.build_args }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Build devel stage
         uses: docker/build-push-action@v6
@@ -86,8 +93,6 @@ jobs:
             GID=1000
             HARDWARE=x86_64
             ${{ inputs.build_args }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Build runtime stage
         if: ${{ inputs.build_runtime }}
@@ -102,5 +107,3 @@ jobs:
             UID=1000
             GID=1000
             ${{ inputs.build_args }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/build.sh
+++ b/build.sh
@@ -113,6 +113,15 @@ set -o allexport
 source "${FILE_PATH}/.env"
 set +o allexport
 
+# Build test-tools image if Dockerfile exists
+_tools_dockerfile="${FILE_PATH}/template/dockerfile/Dockerfile.test-tools"
+if [[ -f "${_tools_dockerfile}" ]]; then
+  docker build -t test-tools:local -f "${_tools_dockerfile}" "${FILE_PATH}" -q >/dev/null
+fi
+
+_cleanup() { docker rmi test-tools:local 2>/dev/null || true; }
+trap _cleanup EXIT
+
 docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" \
   -f "${FILE_PATH}/compose.yaml" \
   --env-file "${FILE_PATH}/.env" \

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -1,0 +1,164 @@
+# Dockerfile.example - Template for new Docker container repos
+#
+# Copy this file to your repo root as "Dockerfile" and customize.
+# The test-tools image (ShellCheck, Hadolint, Bats) is pre-built by build.sh.
+#
+# Stages:
+#   sys     - User/group, locale, timezone
+#   base    - Development tools and packages
+#   devel   - Application-specific tools + entrypoint
+#   test    - Lint + smoke test (ephemeral, discarded after build)
+#   runtime - Minimal runtime image (optional)
+
+ARG BASE_IMAGE="ubuntu:24.04"
+
+############################## sys ##############################
+FROM ${BASE_IMAGE} AS sys
+
+ARG USER_NAME="user"
+ARG USER_GID=1000
+ARG USER_UID=1000
+ARG USER_GROUP="user"
+ARG TZ="Asia/Taipei"
+ARG APT_MIRROR_UBUNTU="tw.archive.ubuntu.com"
+
+SHELL ["/bin/bash", "-x", "-euo", "pipefail", "-c"]
+
+RUN sed -i "s@archive.ubuntu.com@${APT_MIRROR_UBUNTU}@g" /etc/apt/sources.list || true; \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        tzdata \
+        locales \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    sed -i 's/^# *en_US.UTF-8/en_US.UTF-8/' /etc/locale.gen && \
+    locale-gen && \
+    update-locale LANG="en_US.UTF-8" && \
+    ln -snf /usr/share/zoneinfo/"${TZ}" /etc/localtime && echo "${TZ}" > /etc/timezone
+
+ENV LC_ALL="en_US.UTF-8"
+ENV LANG="en_US.UTF-8"
+
+# Create user (handle UID/GID conflicts)
+RUN if getent group "${USER_GID}" >/dev/null; then \
+        groupmod -n "${USER_GROUP}" "$(getent group "${USER_GID}" | cut -d: -f1)"; \
+    else \
+        groupadd -g "${USER_GID}" "${USER_GROUP}"; \
+    fi && \
+    if getent passwd "${USER_UID}" >/dev/null; then \
+        usermod -l "${USER_NAME}" -d "/home/${USER_NAME}" -m \
+            "$(getent passwd "${USER_UID}" | cut -d: -f1)"; \
+    else \
+        useradd -m -s /bin/bash -u "${USER_UID}" -g "${USER_GID}" "${USER_NAME}"; \
+    fi && \
+    echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+############################## base ##############################
+FROM sys AS base
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        sudo \
+        git \
+        vim \
+        tmux \
+        curl \
+        wget \
+        python3 \
+        python3-pip \
+        && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+############################## devel ##############################
+FROM base AS devel
+
+ARG USER="${USER_NAME}"
+ARG GROUP="${USER_GROUP}"
+ARG ENTRYPOINT_FILE="script/entrypoint.sh"
+ARG CONFIG_DIR="/tmp/config"
+ARG CONFIG_SRC="template/config"
+
+# Add your application-specific packages here
+# RUN apt-get update && \
+#     apt-get install -y --no-install-recommends \
+#         your-package \
+#         && \
+#     apt-get clean && \
+#     rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=0755 "./${ENTRYPOINT_FILE}" "/entrypoint.sh"
+COPY --chown="${USER}":"${GROUP}" --chmod=0755 "${CONFIG_SRC}" "${CONFIG_DIR}"
+
+USER "${USER}"
+
+# Setup pip packages
+RUN "${CONFIG_DIR}"/pip/setup.sh
+
+# Setup shell, terminator, tmux
+RUN cat "${CONFIG_DIR}"/shell/bashrc >> "${HOME}/.bashrc" && \
+    chown "${USER}":"${GROUP}" "${HOME}/.bashrc" && \
+    "${CONFIG_DIR}"/shell/terminator/setup.sh && \
+    "${CONFIG_DIR}"/shell/tmux/setup.sh && \
+    sudo rm -rf "${CONFIG_DIR}"
+
+WORKDIR "${HOME}/work"
+
+EXPOSE 22
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["bash"]
+
+############################## test ##############################
+FROM devel AS test
+
+USER root
+
+# Lint tools (from pre-built test-tools image)
+COPY --from=test-tools:local /usr/local/bin/shellcheck /usr/local/bin/shellcheck
+COPY --from=test-tools:local /usr/local/bin/hadolint /usr/local/bin/hadolint
+
+# Lint: ShellCheck (.sh) + Hadolint (Dockerfile)
+COPY .hadolint.yaml /lint/.hadolint.yaml
+COPY Dockerfile /lint/Dockerfile
+COPY compose.yaml /lint/compose.yaml
+COPY *.sh /lint/
+RUN shellcheck -S warning /lint/*.sh
+RUN cd /lint && hadolint Dockerfile
+
+# Bats (from pre-built test-tools image)
+COPY --from=test-tools:local /opt/bats /opt/bats
+COPY --from=test-tools:local /usr/lib/bats /usr/lib/bats
+RUN ln -sf /opt/bats/bin/bats /usr/local/bin/bats
+
+ENV BATS_LIB_PATH="/usr/lib/bats"
+
+# Smoke test (shared from template + repo-specific)
+COPY template/test/smoke/ /smoke_test/
+COPY test/smoke/ /smoke_test/
+
+ARG USER
+USER "${USER}"
+
+RUN bats /smoke_test/
+
+############################## runtime (optional) ##############################
+# FROM sys AS runtime-base
+#
+# RUN apt-get update && \
+#     apt-get install -y --no-install-recommends \
+#         sudo \
+#         tini \
+#         && \
+#     apt-get clean && \
+#     rm -rf /var/lib/apt/lists/*
+#
+# FROM runtime-base AS runtime
+#
+# ARG USER="${USER_NAME}"
+# COPY --chmod=0755 script/entrypoint.sh /entrypoint.sh
+# USER "${USER}"
+# WORKDIR "${HOME}/work"
+# ENTRYPOINT ["/entrypoint.sh"]
+# CMD ["bash"]

--- a/dockerfile/Dockerfile.test-tools
+++ b/dockerfile/Dockerfile.test-tools
@@ -1,0 +1,34 @@
+# Dockerfile.test-tools - Pre-built test tools for Docker container repos
+#
+# Contains: ShellCheck, Hadolint, Bats (with bats-support + bats-assert)
+#
+# Usage:
+#   docker build -t test-tools:local -f template/dockerfile/Dockerfile.test-tools .
+#   Then in repo Dockerfile:
+#     COPY --from=test-tools:local /usr/local/bin/shellcheck /usr/local/bin/shellcheck
+
+FROM bats/bats:latest AS bats-src
+
+FROM alpine:latest AS bats-extensions
+RUN apk add --no-cache git && \
+    git clone --depth 1 -b v0.3.0 \
+        https://github.com/bats-core/bats-support /bats/bats-support && \
+    git clone --depth 1 -b v2.1.0 \
+        https://github.com/bats-core/bats-assert  /bats/bats-assert
+
+FROM alpine:latest AS lint-tools
+RUN apk add --no-cache curl xz && \
+    curl -fsSL \
+        https://github.com/koalaman/shellcheck/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.xz \
+        | tar -xJ -C /tmp && \
+    mv /tmp/shellcheck-v0.10.0/shellcheck /usr/local/bin/shellcheck && \
+    curl -fsSL -o /usr/local/bin/hadolint \
+        https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64 && \
+    chmod +x /usr/local/bin/hadolint
+
+FROM alpine:latest
+COPY --from=bats-src /opt/bats /opt/bats
+COPY --from=bats-src /usr/lib/bats /usr/lib/bats
+COPY --from=bats-extensions /bats /usr/lib/bats
+COPY --from=lint-tools /usr/local/bin/shellcheck /usr/local/bin/
+COPY --from=lint-tools /usr/local/bin/hadolint /usr/local/bin/


### PR DESCRIPTION
## Summary
- `dockerfile/Dockerfile.test-tools`: pre-built test tools image (ShellCheck + Hadolint + Bats)
- `dockerfile/Dockerfile.example`: Dockerfile template for new repos
- `build.sh`: auto-build `test-tools:local` before compose build, cleanup on exit
- `build-worker.yaml`: add pre-build step, switch to docker driver for local image access

After repos update, they can remove 3 duplicated stages (~14 lines) from their Dockerfiles
and use `COPY --from=test-tools:local` instead.

## Test plan
- [x] 137 tests, 100% coverage
- [ ] Pilot: ros2_humble build test with new test-tools flow

Generated with Claude Code