### PR TITLE
refactor: dead code cleanup

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `upgrade.sh`: re-run `init.sh` after subtree pull to sync symlinks
   (avoids stale symlinks when template directory structure changes)
 
+### Removed
+- Stale comments referencing `get_param.sh` (historical, no longer relevant)
+
 ## [v0.5.0] - 2026-03-31
 
 ### Added

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **149 tests** total.
+Template self-tests: **150 tests** total.
 
 ## Test Files
 
-### test/unit/setup_spec.bats (54)
+### test/unit/setup_spec.bats (55)
 
 | Test | Description |
 |------|-------------|
@@ -42,7 +42,8 @@ Template self-tests: **149 tests** total.
 | `main creates .env when it does not exist` | Fresh .env |
 | `main sources existing .env and reuses valid WS_PATH` | WS_PATH reuse |
 | `main re-detects WS_PATH when path in .env no longer exists` | Stale WS_PATH |
-| `main reads IMAGE_NAME from .env.example when detection returns unknown` | .env.example fallback |
+| `main: env_example rule reads IMAGE_NAME from .env.example` | env_example rule via main |
+| `main warns when conf has no fallback and detection fails` | WARNING when no rule matches |
 | `main uses basename for repo without docker_/_ws naming` | basename fallback |
 | `main uses BASH_SOURCE fallback when --base-path not given` | Fallback path |
 | `default _base_path resolves to repo root, not script dir` | Regression test |

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # setup.sh - Auto-detect system parameters and generate .env before build
 #
-# Replaces get_param.sh with the following features:
+# Features:
 #   - User info detection (UID/GID/USER/GROUP)
 #   - Hardware architecture detection
 #   - Docker Hub username detection
 #   - GPU support detection
-#   - Image name inference (compatible with docker_* / *_ws naming conventions)
+#   - Image name detection via image_name.conf rule engine
 #   - Workspace path detection (sibling scan → path traversal → parent directory fallback)
+#   - APT mirror configuration
 #   - .env generation
 #
 # Usage: setup.sh [--base-path <path>] [--lang zh|zh-CN|ja]
@@ -248,8 +249,6 @@ detect_image_name() {
 #   1. If current directory is docker_*, use sibling *_ws (strip prefix)
 #   2. Traverse path upward looking for a *_ws component
 #   3. Fall back to parent directory
-#
-# Compatible with get_param.sh get_workdir behaviour.
 #
 # Usage: detect_ws_path <outvar> <base_path>
 # ════════════════════════════════════════════════════════════════════

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -378,7 +378,8 @@ EOF
     assert_success
 }
 
-@test "main reads IMAGE_NAME from .env.example when detection returns unknown" {
+@test "main: env_example rule reads IMAGE_NAME from .env.example" {
+    # Default conf has env_example before basename, so .env.example wins
     local _ws="${TEMP_DIR}/test_ws"
     local _proj="${TEMP_DIR}/my_generic_project"
     mkdir -p "${_ws}" "${_proj}"
@@ -392,6 +393,27 @@ EOF
     "
     assert_success
     run grep 'IMAGE_NAME=my_custom_image' "${_proj}/.env"
+    assert_success
+}
+
+@test "main warns when conf has no fallback and detection fails" {
+    # Custom conf without basename rule, no .env.example, no matching prefix/suffix
+    local _ws="${TEMP_DIR}/test_ws"
+    local _proj="${TEMP_DIR}/my_generic_project"
+    mkdir -p "${_ws}" "${_proj}"
+
+    cat > "${_proj}/image_name.conf" <<EOF
+prefix:nonexistent_
+EOF
+
+    run bash -c "
+        source /source/script/docker/setup.sh
+        detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
+        main --base-path '${_proj}'
+    "
+    assert_success
+    assert_line --partial "WARNING"
+    run grep 'IMAGE_NAME=unknown' "${_proj}/.env"
     assert_success
 }
 


### PR DESCRIPTION
## Summary
- Remove stale \`get_param.sh\` comments (historical, no longer relevant)
- Update setup.sh header to reflect image_name.conf rule engine
- Rename misleading test name (env_example fallback)
- Add WARNING-path test (custom conf without basename rule)

## Test plan
- [x] 150 tests, 100% coverage (1 new test for WARNING path)

Generated with Claude Code