### PR TITLE
feat: build.sh keeps test-tools image by default + --clean-tools flag

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `build.sh`: `--clean-tools` flag to remove `test-tools:local` image after build
+
+### Changed
+- `build.sh`: keep `test-tools:local` image by default (was removed on EXIT)
+  - Avoids race conditions in parallel builds
+  - Subsequent builds skip the test-tools build (Docker layer cache)
+  - Use `--clean-tools` to restore old behavior
+
 ## [v0.6.0] - 2026-04-01
 
 ### Added

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **153 tests** total.
+Template self-tests: **156 tests** total.
 
 ## Test Files
 
@@ -67,7 +67,7 @@ Template self-tests: **153 tests** total.
 | `main --lang zh sets Chinese messages` | --lang flag |
 | `main --lang requires a value` | Missing --lang value |
 
-### test/unit/template_spec.bats (41)
+### test/unit/template_spec.bats (44)
 
 | Test | Description |
 |------|-------------|
@@ -95,6 +95,9 @@ Template self-tests: **153 tests** total.
 | `build.sh uses set -euo pipefail` | Shell convention |
 | `build.sh supports --no-cache flag` | Force rebuild flag |
 | `build.sh passes --no-cache to docker compose build when set` | NO_CACHE forwarded |
+| `build.sh keeps test-tools image by default (cleanup gated by CLEAN_TOOLS)` | Default keep tools |
+| `build.sh supports --clean-tools flag` | Clean tools flag |
+| `build.sh removes test-tools image when --clean-tools is set` | CLEAN_TOOLS forwarded |
 | `run.sh uses set -euo pipefail` | Shell convention |
 | `exec.sh uses set -euo pipefail` | Shell convention |
 | `stop.sh uses set -euo pipefail` | Shell convention |

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -17,12 +17,13 @@ usage() {
   case "${_LANG}" in
     zh)
       cat >&2 <<'EOF'
-用法: ./build.sh [-h] [--no-env] [--no-cache] [--lang <en|zh|zh-CN|ja>] [TARGET]
+用法: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 選項:
   -h, --help     顯示此說明
   --no-env       跳過 .env 重新產生
   --no-cache     強制不使用 cache 重建
+  --clean-tools  build 結束後移除 test-tools:local image（預設保留以加速下次 build）
   --lang LANG    設定訊息語言（預設: en）
 
 目標:
@@ -33,12 +34,13 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./build.sh [-h] [--no-env] [--no-cache] [--lang <en|zh|zh-CN|ja>] [TARGET]
+用法: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 选项:
   -h, --help     显示此说明
   --no-env       跳过 .env 重新生成
   --no-cache     强制不使用 cache 重建
+  --clean-tools  build 结束后移除 test-tools:local image（默认保留以加速下次 build）
   --lang LANG    设置消息语言（默认: en）
 
 目标:
@@ -49,12 +51,13 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./build.sh [-h] [--no-env] [--no-cache] [--lang <en|zh|zh-CN|ja>] [TARGET]
+使用法: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 オプション:
   -h, --help     このヘルプを表示
   --no-env       .env の再生成をスキップ
   --no-cache     キャッシュを使わず強制リビルド
+  --clean-tools  build 終了後に test-tools:local image を削除（デフォルトは保持）
   --lang LANG    メッセージ言語を設定（デフォルト: en）
 
 ターゲット:
@@ -65,12 +68,13 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./build.sh [-h] [--no-env] [--no-cache] [--lang <en|zh|zh-CN|ja>] [TARGET]
+Usage: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 Options:
   -h, --help     Show this help
   --no-env       Skip .env regeneration
   --no-cache     Force rebuild without cache
+  --clean-tools  Remove test-tools:local image after build (default: keep for faster next build)
   --lang LANG    Set message language (default: en)
 
 Targets:
@@ -85,6 +89,7 @@ EOF
 
 SKIP_ENV=false
 NO_CACHE=false
+CLEAN_TOOLS=false
 TARGET="devel"
 
 while [[ $# -gt 0 ]]; do
@@ -98,6 +103,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-cache)
       NO_CACHE=true
+      shift
+      ;;
+    --clean-tools)
+      CLEAN_TOOLS=true
       shift
       ;;
     --lang)
@@ -130,8 +139,10 @@ if [[ -f "${_tools_dockerfile}" ]]; then
   docker build "${_tools_args[@]}" -t test-tools:local -f "${_tools_dockerfile}" "${FILE_PATH}" -q >/dev/null
 fi
 
-_cleanup() { docker rmi test-tools:local 2>/dev/null || true; }
-trap _cleanup EXIT
+if [[ "${CLEAN_TOOLS}" == true ]]; then
+  _cleanup() { docker rmi test-tools:local 2>/dev/null || true; }
+  trap _cleanup EXIT
+fi
 
 _compose_args=()
 [[ "${NO_CACHE}" == true ]] && _compose_args+=(--no-cache)

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -139,6 +139,23 @@ setup() {
     assert_success
 }
 
+@test "build.sh keeps test-tools image by default (cleanup gated by CLEAN_TOOLS)" {
+    # Default behavior: do NOT auto-remove test-tools:local
+    # cleanup must be conditional on CLEAN_TOOLS
+    run grep -E 'CLEAN_TOOLS.*==.*true' /source/script/docker/build.sh
+    assert_success
+}
+
+@test "build.sh supports --clean-tools flag" {
+    run grep -E '\-\-clean-tools' /source/script/docker/build.sh
+    assert_success
+}
+
+@test "build.sh removes test-tools image when --clean-tools is set" {
+    run grep -E 'CLEAN_TOOLS.*=.*true' /source/script/docker/build.sh
+    assert_success
+}
+
 @test "run.sh uses set -euo pipefail" {
     run grep "set -euo pipefail" /source/script/docker/run.sh
     assert_success


### PR DESCRIPTION
## Summary
- Default: keep \`test-tools:local\` image after build (avoids race + speeds up subsequent builds)
- New \`--clean-tools\` flag: remove image on EXIT (old behavior)
- Documented in usage (4 languages)

## Test plan
- [x] 156 tests, 100% coverage (3 new tests)

Generated with Claude Code