### PR TITLE
feat: add --gen-image-conf flag to upgrade.sh (v0.6.3)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.3] - 2026-04-09
+
+### Added
+- `upgrade.sh`: `--gen-image-conf` flag (delegates to `init.sh --gen-image-conf`)
+  - Lets users copy `image_name.conf` to repo root for per-repo customization
+    without needing to remember the init.sh path
+
 ## [v0.6.2] - 2026-04-09
 
 ### Changed
@@ -171,6 +178,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dockerfile `CONFIG_SRC` path: `docker_setup_helper/src/config` → `template/config`
 - Shared smoke tests loaded via `COPY template/smoke_test/` in Dockerfile (not symlinks)
 
+[v0.6.3]: https://github.com/ycpss91255-docker/template/compare/v0.6.2...v0.6.3
 [v0.6.2]: https://github.com/ycpss91255-docker/template/compare/v0.6.1...v0.6.2
 [v0.6.1]: https://github.com/ycpss91255-docker/template/compare/v0.6.0...v0.6.1
 [v0.6.0]: https://github.com/ycpss91255-docker/template/compare/v0.5.0...v0.6.0

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **171 tests** total.
+Template self-tests: **174 tests** total.
 
 ## Test Files
 
@@ -67,7 +67,7 @@ Template self-tests: **171 tests** total.
 | `main --lang zh sets Chinese messages` | --lang flag |
 | `main --lang requires a value` | Missing --lang value |
 
-### test/unit/template_spec.bats (57)
+### test/unit/template_spec.bats (60)
 
 | Test | Description |
 |------|-------------|
@@ -123,6 +123,9 @@ Template self-tests: **171 tests** total.
 | `setup.sh does not redefine _detect_lang` | No duplication |
 | `upgrade.sh runs init.sh after subtree pull` | Sync symlinks |
 | `upgrade.sh writes target_ver after init.sh (to override init's latest detection)` | Version override |
+| `upgrade.sh supports --gen-image-conf flag` | Flag exists |
+| `upgrade.sh --gen-image-conf delegates to init.sh --gen-image-conf` | Delegation |
+| `upgrade.sh --help mentions --gen-image-conf` | Help text |
 | `run.sh contains XDG_SESSION_TYPE check` | X11/Wayland branch |
 | `run.sh contains xhost +SI:localuser for wayland` | Wayland xhost |
 | `run.sh contains xhost +local: for X11` | X11 xhost |

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -287,6 +287,22 @@ setup() {
     assert_success
 }
 
+@test "upgrade.sh supports --gen-image-conf flag" {
+    run grep -E '\-\-gen-image-conf' /source/upgrade.sh
+    assert_success
+}
+
+@test "upgrade.sh --gen-image-conf delegates to init.sh --gen-image-conf" {
+    run grep -E 'init\.sh.*--gen-image-conf' /source/upgrade.sh
+    assert_success
+}
+
+@test "upgrade.sh --help mentions --gen-image-conf" {
+    run bash -c "bash /source/upgrade.sh --help 2>&1"
+    assert_success
+    assert_output --partial "--gen-image-conf"
+}
+
 @test "upgrade.sh writes target_ver after init.sh (to override init's latest detection)" {
     # init.sh writes latest tag to .template_version, but upgrade may target older version
     # so upgrade.sh must overwrite .template_version AFTER init.sh runs

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -124,19 +124,23 @@ COMMIT
 
 _usage() {
   cat >&2 <<'EOF'
-Usage: ./template/upgrade.sh [VERSION|--check]
+Usage: ./template/upgrade.sh [VERSION|--check|--gen-image-conf]
 
 Upgrade template subtree to the latest (or specified) version.
 
 Arguments:
-  VERSION       Target version (e.g. v0.5.0). Defaults to latest tag.
-  --check       Check if an update is available (no changes made)
-  -h, --help    Show this help
+  VERSION            Target version (e.g. v0.5.0). Defaults to latest tag.
+  --check            Check if an update is available (no changes made)
+  --gen-image-conf   Copy template's image_name.conf to repo root for
+                     per-repo IMAGE_NAME detection customization
+                     (delegates to init.sh --gen-image-conf)
+  -h, --help         Show this help
 
 Examples:
-  ./template/upgrade.sh              # upgrade to latest
-  ./template/upgrade.sh v0.5.0       # upgrade to specific version
-  ./template/upgrade.sh --check      # check only
+  ./template/upgrade.sh                   # upgrade to latest
+  ./template/upgrade.sh v0.5.0            # upgrade to specific version
+  ./template/upgrade.sh --check           # check only
+  ./template/upgrade.sh --gen-image-conf  # copy image_name.conf to repo root
 EOF
   exit 0
 }
@@ -144,11 +148,15 @@ EOF
 # ── Main ─────────────────────────────────────────────────────────────────────
 
 main() {
+  case "${1:-}" in
+    -h|--help) _usage ;;
+  esac
+
   [[ ! -d template ]] && _error "template/ not found. Run from repo root."
 
   case "${1:-}" in
-    -h|--help) _usage ;;
     --check) _check ;;
+    --gen-image-conf) ./template/init.sh --gen-image-conf ;;
     v*)
       _upgrade "$1"
       ;;


### PR DESCRIPTION
## Summary

Adds `--gen-image-conf` flag to `upgrade.sh` that delegates to `init.sh --gen-image-conf`. Lets users copy `image_name.conf` to their repo root for per-repo IMAGE_NAME detection customization without needing to remember the init.sh subcommand path.

## Test plan

- [x] 174 tests pass (3 new for the flag)
- [x] `./template/upgrade.sh --help` shows the new flag
- [x] `./template/upgrade.sh --help` works from anywhere (no template/ dir check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)