### PR TITLE
refactor: extract i18n helpers to shared script/docker/i18n.sh

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `build.sh`: `--clean-tools` flag to remove `test-tools:local` image after build
+- `script/docker/i18n.sh`: shared `_detect_lang()` and `_LANG` initialization
+  - Sourced by build.sh, run.sh, exec.sh, stop.sh, setup.sh
+  - Eliminates ~28 lines of duplication across 5 scripts
+  - Adding a new language now requires editing only one file
 
 ### Changed
 - `build.sh`: keep `test-tools:local` image by default (was removed on EXIT)

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **156 tests** total.
+Template self-tests: **168 tests** total.
 
 ## Test Files
 
@@ -67,7 +67,7 @@ Template self-tests: **156 tests** total.
 | `main --lang zh sets Chinese messages` | --lang flag |
 | `main --lang requires a value` | Missing --lang value |
 
-### test/unit/template_spec.bats (44)
+### test/unit/template_spec.bats (56)
 
 | Test | Description |
 |------|-------------|
@@ -108,6 +108,18 @@ Template self-tests: **156 tests** total.
 | `exec.sh sources .env` | Env loading |
 | `stop.sh sources .env` | Env loading |
 | `stop.sh removes orphan run-mode container by name` | docker rm fallback |
+| `script/docker/i18n.sh exists` | i18n module exists |
+| `i18n.sh defines _detect_lang function` | _detect_lang in i18n.sh |
+| `build.sh sources i18n.sh` | build.sh uses shared i18n |
+| `run.sh sources i18n.sh` | run.sh uses shared i18n |
+| `exec.sh sources i18n.sh` | exec.sh uses shared i18n |
+| `stop.sh sources i18n.sh` | stop.sh uses shared i18n |
+| `setup.sh sources i18n.sh` | setup.sh uses shared i18n |
+| `build.sh does not redefine _detect_lang` | No duplication |
+| `run.sh does not redefine _detect_lang` | No duplication |
+| `exec.sh does not redefine _detect_lang` | No duplication |
+| `stop.sh does not redefine _detect_lang` | No duplication |
+| `setup.sh does not redefine _detect_lang` | No duplication |
 | `upgrade.sh runs init.sh after subtree pull` | Sync symlinks |
 | `upgrade.sh writes target_ver after init.sh (to override init's latest detection)` | Version override |
 | `run.sh contains XDG_SESSION_TYPE check` | X11/Wayland branch |

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -5,13 +5,8 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
-_detect_lang() {
-  local _sys_lang="${LANG:-}"
-  case "${_sys_lang}" in
-    zh_TW*) echo "zh" ;; zh_CN*|zh_SG*) echo "zh-CN" ;; ja*) echo "ja" ;; *) echo "en" ;;
-  esac
-}
-_LANG="${SETUP_LANG:-$(_detect_lang)}"
+# shellcheck disable=SC1091
+source "${FILE_PATH}/template/script/docker/i18n.sh"
 
 usage() {
   case "${_LANG}" in

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -5,13 +5,8 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
-_detect_lang() {
-  local _sys_lang="${LANG:-}"
-  case "${_sys_lang}" in
-    zh_TW*) echo "zh" ;; zh_CN*|zh_SG*) echo "zh-CN" ;; ja*) echo "ja" ;; *) echo "en" ;;
-  esac
-}
-_LANG="${SETUP_LANG:-$(_detect_lang)}"
+# shellcheck disable=SC1091
+source "${FILE_PATH}/template/script/docker/i18n.sh"
 
 usage() {
   case "${_LANG}" in

--- a/script/docker/i18n.sh
+++ b/script/docker/i18n.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# i18n.sh - Shared i18n helpers for Docker scripts
+#
+# Sourced by: build.sh, run.sh, exec.sh, stop.sh, setup.sh
+#
+# Provides:
+#   _detect_lang   — detect language from $LANG env var
+#                    output: "zh" | "zh-CN" | "ja" | "en"
+#
+# After sourcing, _LANG is set (caller can override via SETUP_LANG env var).
+
+_detect_lang() {
+  local _sys_lang="${LANG:-}"
+  case "${_sys_lang}" in
+    zh_TW*) echo "zh" ;;
+    zh_CN*|zh_SG*) echo "zh-CN" ;;
+    ja*) echo "ja" ;;
+    *) echo "en" ;;
+  esac
+}
+
+_LANG="${SETUP_LANG:-$(_detect_lang)}"

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -5,13 +5,8 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
-_detect_lang() {
-  local _sys_lang="${LANG:-}"
-  case "${_sys_lang}" in
-    zh_TW*) echo "zh" ;; zh_CN*|zh_SG*) echo "zh-CN" ;; ja*) echo "ja" ;; *) echo "en" ;;
-  esac
-}
-_LANG="${SETUP_LANG:-$(_detect_lang)}"
+# shellcheck disable=SC1091
+source "${FILE_PATH}/template/script/docker/i18n.sh"
 
 usage() {
   case "${_LANG}" in

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -14,16 +14,8 @@
 # Usage: setup.sh [--base-path <path>] [--lang zh|zh-CN|ja]
 
 # ── i18n messages ──────────────────────────────────────────────
-_detect_lang() {
-  local _sys_lang="${LANG:-}"
-  case "${_sys_lang}" in
-    zh_TW*) echo "zh" ;;
-    zh_CN*|zh_SG*) echo "zh-CN" ;;
-    ja*) echo "ja" ;;
-    *) echo "en" ;;
-  esac
-}
-_LANG="${SETUP_LANG:-$(_detect_lang)}"
+# shellcheck disable=SC1091
+source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/i18n.sh"
 
 _msg() {
   local _key="${1}"

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -5,13 +5,8 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
-_detect_lang() {
-  local _sys_lang="${LANG:-}"
-  case "${_sys_lang}" in
-    zh_TW*) echo "zh" ;; zh_CN*|zh_SG*) echo "zh-CN" ;; ja*) echo "ja" ;; *) echo "en" ;;
-  esac
-}
-_LANG="${SETUP_LANG:-$(_detect_lang)}"
+# shellcheck disable=SC1091
+source "${FILE_PATH}/template/script/docker/i18n.sh"
 
 usage() {
   case "${_LANG}" in

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -482,6 +482,7 @@ EOF
     local _repo_root="${TEMP_DIR}/docker_myapp"
     mkdir -p "${_repo_root}/template/script/docker" "${_repo_root}/template/config"
     cp /source/script/docker/setup.sh "${_repo_root}/template/script/docker/setup.sh"
+    cp /source/script/docker/i18n.sh "${_repo_root}/template/script/docker/i18n.sh"
     cp /source/config/image_name.conf "${_repo_root}/template/config/image_name.conf"
 
     # Create a dummy ws for detect_ws_path

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -211,6 +211,69 @@ setup() {
 }
 
 # ════════════════════════════════════════════════════════════════════
+# i18n.sh shared module
+# ════════════════════════════════════════════════════════════════════
+
+@test "script/docker/i18n.sh exists" {
+    assert [ -f /source/script/docker/i18n.sh ]
+}
+
+@test "i18n.sh defines _detect_lang function" {
+    run grep -E '^_detect_lang\(\)' /source/script/docker/i18n.sh
+    assert_success
+}
+
+@test "build.sh sources i18n.sh" {
+    run grep -E 'source.*i18n\.sh' /source/script/docker/build.sh
+    assert_success
+}
+
+@test "run.sh sources i18n.sh" {
+    run grep -E 'source.*i18n\.sh' /source/script/docker/run.sh
+    assert_success
+}
+
+@test "exec.sh sources i18n.sh" {
+    run grep -E 'source.*i18n\.sh' /source/script/docker/exec.sh
+    assert_success
+}
+
+@test "stop.sh sources i18n.sh" {
+    run grep -E 'source.*i18n\.sh' /source/script/docker/stop.sh
+    assert_success
+}
+
+@test "setup.sh sources i18n.sh" {
+    run grep -E 'source.*i18n\.sh' /source/script/docker/setup.sh
+    assert_success
+}
+
+@test "build.sh does not redefine _detect_lang" {
+    run grep -cE '^_detect_lang\(\)' /source/script/docker/build.sh
+    assert_output "0"
+}
+
+@test "run.sh does not redefine _detect_lang" {
+    run grep -cE '^_detect_lang\(\)' /source/script/docker/run.sh
+    assert_output "0"
+}
+
+@test "exec.sh does not redefine _detect_lang" {
+    run grep -cE '^_detect_lang\(\)' /source/script/docker/exec.sh
+    assert_output "0"
+}
+
+@test "stop.sh does not redefine _detect_lang" {
+    run grep -cE '^_detect_lang\(\)' /source/script/docker/stop.sh
+    assert_output "0"
+}
+
+@test "setup.sh does not redefine _detect_lang" {
+    run grep -cE '^_detect_lang\(\)' /source/script/docker/setup.sh
+    assert_output "0"
+}
+
+# ════════════════════════════════════════════════════════════════════
 # upgrade.sh
 # ════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
- New \`script/docker/i18n.sh\` shared module
- 5 scripts now source it instead of redefining \`_detect_lang()\`
- ~28 lines of duplication removed
- Adding new languages now requires editing only one file

## Test plan
- [x] 168 tests, 100% coverage (12 new tests)

Generated with Claude Code