### PR TITLE
docs: remove hardcoded test counts from README directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ template/
 │   │   ├── test_helper.bash
 │   │   ├── script_help.bats
 │   │   └── display_env.bats
-│   └── unit/                         # Template self-tests (137 tests)
+│   └── unit/                         # Template self-tests
 ├── Makefile.ci                       # Template CI entry (make test/lint/...)
 ├── compose.yaml                      # Docker CI runner
 ├── .hadolint.yaml                    # Shared Hadolint rules

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -248,7 +248,7 @@ template/
 │   │   ├── test_helper.bash
 │   │   ├── script_help.bats
 │   │   └── display_env.bats
-│   └── unit/                         # テンプレート自身のテスト（137 件）
+│   └── unit/                         # テンプレート自身のテスト
 ├── Makefile.ci                       # テンプレート CI エントリ（make test/lint/...）
 ├── compose.yaml                      # Docker CI ランナー
 ├── .hadolint.yaml                    # 共有 Hadolint ルール

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -248,7 +248,7 @@ template/
 │   │   ├── test_helper.bash
 │   │   ├── script_help.bats
 │   │   └── display_env.bats
-│   └── unit/                         # 模板自身测试（137 个）
+│   └── unit/                         # 模板自身测试
 ├── Makefile.ci                       # 模板 CI 入口（make test/lint/...）
 ├── compose.yaml                      # Docker CI 运行器
 ├── .hadolint.yaml                    # 共用 Hadolint 规则

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -248,7 +248,7 @@ template/
 │   │   ├── test_helper.bash
 │   │   ├── script_help.bats
 │   │   └── display_env.bats
-│   └── unit/                         # 模板自身測試（137 個）
+│   └── unit/                         # 模板自身測試
 ├── Makefile.ci                       # 模板 CI 入口（make test/lint/...）
 ├── compose.yaml                      # Docker CI 執行器
 ├── .hadolint.yaml                    # 共用 Hadolint 規則


### PR DESCRIPTION
TEST.md is the source of truth for test counts. README dir structure should not duplicate the number.

Generated with Claude Code