### PR TITLE
chore: prepare v0.6.1 release notes

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.6.1] - 2026-04-08
 
 ### Added
 - `build.sh`: `--clean-tools` flag to remove `test-tools:local` image after build
@@ -162,6 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dockerfile `CONFIG_SRC` path: `docker_setup_helper/src/config` → `template/config`
 - Shared smoke tests loaded via `COPY template/smoke_test/` in Dockerfile (not symlinks)
 
+[v0.6.1]: https://github.com/ycpss91255-docker/template/compare/v0.6.0...v0.6.1
 [v0.6.0]: https://github.com/ycpss91255-docker/template/compare/v0.5.0...v0.6.0
 [v0.5.0]: https://github.com/ycpss91255-docker/template/compare/v0.4.2...v0.5.0
 [v0.4.2]: https://github.com/ycpss91255-docker/template/compare/v0.4.1...v0.4.2


### PR DESCRIPTION
Convert [Unreleased] to [v0.6.1] and add comparison link.

Generated with Claude Code