### PR TITLE
chore: remove LCOV exclusion markers, expose real coverage (v0.6.2)

### DIFF
--- a/config/shell/terminator/setup.sh
+++ b/config/shell/terminator/setup.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
 # Only set strict mode when running directly
-# LCOV_EXCL_START
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
   set -x -eu -o pipefail
 fi
-# LCOV_EXCL_STOP
 
 check_deps() {
   local -r _deps=("terminator")
@@ -39,8 +37,6 @@ _entry_point() {
   fi
 }
 
-# LCOV_EXCL_START
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
   _entry_point "$@" || exit $?
 fi
-# LCOV_EXCL_STOP

--- a/config/shell/tmux/setup.sh
+++ b/config/shell/tmux/setup.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
 # Only set strict mode when running directly
-# LCOV_EXCL_START
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
   set -x -eu -o pipefail
 fi
-# LCOV_EXCL_STOP
 
 check_deps() {
   local -r _deps=("tmux" "git")
@@ -45,8 +43,6 @@ _entry_point() {
   fi
 }
 
-# LCOV_EXCL_START
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
   _entry_point "$@" || exit $?
 fi
-# LCOV_EXCL_STOP

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.2] - 2026-04-09
+
+### Changed
+- Remove all `# LCOV_EXCL_*` markers from shell scripts to expose real coverage
+  - Coverage now reflects actual instrumented lines (95.76% vs prior masked 100%)
+  - 2 new direct-run tests for `tmux/setup.sh` and `terminator/setup.sh` (171 total)
+  - Remaining 10 uncovered lines in `setup.sh` are kcov bash backend limitations
+    (case `;;` arms, `done` redirect close, child-bash guards)
+
 ## [v0.6.1] - 2026-04-08
 
 ### Added
@@ -162,6 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dockerfile `CONFIG_SRC` path: `docker_setup_helper/src/config` → `template/config`
 - Shared smoke tests loaded via `COPY template/smoke_test/` in Dockerfile (not symlinks)
 
+[v0.6.2]: https://github.com/ycpss91255-docker/template/compare/v0.6.1...v0.6.2
 [v0.6.1]: https://github.com/ycpss91255-docker/template/compare/v0.6.0...v0.6.1
 [v0.6.0]: https://github.com/ycpss91255-docker/template/compare/v0.5.0...v0.6.0
 [v0.5.0]: https://github.com/ycpss91255-docker/template/compare/v0.4.2...v0.5.0

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **169 tests** total.
+Template self-tests: **171 tests** total.
 
 ## Test Files
 
@@ -171,7 +171,7 @@ Template self-tests: **169 tests** total.
 | `layouts has Window type` | Window layout |
 | `layouts has Terminal type` | Terminal layout |
 
-### test/unit/terminator_setup_spec.bats (7)
+### test/unit/terminator_setup_spec.bats (8)
 
 | Test | Description |
 |------|-------------|
@@ -182,6 +182,7 @@ Template self-tests: **169 tests** total.
 | `main creates terminator config directory` | Config dir |
 | `main copies terminator config file` | Config copy |
 | `main calls chown with correct user and group` | Permissions |
+| `script runs entry_point when executed directly` | Direct-run guard |
 
 ### test/unit/tmux_conf_spec.bats (12)
 
@@ -200,7 +201,7 @@ Template self-tests: **169 tests** total.
 | `declares tpm plugin` | tpm plugin |
 | `initializes tpm at end of file` | tpm init |
 
-### test/unit/tmux_setup_spec.bats (8)
+### test/unit/tmux_setup_spec.bats (9)
 
 | Test | Description |
 |------|-------------|
@@ -212,3 +213,4 @@ Template self-tests: **169 tests** total.
 | `main clones tpm repository` | tpm clone |
 | `main creates tmux config directory` | Config dir |
 | `main copies tmux.conf to config directory` | Config copy |
+| `script runs entry_point when executed directly` | Direct-run guard |

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -25,34 +25,32 @@ _msg() {
         env_done)      echo ".env 更新完成" ;;
         env_comment)   echo "自動偵測欄位請勿手動修改，如需變更 WS_PATH 可直接編輯此檔案" ;;
         unknown_arg)   echo "未知參數" ;;
-      esac ;; # LCOV_EXCL_LINE
-    zh-CN) # LCOV_EXCL_LINE
+      esac ;;
+    zh-CN)
       case "${_key}" in
         env_done)      echo ".env 更新完成" ;;
         env_comment)   echo "自动检测字段请勿手动修改，如需变更 WS_PATH 可直接编辑此文件" ;;
         unknown_arg)   echo "未知参数" ;;
-      esac ;; # LCOV_EXCL_LINE
-    ja) # LCOV_EXCL_LINE
+      esac ;;
+    ja)
       case "${_key}" in
         env_done)      echo ".env 更新完了" ;;
         env_comment)   echo "自動検出フィールドは手動で編集しないでください。WS_PATH の変更はこのファイルを直接編集してください" ;;
         unknown_arg)   echo "不明な引数" ;;
-      esac ;; # LCOV_EXCL_LINE
-    *) # LCOV_EXCL_LINE
+      esac ;;
+    *)
       case "${_key}" in
         env_done)      echo ".env updated" ;;
         env_comment)   echo "Auto-detected fields, do not edit manually. Edit WS_PATH if needed" ;;
         unknown_arg)   echo "Unknown argument" ;;
-      esac ;; # LCOV_EXCL_LINE
+      esac ;;
   esac
 }
 
 # Only set strict mode when running directly; when sourced, respect caller's settings
-# LCOV_EXCL_START
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
   set -euo pipefail
 fi
-# LCOV_EXCL_STOP
 
 # ════════════════════════════════════════════════════════════════════
 # detect_user_info
@@ -230,7 +228,7 @@ detect_image_name() {
       fi
 
       [[ -n "${_found}" ]] && break
-    done < "${_conf}"  # LCOV_EXCL_LINE
+    done < "${_conf}"
   fi
 
   if [[ -z "${_found}" ]]; then
@@ -399,8 +397,6 @@ main() {
 }
 
 # Guard: only run main when executed directly, not when sourced (for testing)
-# LCOV_EXCL_START
 if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
   main "$@"
 fi
-# LCOV_EXCL_STOP

--- a/test/unit/terminator_setup_spec.bats
+++ b/test/unit/terminator_setup_spec.bats
@@ -70,3 +70,10 @@ teardown() {
     assert_success
     assert_output --partial "chown called:"
 }
+
+@test "script runs entry_point when executed directly" {
+    mock_cmd "terminator" 'exit 0'
+    mock_cmd "chown" 'exit 0'
+    run bash /source/config/shell/terminator/setup.sh
+    assert_success
+}

--- a/test/unit/tmux_setup_spec.bats
+++ b/test/unit/tmux_setup_spec.bats
@@ -105,3 +105,16 @@ exit 0'
     run main
     assert [ -f "${TEMP_DIR}/.config/tmux/tmux.conf" ]
 }
+
+@test "script runs entry_point when executed directly" {
+    mock_cmd "tmux" 'exit 0'
+    mock_cmd "git" '
+if [[ "$1" == "clone" ]]; then
+    mkdir -p "${@: -1}/scripts"
+    echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
+    chmod +x "${@: -1}/scripts/install_plugins.sh"
+fi
+exit 0'
+    run bash /source/config/shell/tmux/setup.sh
+    assert_success
+}


### PR DESCRIPTION
## Summary

- Remove all `# LCOV_EXCL_*` markers from shell scripts so coverage reflects reality
- Add 2 direct-run tests for `tmux/setup.sh` and `terminator/setup.sh` to cover direct-execution guards
- 171 tests (was 169), 95.76% real coverage

## Why

Previously the LCOV markers hid uninstrumented code from kcov, making coverage look like 100% while actually masking ~6% of lines. Per new CLAUDE.md rule: no coverage-ignore comments allowed.

## Coverage breakdown

| File | Coverage |
|---|---|
| `config/shell/tmux/setup.sh` | 100% |
| `config/shell/terminator/setup.sh` | 100% |
| `script/docker/i18n.sh` | 100% |
| `script/docker/setup.sh` | 94.54% |
| **Overall** | **95.76%** |

The remaining 10 uncovered lines in `setup.sh` are kcov bash backend limitations (case `;;` arms, `done < file` redirect close, child-bash direct-run guards) — confirmed kcov image is already at v44-pre (newer than upstream v43 release), so no upgrade path.

## Test plan

- [x] `make -f Makefile.ci test` passes (171/171)
- [x] TEST.md count aligned (171)
- [x] CHANGELOG updated for v0.6.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)