### PR TITLE
feat: `@default:<value>` keyword for explicit fallback

### DIFF
--- a/config/image_name.conf
+++ b/config/image_name.conf
@@ -18,6 +18,10 @@
 #                    by default to avoid matching generic names like "docker")
 #                    e.g. "/home/yunchien/ros_noetic" → "ros_noetic"
 #
+#   @default:<value> Use <value> as final fallback if no other rule matches.
+#                    Prints an INFO log so users know to set IMAGE_NAME explicitly.
+#                    e.g. "@default:unknown" → "unknown"
+#
 # Special keywords are prefixed with @ to distinguish from user-defined values.
 # Lines starting with # and empty lines are ignored.
 #
@@ -27,3 +31,4 @@
 @env_example
 prefix:docker_
 suffix:_ws
+@default:unknown

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `build.sh`: `--no-cache` flag for force rebuild (passes to both
   test-tools image build and docker compose build)
 - `config/image_name.conf`: rule-driven IMAGE_NAME detection
-  - Rule types: `prefix:`, `suffix:`, `env_example`, `basename`
+  - Rule types: `prefix:<value>`, `suffix:<value>`, `@env_example`, `@basename`, `@default:<value>`
   - Per-repo override: place `image_name.conf` in repo root
-  - Default rules: `prefix:docker_` → `suffix:_ws` → `env_example` → `basename`
+  - Default rules: `@env_example` → `prefix:docker_` → `suffix:_ws` → `@default:unknown`
 - `init.sh --gen-image-conf`: copy template's image_name.conf to repo root
   for per-repo customization
 
@@ -23,9 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: `image_name.conf` keywords now require `@` prefix
   (`env_example` → `@env_example`, `basename` → `@basename`) to distinguish
   from user-defined values
-- Default conf order: `@env_example` → `prefix:docker_` → `suffix:_ws`
-  (`.env.example` highest priority; no `@basename` to avoid matching
-  generic dir names like `docker`. WARNING + `unknown` if no rule matches.)
+- Default conf order: `@env_example` → `prefix:docker_` → `suffix:_ws` → `@default:unknown`
+  (`.env.example` highest priority; `@default:unknown` as final fallback
+  prints INFO log so users know to set IMAGE_NAME explicitly)
+- New `@default:<value>` keyword: explicit fallback value with INFO log
+- WARNING only when no rule matches AND no `@default:` set (custom conf scenario)
 
 ### Fixed
 - `stop.sh`: remove orphan container left by `docker compose run --name`

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **150 tests** total.
+Template self-tests: **153 tests** total.
 
 ## Test Files
 
-### test/unit/setup_spec.bats (55)
+### test/unit/setup_spec.bats (58)
 
 | Test | Description |
 |------|-------------|
@@ -32,6 +32,9 @@ Template self-tests: **150 tests** total.
 | `detect_image_name skips comments and empty lines in conf` | Conf parsing |
 | `detect_image_name skips whitespace-only lines in conf` | Conf parsing |
 | `detect_image_name returns unknown when no rule matches and no basename` | Unknown fallback |
+| `detect_image_name uses @basename when no other rule matches` | @basename rule |
+| `detect_image_name applies @default:<value> as fallback` | @default rule |
+| `detect_image_name @default:<value> is skipped if earlier rule matches` | @default skip |
 | `detect_ws_path strategy 1: docker_* finds sibling *_ws` | Sibling scan |
 | `detect_ws_path strategy 1: docker_* without sibling falls through` | No sibling |
 | `detect_ws_path strategy 2: finds _ws component in path` | Path traversal |
@@ -44,7 +47,7 @@ Template self-tests: **150 tests** total.
 | `main re-detects WS_PATH when path in .env no longer exists` | Stale WS_PATH |
 | `main: env_example rule reads IMAGE_NAME from .env.example` | env_example rule via main |
 | `main warns when conf has no fallback and detection fails` | WARNING when no rule matches |
-| `main warns and uses unknown for repo without docker_/_ws naming` | WARNING + unknown |
+| `main: default conf @default:unknown applies for repo without docker_/_ws naming` | @default:unknown INFO |
 | `main uses BASH_SOURCE fallback when --base-path not given` | Fallback path |
 | `default _base_path resolves to repo root, not script dir` | Regression test |
 | `main returns error on unknown argument` | Error handling |

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -232,14 +232,20 @@ detect_image_name() {
         _found="$(BASE_PATH="${BASE_PATH:-${_path}}" _rule_env_example "${_path}")"
       elif [[ "${_line}" == "@basename" ]]; then
         _found="$(_rule_basename "${_path}")"
+      elif [[ "${_line}" == @default:* ]]; then
+        _found="${_line#@default:}"
+        printf "[setup] INFO: IMAGE_NAME using @default:%s\n" "${_found}" >&2
       fi
 
       [[ -n "${_found}" ]] && break
     done < "${_conf}"  # LCOV_EXCL_LINE
   fi
 
-  _outvar="${_found:-unknown}"
-  _outvar="${_outvar,,}"
+  if [[ -z "${_found}" ]]; then
+    printf "[setup] WARNING: IMAGE_NAME could not be detected. Using 'unknown'.\n" >&2
+    _found="unknown"
+  fi
+  _outvar="${_found,,}"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -382,10 +388,6 @@ main() {
   detect_docker_hub_user docker_hub_user
   detect_gpu             gpu_enabled
   BASE_PATH="${_base_path}" detect_image_name image_name "${_base_path}"
-
-  if [[ "${image_name}" == "unknown" ]]; then
-    printf "[setup] WARNING: IMAGE_NAME could not be detected. Using 'unknown'.\n" >&2
-  fi
 
   if [[ -z "${ws_path}" ]] || [[ ! -d "${ws_path}" ]]; then
     detect_ws_path ws_path "${_base_path}"

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -251,6 +251,39 @@ EOF
     assert_equal "${_result}" "unknown"
 }
 
+@test "detect_image_name uses @basename when no other rule matches" {
+    local _conf="${TEMP_DIR}/image_name.conf"
+    cat > "${_conf}" <<EOF
+prefix:nonexistent_
+@basename
+EOF
+    local _result
+    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/myapp"
+    assert_equal "${_result}" "myapp"
+}
+
+@test "detect_image_name applies @default:<value> as fallback" {
+    local _conf="${TEMP_DIR}/image_name.conf"
+    cat > "${_conf}" <<EOF
+prefix:nonexistent_
+@default:my_repo
+EOF
+    local _result
+    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/myapp"
+    assert_equal "${_result}" "my_repo"
+}
+
+@test "detect_image_name @default:<value> is skipped if earlier rule matches" {
+    local _conf="${TEMP_DIR}/image_name.conf"
+    cat > "${_conf}" <<EOF
+prefix:foo_
+@default:my_repo
+EOF
+    local _result
+    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_realname"
+    assert_equal "${_result}" "realname"
+}
+
 # ════════════════════════════════════════════════════════════════════
 # detect_ws_path
 # ════════════════════════════════════════════════════════════════════
@@ -418,7 +451,7 @@ EOF
     assert_success
 }
 
-@test "main warns and uses unknown for repo without docker_/_ws naming" {
+@test "main: default conf @default:unknown applies for repo without docker_/_ws naming" {
     local _ws="${TEMP_DIR}/test_ws"
     local _proj="${TEMP_DIR}/my_generic_project"
     mkdir -p "${_ws}" "${_proj}"
@@ -429,7 +462,8 @@ EOF
         main --base-path '${_proj}'
     "
     assert_success
-    assert_line --partial "WARNING"
+    assert_line --partial "INFO"
+    assert_line --partial "@default"
     run grep 'IMAGE_NAME=unknown' "${_proj}/.env"
     assert_success
 }

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -124,19 +124,19 @@ COMMIT
 
 _usage() {
   cat >&2 <<'EOF'
-Usage: ./template/script/upgrade.sh [VERSION|--check]
+Usage: ./template/upgrade.sh [VERSION|--check]
 
 Upgrade template subtree to the latest (or specified) version.
 
 Arguments:
-  VERSION       Target version (e.g. v0.3.0). Defaults to latest tag.
+  VERSION       Target version (e.g. v0.5.0). Defaults to latest tag.
   --check       Check if an update is available (no changes made)
   -h, --help    Show this help
 
 Examples:
-  ./template/script/upgrade.sh              # upgrade to latest
-  ./template/script/upgrade.sh v0.3.0       # upgrade to specific version
-  ./template/script/upgrade.sh --check      # check only
+  ./template/upgrade.sh              # upgrade to latest
+  ./template/upgrade.sh v0.5.0       # upgrade to specific version
+  ./template/upgrade.sh --check      # check only
 EOF
   exit 0
 }


### PR DESCRIPTION
## Summary
- New \`@default:<value>\` keyword in image_name.conf
- Prints INFO log when fallback is used (e.g. \`@default:unknown\`)
- Default conf: \`@env_example\` → \`prefix:docker_\` → \`suffix:_ws\` → \`@default:unknown\`
- WARNING only when custom conf has no fallback and detection fails
- Fix \`upgrade.sh\` stale usage text
- Sync CHANGELOG \`[Unreleased]\` with current keyword format

## Test plan
- [x] 153 tests, 100% coverage (3 new tests for @default + @basename)
- [x] TEST.md aligned (153 rows = 153 tests)

Generated with Claude Code