### PR TITLE
fix: self-test.yaml release archive uses new directory structure

### DIFF
--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -42,9 +42,9 @@ jobs:
           ARCHIVE_NAME="template-${VERSION}"
 
           mkdir -p "${ARCHIVE_NAME}"
-          cp -r build.sh run.sh exec.sh stop.sh \
-                .hadolint.yaml Makefile Makefile.ci compose.yaml \
-                config/ test/ script/ doc/ \
+          cp -r init.sh upgrade.sh \
+                .hadolint.yaml Makefile.ci compose.yaml \
+                config/ dockerfile/ test/ script/ doc/ \
                 README.md LICENSE \
                 "${ARCHIVE_NAME}/"
 


### PR DESCRIPTION
Fixes release CI failure for v0.6.0-rc1.

Generated with Claude Code