### PR TITLE
feat: include bats-mock in Dockerfile.test-tools

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Sourced by build.sh, run.sh, exec.sh, stop.sh, setup.sh
   - Eliminates ~28 lines of duplication across 5 scripts
   - Adding a new language now requires editing only one file
+- `dockerfile/Dockerfile.test-tools`: include `bats-mock` (jasonkarns v1.2.5)
+  - Other repos' smoke tests can now use `stub`/`unstub` for command mocking
 
 ### Changed
 - `build.sh`: keep `test-tools:local` image by default (was removed on EXIT)

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **168 tests** total.
+Template self-tests: **169 tests** total.
 
 ## Test Files
 
@@ -67,7 +67,7 @@ Template self-tests: **168 tests** total.
 | `main --lang zh sets Chinese messages` | --lang flag |
 | `main --lang requires a value` | Missing --lang value |
 
-### test/unit/template_spec.bats (56)
+### test/unit/template_spec.bats (57)
 
 | Test | Description |
 |------|-------------|
@@ -109,6 +109,7 @@ Template self-tests: **168 tests** total.
 | `stop.sh sources .env` | Env loading |
 | `stop.sh removes orphan run-mode container by name` | docker rm fallback |
 | `script/docker/i18n.sh exists` | i18n module exists |
+| `Dockerfile.test-tools includes bats-mock` | bats-mock available in test image |
 | `i18n.sh defines _detect_lang function` | _detect_lang in i18n.sh |
 | `build.sh sources i18n.sh` | build.sh uses shared i18n |
 | `run.sh sources i18n.sh` | run.sh uses shared i18n |

--- a/dockerfile/Dockerfile.test-tools
+++ b/dockerfile/Dockerfile.test-tools
@@ -1,6 +1,6 @@
 # Dockerfile.test-tools - Pre-built test tools for Docker container repos
 #
-# Contains: ShellCheck, Hadolint, Bats (with bats-support + bats-assert)
+# Contains: ShellCheck, Hadolint, Bats (with bats-support + bats-assert + bats-mock)
 #
 # Usage:
 #   docker build -t test-tools:local -f template/dockerfile/Dockerfile.test-tools .
@@ -14,7 +14,9 @@ RUN apk add --no-cache git && \
     git clone --depth 1 -b v0.3.0 \
         https://github.com/bats-core/bats-support /bats/bats-support && \
     git clone --depth 1 -b v2.1.0 \
-        https://github.com/bats-core/bats-assert  /bats/bats-assert
+        https://github.com/bats-core/bats-assert  /bats/bats-assert && \
+    git clone --depth 1 -b v1.2.5 \
+        https://github.com/jasonkarns/bats-mock   /bats/bats-mock
 
 FROM alpine:latest AS lint-tools
 RUN apk add --no-cache curl xz && \

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -218,6 +218,11 @@ setup() {
     assert [ -f /source/script/docker/i18n.sh ]
 }
 
+@test "Dockerfile.test-tools includes bats-mock" {
+    run grep 'bats-mock' /source/dockerfile/Dockerfile.test-tools
+    assert_success
+}
+
 @test "i18n.sh defines _detect_lang function" {
     run grep -E '^_detect_lang\(\)' /source/script/docker/i18n.sh
     assert_success


### PR DESCRIPTION
## Summary
- Add jasonkarns/bats-mock v1.2.5 to the bats-extensions stage
- Other repos can now use \`stub\`/\`unstub\` for command mocking in smoke tests

## Test plan
- [x] 169 tests, 100% coverage (1 new test)

Generated with Claude Code