### PR TITLE
fix: build/run/exec/stop.sh graceful fallback when i18n.sh missing (v0.6.5)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.5] - 2026-04-09
+
+### Fixed
+- `build.sh`/`run.sh`/`exec.sh`/`stop.sh`: graceful fallback when `i18n.sh` is missing
+  - v0.6.1 added `source template/script/docker/i18n.sh` but consumer Dockerfile
+    `test` stages do `COPY *.sh /lint/` without the template tree, so the source
+    failed and broke smoke tests in all consumer repos
+  - Fix: each script checks for i18n.sh and falls back to inline `_detect_lang`
+    if missing — no Dockerfile changes required in consumer repos
+
 ## [v0.6.4] - 2026-04-09
 
 ### Fixed
@@ -188,6 +198,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dockerfile `CONFIG_SRC` path: `docker_setup_helper/src/config` → `template/config`
 - Shared smoke tests loaded via `COPY template/smoke_test/` in Dockerfile (not symlinks)
 
+[v0.6.5]: https://github.com/ycpss91255-docker/template/compare/v0.6.4...v0.6.5
 [v0.6.4]: https://github.com/ycpss91255-docker/template/compare/v0.6.3...v0.6.4
 [v0.6.3]: https://github.com/ycpss91255-docker/template/compare/v0.6.2...v0.6.3
 [v0.6.2]: https://github.com/ycpss91255-docker/template/compare/v0.6.1...v0.6.2

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -116,10 +116,10 @@ Template self-tests: **175 tests** total.
 | `exec.sh sources i18n.sh` | exec.sh uses shared i18n |
 | `stop.sh sources i18n.sh` | stop.sh uses shared i18n |
 | `setup.sh sources i18n.sh` | setup.sh uses shared i18n |
-| `build.sh does not redefine _detect_lang` | No duplication |
-| `run.sh does not redefine _detect_lang` | No duplication |
-| `exec.sh does not redefine _detect_lang` | No duplication |
-| `stop.sh does not redefine _detect_lang` | No duplication |
+| `build.sh -h works when i18n.sh is missing (consumer Dockerfile /lint scenario)` | i18n fallback |
+| `run.sh -h works when i18n.sh is missing` | i18n fallback |
+| `exec.sh -h works when i18n.sh is missing` | i18n fallback |
+| `stop.sh -h works when i18n.sh is missing` | i18n fallback |
 | `setup.sh does not redefine _detect_lang` | No duplication |
 | `upgrade.sh runs init.sh after subtree pull` | Sync symlinks |
 | `upgrade.sh writes target_ver after init.sh (to override init's latest detection)` | Version override |

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -5,8 +5,22 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
-# shellcheck disable=SC1091
-source "${FILE_PATH}/template/script/docker/i18n.sh"
+if [[ -f "${FILE_PATH}/template/script/docker/i18n.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${FILE_PATH}/template/script/docker/i18n.sh"
+else
+  # Fallback for environments without template/ tree (e.g. consumer
+  # Dockerfile /lint smoke test stage that COPYs only *.sh files)
+  _detect_lang() {
+    case "${LANG:-}" in
+      zh_TW*) echo "zh" ;;
+      zh_CN*|zh_SG*) echo "zh-CN" ;;
+      ja*) echo "ja" ;;
+      *) echo "en" ;;
+    esac
+  }
+  _LANG="${SETUP_LANG:-$(_detect_lang)}"
+fi
 
 usage() {
   case "${_LANG}" in

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -5,8 +5,20 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
-# shellcheck disable=SC1091
-source "${FILE_PATH}/template/script/docker/i18n.sh"
+if [[ -f "${FILE_PATH}/template/script/docker/i18n.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${FILE_PATH}/template/script/docker/i18n.sh"
+else
+  _detect_lang() {
+    case "${LANG:-}" in
+      zh_TW*) echo "zh" ;;
+      zh_CN*|zh_SG*) echo "zh-CN" ;;
+      ja*) echo "ja" ;;
+      *) echo "en" ;;
+    esac
+  }
+  _LANG="${SETUP_LANG:-$(_detect_lang)}"
+fi
 
 usage() {
   case "${_LANG}" in

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -5,8 +5,20 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
-# shellcheck disable=SC1091
-source "${FILE_PATH}/template/script/docker/i18n.sh"
+if [[ -f "${FILE_PATH}/template/script/docker/i18n.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${FILE_PATH}/template/script/docker/i18n.sh"
+else
+  _detect_lang() {
+    case "${LANG:-}" in
+      zh_TW*) echo "zh" ;;
+      zh_CN*|zh_SG*) echo "zh-CN" ;;
+      ja*) echo "ja" ;;
+      *) echo "en" ;;
+    esac
+  }
+  _LANG="${SETUP_LANG:-$(_detect_lang)}"
+fi
 
 usage() {
   case "${_LANG}" in

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -5,8 +5,20 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
-# shellcheck disable=SC1091
-source "${FILE_PATH}/template/script/docker/i18n.sh"
+if [[ -f "${FILE_PATH}/template/script/docker/i18n.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${FILE_PATH}/template/script/docker/i18n.sh"
+else
+  _detect_lang() {
+    case "${LANG:-}" in
+      zh_TW*) echo "zh" ;;
+      zh_CN*|zh_SG*) echo "zh-CN" ;;
+      ja*) echo "ja" ;;
+      *) echo "en" ;;
+    esac
+  }
+  _LANG="${SETUP_LANG:-$(_detect_lang)}"
+fi
 
 usage() {
   case "${_LANG}" in

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -253,27 +253,48 @@ setup() {
     assert_success
 }
 
-@test "build.sh does not redefine _detect_lang" {
-    run grep -cE '^_detect_lang\(\)' /source/script/docker/build.sh
-    assert_output "0"
+@test "build.sh -h works when i18n.sh is missing (consumer Dockerfile /lint scenario)" {
+    # Regression: consumer Dockerfile copies *.sh into /lint without template/
+    # tree, so sourcing template/script/docker/i18n.sh fails. build.sh must
+    # gracefully fall back to inline _detect_lang so smoke tests pass.
+    local _tmp
+    _tmp="$(mktemp -d)"
+    cp /source/script/docker/build.sh "${_tmp}/build.sh"
+    run bash "${_tmp}/build.sh" -h
+    assert_success
+    assert_output --partial "Usage"
+    rm -rf "${_tmp}"
 }
 
-@test "run.sh does not redefine _detect_lang" {
-    run grep -cE '^_detect_lang\(\)' /source/script/docker/run.sh
-    assert_output "0"
+@test "run.sh -h works when i18n.sh is missing" {
+    local _tmp
+    _tmp="$(mktemp -d)"
+    cp /source/script/docker/run.sh "${_tmp}/run.sh"
+    run bash "${_tmp}/run.sh" -h
+    assert_success
+    rm -rf "${_tmp}"
 }
 
-@test "exec.sh does not redefine _detect_lang" {
-    run grep -cE '^_detect_lang\(\)' /source/script/docker/exec.sh
-    assert_output "0"
+@test "exec.sh -h works when i18n.sh is missing" {
+    local _tmp
+    _tmp="$(mktemp -d)"
+    cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
+    run bash "${_tmp}/exec.sh" -h
+    assert_success
+    rm -rf "${_tmp}"
 }
 
-@test "stop.sh does not redefine _detect_lang" {
-    run grep -cE '^_detect_lang\(\)' /source/script/docker/stop.sh
-    assert_output "0"
+@test "stop.sh -h works when i18n.sh is missing" {
+    local _tmp
+    _tmp="$(mktemp -d)"
+    cp /source/script/docker/stop.sh "${_tmp}/stop.sh"
+    run bash "${_tmp}/stop.sh" -h
+    assert_success
+    rm -rf "${_tmp}"
 }
 
 @test "setup.sh does not redefine _detect_lang" {
+    # setup.sh is not COPY'd into consumer /lint stage, so no fallback needed
     run grep -cE '^_detect_lang\(\)' /source/script/docker/setup.sh
     assert_output "0"
 }


### PR DESCRIPTION
## Summary

Critical fix: v0.6.1's `source template/script/docker/i18n.sh` broke smoke tests in **every consumer repo** upgraded past v0.6.1.

## Reproduction

While upgrading `ai_agent` from v0.5.0 to v0.6.4, the build CI failed:

```
/lint/build.sh: line 9: /lint/template/script/docker/i18n.sh: No such file or directory
not ok 45 build.sh SETUP_LANG overrides LANG
```

## Root cause

Consumer Dockerfiles do:

```dockerfile
COPY *.sh /lint/
RUN bats /smoke_test/
```

This copies the symlinks (resolved to file content) into `/lint/`, but `template/` is not present. build.sh's `source template/script/docker/i18n.sh` fails immediately.

Template's own CI didn't catch this because it doesn't go through a Dockerfile build.

## Fix

Wrap the source in a file check and fall back to inline `_detect_lang`:

```bash
if [[ -f "${FILE_PATH}/template/script/docker/i18n.sh" ]]; then
  source "${FILE_PATH}/template/script/docker/i18n.sh"
else
  _detect_lang() {
    case "${LANG:-}" in
      zh_TW*) echo "zh" ;;
      ...
    esac
  }
  _LANG="${SETUP_LANG:-$(_detect_lang)}"
fi
```

Applied to build.sh, run.sh, exec.sh, stop.sh. setup.sh unchanged (not COPY'd into /lint).

No consumer Dockerfile changes needed.

## Test plan

- [x] 4 new regression tests covering /lint scenario (RED before fix, GREEN after)
- [x] 175/175 tests pass
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)