### PR TITLE
fix: upgrade.sh re-runs init.sh after subtree pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Or directly:
 
 ## Tests
 
-- **138** template self-tests (`test/unit/`)
+- **140** template self-tests (`test/unit/`)
 - **27** shared smoke tests (`test/smoke/`)
 
 See [TEST.md](doc/test/TEST.md) for details.

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `stop.sh`: remove orphan container left by `docker compose run --name`
   (`docker compose down` only cleans up `up`-mode containers, not `run`-mode)
+- `upgrade.sh`: re-run `init.sh` after subtree pull to sync symlinks
+  (avoids stale symlinks when template directory structure changes)
 
 ## [v0.5.0] - 2026-03-31
 

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # CI ターゲット表示
 
 ## テスト
 
-- **138** テンプレート自身のテスト（`test/unit/`）
+- **140** テンプレート自身のテスト（`test/unit/`）
 - **27** 共有 smoke tests（`test/smoke/`）
 
 詳細は [TEST.md](../test/TEST.md) を参照。

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # 显示 CI 命令
 
 ## 测试
 
-- **138** 个 template 自身测试（`test/unit/`）
+- **140** 个 template 自身测试（`test/unit/`）
 - **27** 个共用 smoke tests（`test/smoke/`）
 
 详见 [TEST.md](../test/TEST.md)。

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -215,7 +215,7 @@ make -f Makefile.ci help  # 顯示 CI 指令
 
 ## 測試
 
-- **138** 個 template 自身測試（`test/unit/`）
+- **140** 個 template 自身測試（`test/unit/`）
 - **27** 個共用 smoke tests（`test/smoke/`）
 
 詳見 [TEST.md](../test/TEST.md)。

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **138 tests** total.
+Template self-tests: **140 tests** total.
 
 ## Test Files
 

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -184,6 +184,26 @@ setup() {
 }
 
 # ════════════════════════════════════════════════════════════════════
+# upgrade.sh
+# ════════════════════════════════════════════════════════════════════
+
+@test "upgrade.sh runs init.sh after subtree pull" {
+    run grep -E 'init\.sh' /source/upgrade.sh
+    assert_success
+}
+
+@test "upgrade.sh writes target_ver after init.sh (to override init's latest detection)" {
+    # init.sh writes latest tag to .template_version, but upgrade may target older version
+    # so upgrade.sh must overwrite .template_version AFTER init.sh runs
+    run bash -c "grep -n 'init\.sh\|VERSION_FILE' /source/upgrade.sh | grep -v '^[0-9]*:#'"
+    assert_success
+    # Check that init.sh appears before the final VERSION_FILE write
+    init_line=$(grep -n 'init\.sh' /source/upgrade.sh | head -1 | cut -d: -f1)
+    write_line=$(grep -n 'echo.*target_ver.*>.*VERSION_FILE\|echo.*"\${target_ver}".*VERSION_FILE' /source/upgrade.sh | tail -1 | cut -d: -f1)
+    [[ -n "${init_line}" && -n "${write_line}" && "${init_line}" -lt "${write_line}" ]]
+}
+
+# ════════════════════════════════════════════════════════════════════
 # run.sh: XDG_SESSION_TYPE branching
 # ════════════════════════════════════════════════════════════════════
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -77,18 +77,22 @@ _upgrade() {
   _log "Upgrading: ${local_ver} → ${target_ver}"
 
   # Step 1: subtree pull
-  _log "Step 1/3: git subtree pull"
+  _log "Step 1/4: git subtree pull"
   git subtree pull --prefix=template \
     "${TEMPLATE_REMOTE}" "${target_ver}" --squash \
     -m "chore: upgrade template subtree to ${target_ver}"
 
-  # Step 2: update version file
-  _log "Step 2/3: update .template_version"
+  # Step 2: re-run init.sh to sync symlinks (in case template structure changed)
+  _log "Step 2/4: re-run init.sh to sync symlinks"
+  ./template/init.sh
+
+  # Step 3: update version file (override init.sh's latest-tag detection)
+  _log "Step 3/4: update .template_version"
   echo "${target_ver}" > "${VERSION_FILE}"
   git add "${VERSION_FILE}"
 
-  # Step 3: update main.yaml @tag references
-  _log "Step 3/3: update workflow @tag references"
+  # Step 4: update main.yaml @tag references
+  _log "Step 4/4: update workflow @tag references"
   local main_yaml="${REPO_ROOT}/.github/workflows/main.yaml"
   if [[ -f "${main_yaml}" ]]; then
     # Replace @vX.Y.Z with new version in reusable workflow references


### PR DESCRIPTION
## Summary
- After \`git subtree pull\`, run \`init.sh\` to sync symlinks
- Avoids stale symlinks when template directory structure changes
- \`init.sh\` writes latest tag → \`upgrade.sh\` overwrites with target version

## Test plan
- [x] 140 tests, 100% coverage (2 new tests)

Generated with Claude Code