### PR TITLE
feat: image_name.conf keywords use @ prefix

### DIFF
--- a/config/image_name.conf
+++ b/config/image_name.conf
@@ -10,18 +10,19 @@
 #   suffix:<value>   Scan path components for any ending with <value>, strip <value>
 #                    e.g. "suffix:_ws" → "/home/ros_noetic_ws/src" → "ros_noetic"
 #
-#   env_example      Read IMAGE_NAME from .env.example in repo root
+#   @env_example     Read IMAGE_NAME from .env.example in repo root
 #                    e.g. ".env.example" with "IMAGE_NAME=my_app" → "my_app"
 #
-#   basename         Use the dirname as-is (final fallback)
+#   @basename        Use the dirname as-is (final fallback)
 #                    e.g. "/home/yunchien/ros_noetic" → "ros_noetic"
 #
+# Special keywords are prefixed with @ to distinguish from user-defined values.
 # Lines starting with # and empty lines are ignored.
 #
 # To override per-repo: copy this file to repo root and edit.
 #   ./template/init.sh --gen-image-conf
 
+@env_example
 prefix:docker_
 suffix:_ws
-env_example
-basename
+@basename

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -19,8 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `detect_image_name`: refactored to read rules from `image_name.conf` instead
-  of hardcoded logic. Default conf includes `basename` so most repos work
+  of hardcoded logic. Default conf includes `@basename` so most repos work
   without `.env.example`.
+- **BREAKING**: `image_name.conf` keywords now require `@` prefix
+  (`env_example` → `@env_example`, `basename` → `@basename`) to distinguish
+  from user-defined values
+- Default conf moved `@env_example` to first position so `.env.example`
+  takes highest priority
 
 ### Fixed
 - `stop.sh`: remove orphan container left by `docker compose run --name`

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -228,9 +228,9 @@ detect_image_name() {
       elif [[ "${_line}" == suffix:* ]]; then
         _value="${_line#suffix:}"
         _found="$(_rule_suffix "${_path}" "${_value}")"
-      elif [[ "${_line}" == "env_example" ]]; then
+      elif [[ "${_line}" == "@env_example" ]]; then
         _found="$(BASE_PATH="${BASE_PATH:-${_path}}" _rule_env_example "${_path}")"
-      elif [[ "${_line}" == "basename" ]]; then
+      elif [[ "${_line}" == "@basename" ]]; then
         _found="$(_rule_basename "${_path}")"
       fi
 

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -174,7 +174,7 @@ esac'
     local _conf="${TEMP_DIR}/image_name.conf"
     cat > "${_conf}" <<EOF
 prefix:foo_
-basename
+@basename
 EOF
     local _result
     IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_myapp"
@@ -184,7 +184,7 @@ EOF
 @test "detect_image_name auto-discovers image_name.conf via BASE_PATH" {
     cat > "${TEMP_DIR}/image_name.conf" <<EOF
 prefix:bar_
-basename
+@basename
 EOF
     local _result
     BASE_PATH="${TEMP_DIR}" detect_image_name _result "/home/user/bar_myapp"
@@ -195,8 +195,8 @@ EOF
     local _conf="${TEMP_DIR}/image_name.conf"
     local _example="${TEMP_DIR}/.env.example"
     cat > "${_conf}" <<EOF
-env_example
-basename
+@env_example
+@basename
 EOF
     echo "IMAGE_NAME=from_example" > "${_example}"
     local _result
@@ -210,7 +210,7 @@ EOF
     cat > "${_conf}" <<EOF
 prefix:docker_
 suffix:_ws
-basename
+@basename
 EOF
     local _result
     # path has both docker_ and _ws — prefix wins
@@ -225,7 +225,7 @@ EOF
 prefix:foo_
 
 # Another comment
-basename
+@basename
 EOF
     local _result
     IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_myapp"
@@ -234,7 +234,7 @@ EOF
 
 @test "detect_image_name skips whitespace-only lines in conf" {
     local _conf="${TEMP_DIR}/image_name.conf"
-    printf 'prefix:foo_\n   \n\t\nbasename\n' > "${_conf}"
+    printf 'prefix:foo_\n   \n\t\n@basename\n' > "${_conf}"
     local _result
     IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_myapp"
     assert_equal "${_result}" "myapp"


### PR DESCRIPTION
## Summary
- \`env_example\` → \`@env_example\`
- \`basename\` → \`@basename\`
- Default conf reorders: \`@env_example\` first, \`@basename\` last
- \`.env.example\` now highest priority

## BREAKING
Per-repo \`image_name.conf\` overrides must update keywords. No repo currently has override, so impact is zero.

## Test plan
- [x] 150 tests, 100% coverage

Generated with Claude Code