### PR TITLE
fix: upgrade.sh sed clobbered release-worker.yaml @tag (v0.6.4)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.4] - 2026-04-09
+
+### Fixed
+- `upgrade.sh`: greedy sed pattern clobbered `release-worker.yaml@<ver>` reference,
+  replacing it with `build-worker.yaml@<ver>` and breaking release CI in consumer repos
+  - Root cause: `s|template/\.github/workflows/.*@v[0-9.]*|...build-worker.yaml@...|`
+    matched both worker references; the dedicated `release-worker` line that follows
+    only worked when the first sed didn't already overwrite it
+  - Fix: drop the greedy first sed, keep only the per-worker-name targeted seds
+
 ## [v0.6.3] - 2026-04-09
 
 ### Added
@@ -178,6 +188,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dockerfile `CONFIG_SRC` path: `docker_setup_helper/src/config` → `template/config`
 - Shared smoke tests loaded via `COPY template/smoke_test/` in Dockerfile (not symlinks)
 
+[v0.6.4]: https://github.com/ycpss91255-docker/template/compare/v0.6.3...v0.6.4
 [v0.6.3]: https://github.com/ycpss91255-docker/template/compare/v0.6.2...v0.6.3
 [v0.6.2]: https://github.com/ycpss91255-docker/template/compare/v0.6.1...v0.6.2
 [v0.6.1]: https://github.com/ycpss91255-docker/template/compare/v0.6.0...v0.6.1

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **174 tests** total.
+Template self-tests: **175 tests** total.
 
 ## Test Files
 
@@ -67,7 +67,7 @@ Template self-tests: **174 tests** total.
 | `main --lang zh sets Chinese messages` | --lang flag |
 | `main --lang requires a value` | Missing --lang value |
 
-### test/unit/template_spec.bats (60)
+### test/unit/template_spec.bats (61)
 
 | Test | Description |
 |------|-------------|
@@ -126,6 +126,7 @@ Template self-tests: **174 tests** total.
 | `upgrade.sh supports --gen-image-conf flag` | Flag exists |
 | `upgrade.sh --gen-image-conf delegates to init.sh --gen-image-conf` | Delegation |
 | `upgrade.sh --help mentions --gen-image-conf` | Help text |
+| `upgrade.sh updates main.yaml @tag without clobbering release-worker.yaml` | sed regression |
 | `run.sh contains XDG_SESSION_TYPE check` | X11/Wayland branch |
 | `run.sh contains xhost +SI:localuser for wayland` | Wayland xhost |
 | `run.sh contains xhost +local: for X11` | X11 xhost |

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -303,6 +303,42 @@ setup() {
     assert_output --partial "--gen-image-conf"
 }
 
+@test "upgrade.sh updates main.yaml @tag without clobbering release-worker.yaml" {
+    # Regression: a greedy sed pattern .*@v[0-9.]* matched both build-worker
+    # and release-worker references, replacing both with build-worker.yaml@<ver>
+    local _tmp _yaml
+    _tmp="$(mktemp -d)"
+    _yaml="${_tmp}/main.yaml"
+    mkdir -p "${_tmp}/template" "${_tmp}/.github/workflows"
+    cat > "${_yaml}" <<'EOF'
+jobs:
+  call-docker-build:
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v0.5.0
+  call-release:
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@v0.5.0
+EOF
+    # Source upgrade.sh and exercise just the sed block by inlining the
+    # production sed commands here, mirroring what upgrade.sh does.
+    # We do this by extracting and running the sed commands from upgrade.sh.
+    local _seds
+    _seds="$(grep -E "^[[:space:]]*sed -i" /source/upgrade.sh)"
+    while IFS= read -r _line; do
+        # shellcheck disable=SC2001
+        _line="$(echo "${_line}" | sed "s|\${main_yaml}|${_yaml}|g; s|\${target_ver}|v0.6.4|g")"
+        eval "${_line}"
+    done <<< "${_seds}"
+
+    run grep "build-worker.yaml@v0.6.4" "${_yaml}"
+    assert_success
+    run grep "release-worker.yaml@v0.6.4" "${_yaml}"
+    assert_success
+    # Critical: release-worker must NOT be replaced by build-worker
+    run grep -c "build-worker.yaml" "${_yaml}"
+    assert_output "1"
+
+    rm -rf "${_tmp}"
+}
+
 @test "upgrade.sh writes target_ver after init.sh (to override init's latest detection)" {
     # init.sh writes latest tag to .template_version, but upgrade may target older version
     # so upgrade.sh must overwrite .template_version AFTER init.sh runs

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -95,10 +95,10 @@ _upgrade() {
   _log "Step 4/4: update workflow @tag references"
   local main_yaml="${REPO_ROOT}/.github/workflows/main.yaml"
   if [[ -f "${main_yaml}" ]]; then
-    # Replace @vX.Y.Z with new version in reusable workflow references
-    sed -i "s|template/\.github/workflows/.*@v[0-9.]*|template/.github/workflows/build-worker.yaml@${target_ver}|" "${main_yaml}"
-    sed -i "s|build-worker\.yaml@v[0-9.]*|build-worker.yaml@${target_ver}|" "${main_yaml}"
-    sed -i "s|release-worker\.yaml@v[0-9.]*|release-worker.yaml@${target_ver}|" "${main_yaml}"
+    # Replace @vX.Y.Z with new version in reusable workflow references.
+    # Match each worker file by name to avoid greedy patterns clobbering siblings.
+    sed -i "s|build-worker\.yaml@v[0-9.]*|build-worker.yaml@${target_ver}|g" "${main_yaml}"
+    sed -i "s|release-worker\.yaml@v[0-9.]*|release-worker.yaml@${target_ver}|g" "${main_yaml}"
     git add "${main_yaml}"
   fi
 


### PR DESCRIPTION
## Summary

Bug: greedy sed in `upgrade.sh` replaced `release-worker.yaml@<ver>` with `build-worker.yaml@<ver>`, breaking release CI in consumer repos.

## Reproduction

While upgrading `ai_agent` from template v0.5.0 to v0.6.3, the resulting `main.yaml` had:

```yaml
call-docker-build:
  uses: ...build-worker.yaml@v0.6.3   # correct
call-release:
  uses: ...build-worker.yaml@v0.6.3   # WRONG, should be release-worker.yaml
```

PR CI failed with `startup_failure` because `build-worker.yaml` doesn't accept `release-worker` inputs.

## Root cause

```bash
sed -i "s|template/\.github/workflows/.*@v[0-9.]*|...build-worker.yaml@${target_ver}|" "${main_yaml}"
```

The pattern `.*@v[0-9.]*` matches both `build-worker.yaml@v0.5.0` AND `release-worker.yaml@v0.5.0`, replacing both lines with the build-worker version.

## Fix

Drop the greedy first sed entirely. The two follow-up seds already target each worker file by name:

```bash
sed -i "s|build-worker\.yaml@v[0-9.]*|build-worker.yaml@${target_ver}|g" "${main_yaml}"
sed -i "s|release-worker\.yaml@v[0-9.]*|release-worker.yaml@${target_ver}|g" "${main_yaml}"
```

## Test plan

- [x] New regression test (RED before fix, GREEN after)
- [x] 175/175 tests pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)