### PR TITLE
fix: stop.sh removes orphan run-mode container

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Or directly:
 
 ## Tests
 
-- **137** template self-tests (`test/unit/`)
+- **138** template self-tests (`test/unit/`)
 - **27** shared smoke tests (`test/smoke/`)
 
 See [TEST.md](doc/test/TEST.md) for details.

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `stop.sh`: remove orphan container left by `docker compose run --name`
+  (`docker compose down` only cleans up `up`-mode containers, not `run`-mode)
+
 ## [v0.5.0] - 2026-03-31
 
 ### Added

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # CI ターゲット表示
 
 ## テスト
 
-- **137** テンプレート自身のテスト（`test/unit/`）
+- **138** テンプレート自身のテスト（`test/unit/`）
 - **27** 共有 smoke tests（`test/smoke/`）
 
 詳細は [TEST.md](../test/TEST.md) を参照。

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # 显示 CI 命令
 
 ## 测试
 
-- **137** 个 template 自身测试（`test/unit/`）
+- **138** 个 template 自身测试（`test/unit/`）
 - **27** 个共用 smoke tests（`test/smoke/`）
 
 详见 [TEST.md](../test/TEST.md)。

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # 顯示 CI 指令
 
 ## 測試
 
-- **137** 個 template 自身測試（`test/unit/`）
+- **138** 個 template 自身測試（`test/unit/`）
 - **27** 個共用 smoke tests（`test/smoke/`）
 
 詳見 [TEST.md](../test/TEST.md)。

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **137 tests** total.
+Template self-tests: **138 tests** total.
 
 ## Test Files
 

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -73,3 +73,7 @@ docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" \
   -f "${FILE_PATH}/compose.yaml" \
   --env-file "${FILE_PATH}/.env" \
   down "$@"
+
+# Also remove orphan container started by `docker compose run --name`
+# (compose down does not clean up `compose run` containers)
+docker rm -f "${IMAGE_NAME}" 2>/dev/null || true

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -178,6 +178,11 @@ setup() {
     assert_success
 }
 
+@test "stop.sh removes orphan run-mode container by name" {
+    run grep -E 'docker rm.*-f.*IMAGE_NAME' /source/script/docker/stop.sh
+    assert_success
+}
+
 # ════════════════════════════════════════════════════════════════════
 # run.sh: XDG_SESSION_TYPE branching
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- \`docker compose down\` does NOT remove containers started by \`docker compose run --name\`
- Add \`docker rm -f \"\${IMAGE_NAME}\"\` after \`down\` to clean up orphan run-mode containers
- Fixes the bug where \`./stop.sh\` reports "No resource found" but the container is still running

## Test plan
- [x] 138 tests, 100% coverage (1 new regression test)

Generated with Claude Code