### PR TITLE
feat: --instance flag for parallel container instances (v0.6.8)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.8] - 2026-04-09
+
+### Added
+- `run.sh` / `exec.sh` / `stop.sh`: `--instance NAME` flag for parallel container instances
+  - `./run.sh --instance dev2` starts a parallel container alongside the default
+  - `./exec.sh --instance dev2 [cmd]` enters that named instance
+  - `./stop.sh --instance dev2` stops only that one
+  - `./stop.sh --all` stops the default + every named instance for this image
+- Project name and container name now include `${INSTANCE_SUFFIX}` so each
+  instance has isolated docker compose project (own network/volumes)
+- `init.sh`-generated `compose.yaml` uses
+  `container_name: ${IMAGE_NAME}${INSTANCE_SUFFIX:-}`
+  - Default invocation (no `--instance`) keeps the clean name `${IMAGE_NAME}` —
+    backward-compatible with external tools that grep `docker exec ${IMAGE_NAME}`
+
+### Changed
+- `run.sh`: foreground devel now refuses to start if a container with the
+  default name is already running. Use `./stop.sh` first or pass
+  `--instance NAME` to start a parallel one.
+
+### Note
+- Existing 17 consumer repos must update their `compose.yaml` to use
+  `container_name: ${IMAGE_NAME}${INSTANCE_SUFFIX:-}` (one-line edit) before
+  `--instance` works there. Default behavior unchanged until they upgrade.
+
 ## [v0.6.7] - 2026-04-09
 
 ### Added
@@ -230,6 +255,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dockerfile `CONFIG_SRC` path: `docker_setup_helper/src/config` → `template/config`
 - Shared smoke tests loaded via `COPY template/smoke_test/` in Dockerfile (not symlinks)
 
+[v0.6.8]: https://github.com/ycpss91255-docker/template/compare/v0.6.7...v0.6.8
 [v0.6.7]: https://github.com/ycpss91255-docker/template/compare/v0.6.6...v0.6.7
 [v0.6.6]: https://github.com/ycpss91255-docker/template/compare/v0.6.5...v0.6.6
 [v0.6.5]: https://github.com/ycpss91255-docker/template/compare/v0.6.4...v0.6.5

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **201 tests** total (180 unit + 21 integration).
+Template self-tests: **213 tests** total (192 unit + 21 integration).
 
 ## Test Files
 
@@ -67,7 +67,7 @@ Template self-tests: **201 tests** total (180 unit + 21 integration).
 | `main --lang zh sets Chinese messages` | --lang flag |
 | `main --lang requires a value` | Missing --lang value |
 
-### test/unit/template_spec.bats (66)
+### test/unit/template_spec.bats (78)
 
 | Test | Description |
 |------|-------------|
@@ -113,6 +113,18 @@ Template self-tests: **201 tests** total (180 unit + 21 integration).
 | `run.sh devel branch installs trap to auto-down on exit` | Auto cleanup |
 | `run.sh non-devel TARGET still uses compose run --rm` | One-shot stages |
 | `run.sh devel branch does not use 'compose run --name'` | Old pattern gone |
+| `run.sh supports --instance flag` | --instance |
+| `exec.sh supports --instance flag` | --instance |
+| `stop.sh supports --instance flag` | --instance |
+| `stop.sh supports --all flag` | --all |
+| `run.sh exports INSTANCE_SUFFIX env var to compose` | env passing |
+| `exec.sh exports INSTANCE_SUFFIX env var to compose` | env passing |
+| `stop.sh exports INSTANCE_SUFFIX env var to compose` | env passing |
+| `run.sh refuses when default container already running and no --instance` | collision |
+| `init.sh-generated compose.yaml uses parameterized container_name` | template gen |
+| `run.sh -h shows --instance in help` | help text |
+| `exec.sh -h shows --instance in help` | help text |
+| `stop.sh -h shows --instance in help` | help text |
 | `script/docker/i18n.sh exists` | i18n module exists |
 | `Dockerfile.test-tools includes bats-mock` | bats-mock available in test image |
 | `i18n.sh defines _detect_lang function` | _detect_lang in i18n.sh |

--- a/init.sh
+++ b/init.sh
@@ -86,7 +86,7 @@ services:
         APT_MIRROR_UBUNTU: \${APT_MIRROR_UBUNTU:-tw.archive.ubuntu.com}
         APT_MIRROR_DEBIAN: \${APT_MIRROR_DEBIAN:-mirror.twds.com.tw}
     image: \${DOCKER_HUB_USER:-local}/${name}:devel
-    container_name: ${name}
+    container_name: ${name}\${INSTANCE_SUFFIX:-}
     stdin_open: true
     tty: true
 

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -24,11 +24,12 @@ usage() {
   case "${_LANG}" in
     zh)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-t TARGET] [CMD...]
+用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [CMD...]
 
 選項:
-  -h, --help       顯示此說明
-  -t, --target T   服務名稱（預設: devel）
+  -h, --help        顯示此說明
+  -t, --target T    服務名稱（預設: devel）
+  --instance NAME   進入命名 instance（預設為 default instance）
 
 參數:
   CMD              要執行的指令（預設: bash）
@@ -42,11 +43,12 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-t TARGET] [CMD...]
+用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [CMD...]
 
 选项:
-  -h, --help       显示此说明
-  -t, --target T   服务名称（默认: devel）
+  -h, --help        显示此说明
+  -t, --target T    服务名称（默认: devel）
+  --instance NAME   进入命名 instance（默认为 default instance）
 
 参数:
   CMD              要执行的命令（默认: bash）
@@ -60,11 +62,12 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./exec.sh [-h] [-t TARGET] [CMD...]
+使用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [CMD...]
 
 オプション:
-  -h, --help       このヘルプを表示
-  -t, --target T   サービス名（デフォルト: devel）
+  -h, --help        このヘルプを表示
+  -t, --target T    サービス名（デフォルト: devel）
+  --instance NAME   名前付き instance に入る（デフォルトは default instance）
 
 引数:
   CMD              実行するコマンド（デフォルト: bash）
@@ -78,11 +81,12 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./exec.sh [-h] [-t TARGET] [CMD...]
+Usage: ./exec.sh [-h] [-t TARGET] [--instance NAME] [CMD...]
 
 Options:
-  -h, --help       Show this help
-  -t, --target T   Service name (default: devel)
+  -h, --help        Show this help
+  -t, --target T    Service name (default: devel)
+  --instance NAME   Enter a named instance (default: default instance)
 
 Arguments:
   CMD              Command to execute (default: bash)
@@ -99,6 +103,7 @@ EOF
 }
 
 TARGET="devel"
+INSTANCE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -107,6 +112,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -t|--target)
       TARGET="${2:?"--target requires a value"}"
+      shift 2
+      ;;
+    --instance)
+      INSTANCE="${2:?"--instance requires a value"}"
       shift 2
       ;;
     *)
@@ -123,8 +132,18 @@ set -o allexport
 source "${FILE_PATH}/.env"
 set +o allexport
 
+# Append instance suffix to project name (and to compose.yaml's container_name
+# via the INSTANCE_SUFFIX env var) so we target the right instance.
+if [[ -n "${INSTANCE}" ]]; then
+  INSTANCE_SUFFIX="-${INSTANCE}"
+else
+  INSTANCE_SUFFIX=""
+fi
+export INSTANCE_SUFFIX
+PROJECT_NAME="${DOCKER_HUB_USER}-${IMAGE_NAME}${INSTANCE_SUFFIX}"
+
 # shellcheck disable=SC2086  # Intentional word splitting for multi-word commands
-docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" \
+docker compose -p "${PROJECT_NAME}" \
   -f "${FILE_PATH}/compose.yaml" \
   --env-file "${FILE_PATH}/.env" \
   exec "${TARGET}" ${CMD}

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -24,13 +24,14 @@ usage() {
   case "${_LANG}" in
     zh)
       cat >&2 <<'EOF'
-用法: ./run.sh [-h] [-d|--detach] [--no-env] [--lang <en|zh|zh-CN|ja>] [TARGET]
+用法: ./run.sh [-h] [-d|--detach] [--no-env] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 選項:
-  -h, --help     顯示此說明
-  -d, --detach   背景執行（docker compose up -d）
-  --no-env       跳過 .env 重新產生
-  --lang LANG    設定訊息語言（預設: en）
+  -h, --help        顯示此說明
+  -d, --detach      背景執行（docker compose up -d）
+  --no-env          跳過 .env 重新產生
+  --instance NAME   啟動命名 instance（與預設並行,suffix=-NAME）
+  --lang LANG       設定訊息語言（預設: en）
 
 目標:
   devel    開發環境（預設）
@@ -39,13 +40,14 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./run.sh [-h] [-d|--detach] [--no-env] [--lang <en|zh|zh-CN|ja>] [TARGET]
+用法: ./run.sh [-h] [-d|--detach] [--no-env] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 选项:
-  -h, --help     显示此说明
-  -d, --detach   后台运行（docker compose up -d）
-  --no-env       跳过 .env 重新生成
-  --lang LANG    设置消息语言（默认: en）
+  -h, --help        显示此说明
+  -d, --detach      后台运行（docker compose up -d）
+  --no-env          跳过 .env 重新生成
+  --instance NAME   启动命名 instance（与默认并行,suffix=-NAME）
+  --lang LANG       设置消息语言（默认: en）
 
 目标:
   devel    开发环境（默认）
@@ -54,13 +56,14 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./run.sh [-h] [-d|--detach] [--no-env] [--lang <en|zh|zh-CN|ja>] [TARGET]
+使用法: ./run.sh [-h] [-d|--detach] [--no-env] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 オプション:
-  -h, --help     このヘルプを表示
-  -d, --detach   バックグラウンドで実行（docker compose up -d）
-  --no-env       .env の再生成をスキップ
-  --lang LANG    メッセージ言語を設定（デフォルト: en）
+  -h, --help        このヘルプを表示
+  -d, --detach      バックグラウンドで実行（docker compose up -d）
+  --no-env          .env の再生成をスキップ
+  --instance NAME   名前付き instance を起動（デフォルトと並行、suffix=-NAME）
+  --lang LANG       メッセージ言語を設定（デフォルト: en）
 
 ターゲット:
   devel    開発環境（デフォルト）
@@ -69,13 +72,14 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./run.sh [-h] [-d|--detach] [--no-env] [--lang <en|zh|zh-CN|ja>] [TARGET]
+Usage: ./run.sh [-h] [-d|--detach] [--no-env] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 Options:
-  -h, --help     Show this help
-  -d, --detach   Run in background (docker compose up -d)
-  --no-env       Skip .env regeneration
-  --lang LANG    Set message language (default: en)
+  -h, --help        Show this help
+  -d, --detach      Run in background (docker compose up -d)
+  --no-env          Skip .env regeneration
+  --instance NAME   Start a named parallel instance (suffix=-NAME)
+  --lang LANG       Set message language (default: en)
 
 Targets:
   devel    Development environment (default)
@@ -90,6 +94,7 @@ EOF
 SKIP_ENV=false
 DETACH=false
 TARGET="devel"
+INSTANCE=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -104,6 +109,10 @@ while [[ $# -gt 0 ]]; do
       SKIP_ENV=true
       shift
       ;;
+    --instance)
+      INSTANCE="${2:?"--instance requires a value"}"
+      shift 2
+      ;;
     --lang)
       _LANG="${2:?"--lang requires a value (en|zh|zh-CN|ja)"}"
       shift 2
@@ -114,6 +123,15 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+# INSTANCE_SUFFIX is appended to project name and (via env var) to compose.yaml's
+# container_name: ${IMAGE_NAME}${INSTANCE_SUFFIX:-}
+if [[ -n "${INSTANCE}" ]]; then
+  INSTANCE_SUFFIX="-${INSTANCE}"
+else
+  INSTANCE_SUFFIX=""
+fi
+export INSTANCE_SUFFIX
 
 # Generate / refresh .env
 if [[ "${SKIP_ENV}" == false ]]; then
@@ -133,12 +151,29 @@ else
   xhost +local: >/dev/null 2>&1 || true
 fi
 
+# Project name includes instance suffix so parallel instances have isolated
+# networks/volumes/containers.
+PROJECT_NAME="${DOCKER_HUB_USER}-${IMAGE_NAME}${INSTANCE_SUFFIX}"
+CONTAINER_NAME="${IMAGE_NAME}${INSTANCE_SUFFIX}"
+
+# Refuse to start if the target container is already running and user did not
+# explicitly opt into a parallel instance via --instance.
+# (For -d mode, the existing `down` step handles restart, so collision is OK.)
+if [[ "${DETACH}" != true && "${TARGET}" == "devel" ]]; then
+  if docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+    printf "[run] ERROR: Container '%s' is already running.\n" "${CONTAINER_NAME}" >&2
+    printf "[run] Either stop it with './stop.sh%s' or start a parallel instance with './run.sh --instance NAME'.\n" \
+      "$([[ -n "${INSTANCE}" ]] && printf ' --instance %s' "${INSTANCE}")" >&2
+    exit 1
+  fi
+fi
+
 if [[ "${DETACH}" == true ]]; then
-  docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" \
+  docker compose -p "${PROJECT_NAME}" \
     -f "${FILE_PATH}/compose.yaml" \
     --env-file "${FILE_PATH}/.env" \
     down 2>/dev/null || true
-  docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" \
+  docker compose -p "${PROJECT_NAME}" \
     -f "${FILE_PATH}/compose.yaml" \
     --env-file "${FILE_PATH}/.env" \
     up -d "${TARGET}"
@@ -146,18 +181,19 @@ elif [[ "${TARGET}" == "devel" ]]; then
   # Foreground devel: use `up -d` + `exec` so a second terminal can join via
   # `./exec.sh`. Trap auto-`down` on exit to preserve the original
   # "exit shell = container gone" semantic of the previous `compose run`.
-  trap 'docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" -f "${FILE_PATH}/compose.yaml" --env-file "${FILE_PATH}/.env" down >/dev/null 2>&1 || true' EXIT
-  docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" \
+  # shellcheck disable=SC2064  # PROJECT_NAME must be expanded NOW, not at trap time
+  trap "docker compose -p '${PROJECT_NAME}' -f '${FILE_PATH}/compose.yaml' --env-file '${FILE_PATH}/.env' down >/dev/null 2>&1 || true" EXIT
+  docker compose -p "${PROJECT_NAME}" \
     -f "${FILE_PATH}/compose.yaml" \
     --env-file "${FILE_PATH}/.env" \
     up -d "${TARGET}"
-  docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" \
+  docker compose -p "${PROJECT_NAME}" \
     -f "${FILE_PATH}/compose.yaml" \
     --env-file "${FILE_PATH}/.env" \
     exec "${TARGET}" bash
 else
   # Other one-shot stages (test, runtime, ...): keep `compose run --rm`
-  docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" \
+  docker compose -p "${PROJECT_NAME}" \
     -f "${FILE_PATH}/compose.yaml" \
     --env-file "${FILE_PATH}/.env" \
     run --rm "${TARGET}"

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -24,51 +24,79 @@ usage() {
   case "${_LANG}" in
     zh)
       cat >&2 <<'EOF'
-用法: ./stop.sh [-h]
+用法: ./stop.sh [-h] [--instance NAME] [--all]
 
-停止並移除此專案的所有容器。
+停止並移除容器。預設只停止 default instance。
 
 選項:
-  -h, --help     顯示此說明
+  -h, --help        顯示此說明
+  --instance NAME   只停止指定的命名 instance
+  --all             停止所有 instance(預設 + 全部命名 instance)
 EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./stop.sh [-h]
+用法: ./stop.sh [-h] [--instance NAME] [--all]
 
-停止并移除此项目的所有容器。
+停止并移除容器。默认只停止 default instance。
 
 选项:
-  -h, --help     显示此说明
+  -h, --help        显示此说明
+  --instance NAME   只停止指定的命名 instance
+  --all             停止所有 instance(默认 + 全部命名 instance)
 EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./stop.sh [-h]
+使用法: ./stop.sh [-h] [--instance NAME] [--all]
 
-このプロジェクトのすべてのコンテナを停止・削除します。
+コンテナを停止・削除します。デフォルトは default instance のみ。
 
 オプション:
-  -h, --help     このヘルプを表示
+  -h, --help        このヘルプを表示
+  --instance NAME   指定された名前付き instance のみ停止
+  --all             すべての instance を停止（デフォルト + 全名前付き instance）
 EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./stop.sh [-h]
+Usage: ./stop.sh [-h] [--instance NAME] [--all]
 
-Stop and remove all containers for this project.
+Stop and remove containers. Default: stop only the default instance.
 
 Options:
-  -h, --help     Show this help
+  -h, --help        Show this help
+  --instance NAME   Stop only the named instance
+  --all             Stop ALL instances (default + every named instance)
 EOF
       ;;
   esac
   exit 0
 }
 
-if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
-  usage
-fi
+INSTANCE=""
+ALL_INSTANCES=false
+PASSTHROUGH=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      ;;
+    --instance)
+      INSTANCE="${2:?"--instance requires a value"}"
+      shift 2
+      ;;
+    --all)
+      ALL_INSTANCES=true
+      shift
+      ;;
+    *)
+      PASSTHROUGH+=("$1")
+      shift
+      ;;
+  esac
+done
 
 # Load .env for project name
 set -o allexport
@@ -76,7 +104,34 @@ set -o allexport
 source "${FILE_PATH}/.env"
 set +o allexport
 
-docker compose -p "${DOCKER_HUB_USER}-${IMAGE_NAME}" \
-  -f "${FILE_PATH}/compose.yaml" \
-  --env-file "${FILE_PATH}/.env" \
-  down "$@"
+# Helper: down a single project (with the right INSTANCE_SUFFIX so compose.yaml
+# resolves the same container_name as run.sh used).
+_down_one() {
+  local _suffix="${1}"
+  local _project="${DOCKER_HUB_USER}-${IMAGE_NAME}${_suffix}"
+  INSTANCE_SUFFIX="${_suffix}" docker compose -p "${_project}" \
+    -f "${FILE_PATH}/compose.yaml" \
+    --env-file "${FILE_PATH}/.env" \
+    down "${PASSTHROUGH[@]}"
+}
+
+if [[ "${ALL_INSTANCES}" == true ]]; then
+  # Find all docker compose projects whose name starts with our prefix.
+  _prefix="${DOCKER_HUB_USER}-${IMAGE_NAME}"
+  mapfile -t _projects < <(
+    docker ps -a --format '{{.Label "com.docker.compose.project"}}' \
+      | sort -u | grep -E "^${_prefix}(\$|-)" || true
+  )
+  if [[ ${#_projects[@]} -eq 0 ]]; then
+    printf "[stop] No instances found for %s\n" "${IMAGE_NAME}" >&2
+    exit 0
+  fi
+  for _proj in "${_projects[@]}"; do
+    _suffix="${_proj#"${_prefix}"}"
+    _down_one "${_suffix}"
+  done
+elif [[ -n "${INSTANCE}" ]]; then
+  _down_one "-${INSTANCE}"
+else
+  _down_one ""
+fi

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -180,18 +180,18 @@ setup() {
     assert_success
 }
 
-@test "run.sh uses -p for compose project name" {
-    run grep -E '\-p.*DOCKER_HUB_USER.*IMAGE_NAME' /source/script/docker/run.sh
+@test "run.sh derives project name from DOCKER_HUB_USER and IMAGE_NAME" {
+    run grep -E 'PROJECT_NAME=.*DOCKER_HUB_USER.*IMAGE_NAME' /source/script/docker/run.sh
     assert_success
 }
 
-@test "exec.sh uses -p for compose project name" {
-    run grep -E '\-p.*DOCKER_HUB_USER.*IMAGE_NAME' /source/script/docker/exec.sh
+@test "exec.sh derives project name from DOCKER_HUB_USER and IMAGE_NAME" {
+    run grep -E 'PROJECT_NAME=.*DOCKER_HUB_USER.*IMAGE_NAME' /source/script/docker/exec.sh
     assert_success
 }
 
-@test "stop.sh uses -p for compose project name" {
-    run grep -E '\-p.*DOCKER_HUB_USER.*IMAGE_NAME' /source/script/docker/stop.sh
+@test "stop.sh derives project name from DOCKER_HUB_USER and IMAGE_NAME" {
+    run grep -E 'DOCKER_HUB_USER.*IMAGE_NAME' /source/script/docker/stop.sh
     assert_success
 }
 
@@ -240,6 +240,73 @@ setup() {
     # The old buggy pattern must be gone for devel; only run --rm for one-shots
     run grep -E 'run .*--name' /source/script/docker/run.sh
     assert_failure
+}
+
+# ════════════════════════════════════════════════════════════════════
+# --instance flag (v0.6.8)
+# ════════════════════════════════════════════════════════════════════
+
+@test "run.sh supports --instance flag" {
+    run grep -E '\-\-instance' /source/script/docker/run.sh
+    assert_success
+}
+
+@test "exec.sh supports --instance flag" {
+    run grep -E '\-\-instance' /source/script/docker/exec.sh
+    assert_success
+}
+
+@test "stop.sh supports --instance flag" {
+    run grep -E '\-\-instance' /source/script/docker/stop.sh
+    assert_success
+}
+
+@test "stop.sh supports --all flag" {
+    run grep -E '\-\-all' /source/script/docker/stop.sh
+    assert_success
+}
+
+@test "run.sh exports INSTANCE_SUFFIX env var to compose" {
+    # Compose YAML resolves ${INSTANCE_SUFFIX:-} from this env var
+    run grep -E 'INSTANCE_SUFFIX' /source/script/docker/run.sh
+    assert_success
+}
+
+@test "exec.sh exports INSTANCE_SUFFIX env var to compose" {
+    run grep -E 'INSTANCE_SUFFIX' /source/script/docker/exec.sh
+    assert_success
+}
+
+@test "stop.sh exports INSTANCE_SUFFIX env var to compose" {
+    run grep -E 'INSTANCE_SUFFIX' /source/script/docker/stop.sh
+    assert_success
+}
+
+@test "run.sh refuses when default container already running and no --instance" {
+    # The script should grep docker ps for existing container with the
+    # default name and exit non-zero with a helpful message
+    run grep -E 'already running|already exists' /source/script/docker/run.sh
+    assert_success
+}
+
+@test "init.sh-generated compose.yaml uses parameterized container_name" {
+    run grep 'INSTANCE_SUFFIX' /source/init.sh
+    assert_success
+}
+
+@test "run.sh -h shows --instance in help" {
+    run bash -c "bash /source/script/docker/run.sh -h 2>&1"
+    assert_output --partial "--instance"
+}
+
+@test "exec.sh -h shows --instance in help" {
+    run bash -c "bash /source/script/docker/exec.sh -h 2>&1"
+    assert_output --partial "--instance"
+}
+
+@test "stop.sh -h shows --instance in help" {
+    run bash -c "bash /source/script/docker/stop.sh -h 2>&1"
+    assert_output --partial "--instance"
 }
 
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Adds optional `--instance NAME` to `run.sh`/`exec.sh`/`stop.sh` so you can run multiple containers from the same repo in parallel without name collision.

## Usage

```bash
# Default (unchanged)
./run.sh                     # container = lidar_filter_kinetic
./exec.sh bash               # enters it
./stop.sh                    # stops it

# Parallel instance
./run.sh --instance dev2     # container = lidar_filter_kinetic-dev2 (separate project)
./exec.sh --instance dev2    # enters that one
./stop.sh --instance dev2    # stops only dev2
./stop.sh --all              # stops default + every named instance
```

## Design

- **Default invocation unchanged** — container = `${IMAGE_NAME}`, ci.sh and other tools that grep `docker exec ${IMAGE_NAME}` continue to work
- **With `--instance NAME`** — project name + container name get `-NAME` suffix, fully isolated docker compose project (own network, volumes)
- **`compose.yaml`** uses `container_name: ${IMAGE_NAME}${INSTANCE_SUFFIX:-}` (template's `init.sh`-generated example updated; existing 17 consumer repos need a one-line edit before `--instance` works there)
- **Collision safety** — `./run.sh` (foreground devel) refuses if a container with the default name is already running. Caller must explicitly `./stop.sh` or use `--instance NAME`
- **`stop.sh --all`** — enumerates all compose projects matching `${DOCKER_HUB_USER}-${IMAGE_NAME}*` via docker labels and downs each

## Test plan

- [x] 213/213 tests pass (12 new for flag/env/help/collision)
- [ ] CI green
- [ ] Integration-e2e job still passes (verifies init.sh-generated compose.yaml builds OK)

## Note for consumer repos

Existing 17 repos must update `compose.yaml`:
```diff
-    container_name: ${IMAGE_NAME}
+    container_name: ${IMAGE_NAME}${INSTANCE_SUFFIX:-}
```
Backward compatible — default behavior unchanged until they upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)