### PR TITLE
refactor: remove `@basename` from default conf

### DIFF
--- a/config/image_name.conf
+++ b/config/image_name.conf
@@ -2,6 +2,7 @@
 #
 # IMAGE_NAME detection rules for setup.sh.
 # Rules are applied in order. First match wins.
+# If no rule matches, IMAGE_NAME is set to "unknown" with a WARNING.
 #
 # Available rule types:
 #   prefix:<value>   Match dirname starting with <value>, strip <value>
@@ -13,7 +14,8 @@
 #   @env_example     Read IMAGE_NAME from .env.example in repo root
 #                    e.g. ".env.example" with "IMAGE_NAME=my_app" → "my_app"
 #
-#   @basename        Use the dirname as-is (final fallback)
+#   @basename        Use the dirname as-is (last-resort fallback; not enabled
+#                    by default to avoid matching generic names like "docker")
 #                    e.g. "/home/yunchien/ros_noetic" → "ros_noetic"
 #
 # Special keywords are prefixed with @ to distinguish from user-defined values.
@@ -25,4 +27,3 @@
 @env_example
 prefix:docker_
 suffix:_ws
-@basename

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -19,13 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `detect_image_name`: refactored to read rules from `image_name.conf` instead
-  of hardcoded logic. Default conf includes `@basename` so most repos work
-  without `.env.example`.
+  of hardcoded logic
 - **BREAKING**: `image_name.conf` keywords now require `@` prefix
   (`env_example` → `@env_example`, `basename` → `@basename`) to distinguish
   from user-defined values
-- Default conf moved `@env_example` to first position so `.env.example`
-  takes highest priority
+- Default conf order: `@env_example` → `prefix:docker_` → `suffix:_ws`
+  (`.env.example` highest priority; no `@basename` to avoid matching
+  generic dir names like `docker`. WARNING + `unknown` if no rule matches.)
 
 ### Fixed
 - `stop.sh`: remove orphan container left by `docker compose run --name`

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -22,8 +22,8 @@ Template self-tests: **150 tests** total.
 | `detect_image_name prefers docker_* over *_ws in path` | Priority check |
 | `detect_image_name strips docker_ prefix from last dir` | Prefix stripping |
 | `detect_image_name strips docker_ from absolute root` | Root path |
-| `detect_image_name uses basename for plain directory (default conf)` | basename rule |
-| `detect_image_name uses basename for generic path (default conf)` | basename rule |
+| `detect_image_name returns unknown for plain directory (default conf)` | Unknown fallback |
+| `detect_image_name returns unknown for generic path (default conf)` | Unknown fallback |
 | `detect_image_name lowercases the result` | Lowercase |
 | `detect_image_name uses repo-level image_name.conf when present` | Per-repo override (env var) |
 | `detect_image_name auto-discovers image_name.conf via BASE_PATH` | Per-repo auto-discover |
@@ -44,7 +44,7 @@ Template self-tests: **150 tests** total.
 | `main re-detects WS_PATH when path in .env no longer exists` | Stale WS_PATH |
 | `main: env_example rule reads IMAGE_NAME from .env.example` | env_example rule via main |
 | `main warns when conf has no fallback and detection fails` | WARNING when no rule matches |
-| `main uses basename for repo without docker_/_ws naming` | basename fallback |
+| `main warns and uses unknown for repo without docker_/_ws naming` | WARNING + unknown |
 | `main uses BASH_SOURCE fallback when --base-path not given` | Fallback path |
 | `default _base_path resolves to repo root, not script dir` | Regression test |
 | `main returns error on unknown argument` | Error handling |

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -148,16 +148,17 @@ esac'
     assert_equal "${_result}" "project"
 }
 
-@test "detect_image_name uses basename for plain directory (default conf)" {
+@test "detect_image_name returns unknown for plain directory (default conf)" {
+    # default conf only has @env_example/prefix:docker_/suffix:_ws (no @basename)
     local _result
     detect_image_name _result "/home/user/projects/ros_noetic"
-    assert_equal "${_result}" "ros_noetic"
+    assert_equal "${_result}" "unknown"
 }
 
-@test "detect_image_name uses basename for generic path (default conf)" {
+@test "detect_image_name returns unknown for generic path (default conf)" {
     local _result
     detect_image_name _result "/home/user/myproject"
-    assert_equal "${_result}" "myproject"
+    assert_equal "${_result}" "unknown"
 }
 
 @test "detect_image_name lowercases the result" {
@@ -417,7 +418,7 @@ EOF
     assert_success
 }
 
-@test "main uses basename for repo without docker_/_ws naming" {
+@test "main warns and uses unknown for repo without docker_/_ws naming" {
     local _ws="${TEMP_DIR}/test_ws"
     local _proj="${TEMP_DIR}/my_generic_project"
     mkdir -p "${_ws}" "${_proj}"
@@ -428,7 +429,8 @@ EOF
         main --base-path '${_proj}'
     "
     assert_success
-    run grep 'IMAGE_NAME=my_generic_project' "${_proj}/.env"
+    assert_line --partial "WARNING"
+    run grep 'IMAGE_NAME=unknown' "${_proj}/.env"
     assert_success
 }
 


### PR DESCRIPTION
## Summary
- Default conf no longer includes \`@basename\`
- Avoids matching generic dir names like \`docker\` (which is the typical clone target)
- Default order: \`@env_example\` → \`prefix:docker_\` → \`suffix:_ws\`
- No match → WARNING + \`unknown\`

## Test plan
- [x] 150 tests, 100% coverage

Generated with Claude Code