### PR TITLE
feat: --dry-run flag and exec.sh container precheck

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `build.sh` / `run.sh` / `exec.sh` / `stop.sh`: `--dry-run` flag prints the
+  `docker` / `docker compose` commands that would run instead of executing them.
+  Useful for debugging compose / env / instance resolution without side effects.
+- `exec.sh`: precheck refuses with a friendly error pointing at `./run.sh`
+  (and `--instance NAME` if applicable) when the target container is not running,
+  instead of letting `compose exec` print the cryptic `service "devel" is not running`.
+
 ### Changed
 - Refactor: extracted shared helpers (`_LANG` setup, `_load_env`, `_compute_project_name`,
   `_compose`, `_compose_project`) into `template/script/docker/_lib.sh`. `build.sh`,
@@ -16,8 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so arguments containing whitespace are preserved instead of being word-split.
 - `run.sh`: trap is now `trap _devel_cleanup EXIT` (calls a named function) instead of
   an inline string-expanded command, matching `build.sh`'s style.
-
-No user-facing behavior change.
 
 ## [v0.6.8] - 2026-04-09
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **233 tests** total (212 unit + 21 integration).
+Template self-tests: **246 tests** total (225 unit + 21 integration).
 
 ## Test Files
 
-### test/unit/lib_spec.bats (14)
+### test/unit/lib_spec.bats (15)
 
 | Test | Description |
 |------|-------------|
@@ -21,6 +21,7 @@ Template self-tests: **233 tests** total (212 unit + 21 integration).
 | `_compute_project_name with named instance suffixes both` | Named instance |
 | `_compute_project_name exports INSTANCE_SUFFIX so child processes see it` | Export propagation |
 | `_compose with DRY_RUN=true prints command instead of running` | DRY_RUN path |
+| `_compose without DRY_RUN tries to invoke docker compose (sanity)` | Real-call branch |
 | `_compose_project pre-fills -p / -f / --env-file from PROJECT_NAME and FILE_PATH` | Project wrapper |
 
 ### test/unit/setup_spec.bats (58)
@@ -86,7 +87,7 @@ Template self-tests: **233 tests** total (212 unit + 21 integration).
 | `main --lang zh sets Chinese messages` | --lang flag |
 | `main --lang requires a value` | Missing --lang value |
 
-### test/unit/template_spec.bats (84)
+### test/unit/template_spec.bats (96)
 
 | Test | Description |
 |------|-------------|
@@ -149,6 +150,18 @@ Template self-tests: **233 tests** total (212 unit + 21 integration).
 | `run.sh -h shows --instance in help` | help text |
 | `exec.sh -h shows --instance in help` | help text |
 | `stop.sh -h shows --instance in help` | help text |
+| `build.sh supports --dry-run flag` | --dry-run |
+| `run.sh supports --dry-run flag` | --dry-run |
+| `exec.sh supports --dry-run flag` | --dry-run |
+| `stop.sh supports --dry-run flag` | --dry-run |
+| `build.sh -h shows --dry-run in help` | --dry-run help |
+| `run.sh -h shows --dry-run in help` | --dry-run help |
+| `exec.sh -h shows --dry-run in help` | --dry-run help |
+| `stop.sh -h shows --dry-run in help` | --dry-run help |
+| `exec.sh checks container is running before exec` | precheck |
+| `exec.sh precheck error mentions run.sh hint` | friendly hint |
+| `exec.sh exits non-zero with friendly hint when container not running` | precheck e2e |
+| `exec.sh --dry-run skips precheck and prints compose command` | dry-run e2e |
 | `script/docker/i18n.sh exists` | i18n module exists |
 | `Dockerfile.test-tools includes bats-mock` | bats-mock available in test image |
 | `i18n.sh defines _detect_lang function` | _detect_lang in i18n.sh |

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -27,13 +27,14 @@ usage() {
   case "${_LANG}" in
     zh)
       cat >&2 <<'EOF'
-用法: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--lang <en|zh|zh-CN|ja>] [TARGET]
+用法: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 選項:
   -h, --help     顯示此說明
   --no-env       跳過 .env 重新產生
   --no-cache     強制不使用 cache 重建
   --clean-tools  build 結束後移除 test-tools:local image（預設保留以加速下次 build）
+  --dry-run      只印出將執行的 docker 指令，不實際執行
   --lang LANG    設定訊息語言（預設: en）
 
 目標:
@@ -44,13 +45,14 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--lang <en|zh|zh-CN|ja>] [TARGET]
+用法: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 选项:
   -h, --help     显示此说明
   --no-env       跳过 .env 重新生成
   --no-cache     强制不使用 cache 重建
   --clean-tools  build 结束后移除 test-tools:local image（默认保留以加速下次 build）
+  --dry-run      只打印将执行的 docker 命令，不实际执行
   --lang LANG    设置消息语言（默认: en）
 
 目标:
@@ -61,13 +63,14 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--lang <en|zh|zh-CN|ja>] [TARGET]
+使用法: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 オプション:
   -h, --help     このヘルプを表示
   --no-env       .env の再生成をスキップ
   --no-cache     キャッシュを使わず強制リビルド
   --clean-tools  build 終了後に test-tools:local image を削除（デフォルトは保持）
+  --dry-run      実行される docker コマンドを表示するのみ（実行はしない）
   --lang LANG    メッセージ言語を設定（デフォルト: en）
 
 ターゲット:
@@ -78,13 +81,14 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--lang <en|zh|zh-CN|ja>] [TARGET]
+Usage: ./build.sh [-h] [--no-env] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 Options:
   -h, --help     Show this help
   --no-env       Skip .env regeneration
   --no-cache     Force rebuild without cache
   --clean-tools  Remove test-tools:local image after build (default: keep for faster next build)
+  --dry-run      Print the docker commands that would run, but do not execute
   --lang LANG    Set message language (default: en)
 
 Targets:
@@ -100,6 +104,7 @@ EOF
 SKIP_ENV=false
 NO_CACHE=false
 CLEAN_TOOLS=false
+DRY_RUN=false
 TARGET="devel"
 
 while [[ $# -gt 0 ]]; do
@@ -119,6 +124,10 @@ while [[ $# -gt 0 ]]; do
       CLEAN_TOOLS=true
       shift
       ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
     --lang)
       _LANG="${2:?"--lang requires a value (en|zh|zh-CN|ja)"}"
       shift 2
@@ -129,6 +138,7 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+export DRY_RUN
 
 # Generate / refresh .env
 if [[ "${SKIP_ENV}" == false ]]; then
@@ -144,7 +154,13 @@ _tools_dockerfile="${FILE_PATH}/template/dockerfile/Dockerfile.test-tools"
 _tools_args=()
 [[ "${NO_CACHE}" == true ]] && _tools_args+=(--no-cache)
 if [[ -f "${_tools_dockerfile}" ]]; then
-  docker build "${_tools_args[@]}" -t test-tools:local -f "${_tools_dockerfile}" "${FILE_PATH}" -q >/dev/null
+  if [[ "${DRY_RUN}" == true ]]; then
+    printf '[dry-run] docker build'
+    printf ' %q' "${_tools_args[@]}" -t test-tools:local -f "${_tools_dockerfile}" "${FILE_PATH}" -q
+    printf '\n'
+  else
+    docker build "${_tools_args[@]}" -t test-tools:local -f "${_tools_dockerfile}" "${FILE_PATH}" -q >/dev/null
+  fi
 fi
 
 if [[ "${CLEAN_TOOLS}" == true ]]; then

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -25,12 +25,13 @@ usage() {
   case "${_LANG}" in
     zh)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [CMD...]
+用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [--dry-run] [CMD...]
 
 選項:
   -h, --help        顯示此說明
   -t, --target T    服務名稱（預設: devel）
   --instance NAME   進入命名 instance（預設為 default instance）
+  --dry-run         只印出將執行的 docker 指令，不實際執行
 
 參數:
   CMD              要執行的指令（預設: bash）
@@ -44,12 +45,13 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [CMD...]
+用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [--dry-run] [CMD...]
 
 选项:
   -h, --help        显示此说明
   -t, --target T    服务名称（默认: devel）
   --instance NAME   进入命名 instance（默认为 default instance）
+  --dry-run         只打印将执行的 docker 命令，不实际执行
 
 参数:
   CMD              要执行的命令（默认: bash）
@@ -63,12 +65,13 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [CMD...]
+使用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [--dry-run] [CMD...]
 
 オプション:
   -h, --help        このヘルプを表示
   -t, --target T    サービス名（デフォルト: devel）
   --instance NAME   名前付き instance に入る（デフォルトは default instance）
+  --dry-run         実行される docker コマンドを表示するのみ（実行はしない）
 
 引数:
   CMD              実行するコマンド（デフォルト: bash）
@@ -82,12 +85,13 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./exec.sh [-h] [-t TARGET] [--instance NAME] [CMD...]
+Usage: ./exec.sh [-h] [-t TARGET] [--instance NAME] [--dry-run] [CMD...]
 
 Options:
   -h, --help        Show this help
   -t, --target T    Service name (default: devel)
   --instance NAME   Enter a named instance (default: default instance)
+  --dry-run         Print the docker commands that would run, but do not execute
 
 Arguments:
   CMD              Command to execute (default: bash)
@@ -105,6 +109,7 @@ EOF
 
 TARGET="devel"
 INSTANCE=""
+DRY_RUN=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -119,11 +124,16 @@ while [[ $# -gt 0 ]]; do
       INSTANCE="${2:?"--instance requires a value"}"
       shift 2
       ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
     *)
       break
       ;;
   esac
 done
+export DRY_RUN
 
 # Default to bash when no command is supplied. Using an array preserves
 # arguments containing whitespace, unlike the previous `${CMD}` splitting.
@@ -134,5 +144,19 @@ fi
 # Load .env, derive PROJECT_NAME (sets/exports INSTANCE_SUFFIX too).
 _load_env "${FILE_PATH}/.env"
 _compute_project_name "${INSTANCE}"
+
+# Precheck: refuse with a friendly hint if the target container is not running.
+# Skipped under --dry-run since the user is asking what *would* run.
+_container_name="${IMAGE_NAME}${INSTANCE_SUFFIX}"
+if [[ "${DRY_RUN}" != true ]] \
+   && ! docker ps --format '{{.Names}}' | grep -qx "${_container_name}"; then
+  printf "[exec] ERROR: Container '%s' is not running.\n" "${_container_name}" >&2
+  if [[ -n "${INSTANCE}" ]]; then
+    printf "[exec] Start it first with './run.sh --instance %s'.\n" "${INSTANCE}" >&2
+  else
+    printf "[exec] Start it first with './run.sh' (or use './run.sh --instance NAME' for a parallel one).\n" >&2
+  fi
+  exit 1
+fi
 
 _compose_project exec "${TARGET}" "$@"

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -25,12 +25,13 @@ usage() {
   case "${_LANG}" in
     zh)
       cat >&2 <<'EOF'
-用法: ./run.sh [-h] [-d|--detach] [--no-env] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
+用法: ./run.sh [-h] [-d|--detach] [--no-env] [--dry-run] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 選項:
   -h, --help        顯示此說明
   -d, --detach      背景執行（docker compose up -d）
   --no-env          跳過 .env 重新產生
+  --dry-run         只印出將執行的 docker 指令，不實際執行
   --instance NAME   啟動命名 instance（與預設並行,suffix=-NAME）
   --lang LANG       設定訊息語言（預設: en）
 
@@ -41,12 +42,13 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./run.sh [-h] [-d|--detach] [--no-env] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
+用法: ./run.sh [-h] [-d|--detach] [--no-env] [--dry-run] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 选项:
   -h, --help        显示此说明
   -d, --detach      后台运行（docker compose up -d）
   --no-env          跳过 .env 重新生成
+  --dry-run         只打印将执行的 docker 命令，不实际执行
   --instance NAME   启动命名 instance（与默认并行,suffix=-NAME）
   --lang LANG       设置消息语言（默认: en）
 
@@ -57,12 +59,13 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./run.sh [-h] [-d|--detach] [--no-env] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
+使用法: ./run.sh [-h] [-d|--detach] [--no-env] [--dry-run] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 オプション:
   -h, --help        このヘルプを表示
   -d, --detach      バックグラウンドで実行（docker compose up -d）
   --no-env          .env の再生成をスキップ
+  --dry-run         実行される docker コマンドを表示するのみ（実行はしない）
   --instance NAME   名前付き instance を起動（デフォルトと並行、suffix=-NAME）
   --lang LANG       メッセージ言語を設定（デフォルト: en）
 
@@ -73,12 +76,13 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./run.sh [-h] [-d|--detach] [--no-env] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
+Usage: ./run.sh [-h] [-d|--detach] [--no-env] [--dry-run] [--instance NAME] [--lang <en|zh|zh-CN|ja>] [TARGET]
 
 Options:
   -h, --help        Show this help
   -d, --detach      Run in background (docker compose up -d)
   --no-env          Skip .env regeneration
+  --dry-run         Print the docker commands that would run, but do not execute
   --instance NAME   Start a named parallel instance (suffix=-NAME)
   --lang LANG       Set message language (default: en)
 
@@ -94,6 +98,7 @@ EOF
 # Parse arguments
 SKIP_ENV=false
 DETACH=false
+DRY_RUN=false
 TARGET="devel"
 INSTANCE=""
 
@@ -110,6 +115,10 @@ while [[ $# -gt 0 ]]; do
       SKIP_ENV=true
       shift
       ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
     --instance)
       INSTANCE="${2:?"--instance requires a value"}"
       shift 2
@@ -124,6 +133,7 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+export DRY_RUN
 
 # Generate / refresh .env
 if [[ "${SKIP_ENV}" == false ]]; then
@@ -147,7 +157,7 @@ CONTAINER_NAME="${IMAGE_NAME}${INSTANCE_SUFFIX}"
 # Refuse to start if the target container is already running and user did not
 # explicitly opt into a parallel instance via --instance.
 # (For -d mode, the existing `down` step handles restart, so collision is OK.)
-if [[ "${DETACH}" != true && "${TARGET}" == "devel" ]]; then
+if [[ "${DETACH}" != true && "${TARGET}" == "devel" && "${DRY_RUN}" != true ]]; then
   if docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
     printf "[run] ERROR: Container '%s' is already running.\n" "${CONTAINER_NAME}" >&2
     printf "[run] Either stop it with './stop.sh%s' or start a parallel instance with './run.sh --instance NAME'.\n" \

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -25,7 +25,7 @@ usage() {
   case "${_LANG}" in
     zh)
       cat >&2 <<'EOF'
-用法: ./stop.sh [-h] [--instance NAME] [--all]
+用法: ./stop.sh [-h] [--instance NAME] [--all] [--dry-run]
 
 停止並移除容器。預設只停止 default instance。
 
@@ -33,11 +33,12 @@ usage() {
   -h, --help        顯示此說明
   --instance NAME   只停止指定的命名 instance
   --all             停止所有 instance(預設 + 全部命名 instance)
+  --dry-run         只印出將執行的 docker 指令，不實際執行
 EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./stop.sh [-h] [--instance NAME] [--all]
+用法: ./stop.sh [-h] [--instance NAME] [--all] [--dry-run]
 
 停止并移除容器。默认只停止 default instance。
 
@@ -45,11 +46,12 @@ EOF
   -h, --help        显示此说明
   --instance NAME   只停止指定的命名 instance
   --all             停止所有 instance(默认 + 全部命名 instance)
+  --dry-run         只打印将执行的 docker 命令，不实际执行
 EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./stop.sh [-h] [--instance NAME] [--all]
+使用法: ./stop.sh [-h] [--instance NAME] [--all] [--dry-run]
 
 コンテナを停止・削除します。デフォルトは default instance のみ。
 
@@ -57,11 +59,12 @@ EOF
   -h, --help        このヘルプを表示
   --instance NAME   指定された名前付き instance のみ停止
   --all             すべての instance を停止（デフォルト + 全名前付き instance）
+  --dry-run         実行される docker コマンドを表示するのみ（実行はしない）
 EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./stop.sh [-h] [--instance NAME] [--all]
+Usage: ./stop.sh [-h] [--instance NAME] [--all] [--dry-run]
 
 Stop and remove containers. Default: stop only the default instance.
 
@@ -69,6 +72,7 @@ Options:
   -h, --help        Show this help
   --instance NAME   Stop only the named instance
   --all             Stop ALL instances (default + every named instance)
+  --dry-run         Print the docker commands that would run, but do not execute
 EOF
       ;;
   esac
@@ -77,6 +81,7 @@ EOF
 
 INSTANCE=""
 ALL_INSTANCES=false
+DRY_RUN=false
 PASSTHROUGH=()
 
 while [[ $# -gt 0 ]]; do
@@ -92,12 +97,17 @@ while [[ $# -gt 0 ]]; do
       ALL_INSTANCES=true
       shift
       ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
     *)
       PASSTHROUGH+=("$1")
       shift
       ;;
   esac
 done
+export DRY_RUN
 
 # Load .env so DOCKER_HUB_USER / IMAGE_NAME are available below.
 _load_env "${FILE_PATH}/.env"

--- a/test/unit/lib_spec.bats
+++ b/test/unit/lib_spec.bats
@@ -121,6 +121,17 @@ EOF
     assert_output --partial "--all"
 }
 
+@test "_compose without DRY_RUN tries to invoke docker compose (sanity)" {
+    # When DRY_RUN is unset/false, _compose calls real docker compose; on a
+    # CI runner without docker the command exits non-zero, but we just want
+    # to confirm the false branch executes (kcov coverage).
+    run bash -c "source ${LIB}; PATH=/nonexistent _compose version"
+    # Either docker compose ran (rc 0) or PATH lookup failed (rc 127);
+    # both are fine. We assert the script *attempted* the call by checking
+    # we did not see the dry-run prefix in output.
+    refute_output --partial "[dry-run]"
+}
+
 @test "_compose_project pre-fills -p / -f / --env-file from PROJECT_NAME and FILE_PATH" {
     run bash -c "
         source ${LIB}

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -340,6 +340,106 @@ setup() {
 }
 
 # ════════════════════════════════════════════════════════════════════
+# --dry-run flag (PR B)
+# ════════════════════════════════════════════════════════════════════
+
+@test "build.sh supports --dry-run flag" {
+    run grep -E '\-\-dry-run' /source/script/docker/build.sh
+    assert_success
+}
+
+@test "run.sh supports --dry-run flag" {
+    run grep -E '\-\-dry-run' /source/script/docker/run.sh
+    assert_success
+}
+
+@test "exec.sh supports --dry-run flag" {
+    run grep -E '\-\-dry-run' /source/script/docker/exec.sh
+    assert_success
+}
+
+@test "stop.sh supports --dry-run flag" {
+    run grep -E '\-\-dry-run' /source/script/docker/stop.sh
+    assert_success
+}
+
+@test "build.sh -h shows --dry-run in help" {
+    run bash -c "bash /source/script/docker/build.sh -h 2>&1"
+    assert_output --partial "--dry-run"
+}
+
+@test "run.sh -h shows --dry-run in help" {
+    run bash -c "bash /source/script/docker/run.sh -h 2>&1"
+    assert_output --partial "--dry-run"
+}
+
+@test "exec.sh -h shows --dry-run in help" {
+    run bash -c "bash /source/script/docker/exec.sh -h 2>&1"
+    assert_output --partial "--dry-run"
+}
+
+@test "stop.sh -h shows --dry-run in help" {
+    run bash -c "bash /source/script/docker/stop.sh -h 2>&1"
+    assert_output --partial "--dry-run"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# exec.sh container precheck (PR B)
+# ════════════════════════════════════════════════════════════════════
+
+@test "exec.sh checks container is running before exec" {
+    # Should reference docker ps / docker inspect or similar precheck
+    run grep -E 'docker (ps|inspect)' /source/script/docker/exec.sh
+    assert_success
+}
+
+@test "exec.sh precheck error mentions run.sh hint" {
+    # Friendly error pointing user at ./run.sh or --instance
+    run grep -E 'run\.sh|--instance' /source/script/docker/exec.sh
+    assert_success
+}
+
+@test "exec.sh exits non-zero with friendly hint when container not running" {
+    # Simulate a tmp repo with .env so exec.sh gets past _load_env, then call
+    # without docker on PATH so the precheck fails (no container can be found).
+    local _tmp
+    _tmp="$(mktemp -d)"
+    cat > "${_tmp}/.env" <<EOF
+DOCKER_HUB_USER=alice
+IMAGE_NAME=missing-image-$$
+EOF
+    mkdir -p "${_tmp}/template/script/docker"
+    cp /source/script/docker/_lib.sh "${_tmp}/template/script/docker/_lib.sh"
+    cp /source/script/docker/i18n.sh "${_tmp}/template/script/docker/i18n.sh" 2>/dev/null || true
+    cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
+
+    run bash "${_tmp}/exec.sh"
+    assert_failure
+    assert_output --partial "is not running"
+    assert_output --partial "run.sh"
+    rm -rf "${_tmp}"
+}
+
+@test "exec.sh --dry-run skips precheck and prints compose command" {
+    local _tmp
+    _tmp="$(mktemp -d)"
+    cat > "${_tmp}/.env" <<EOF
+DOCKER_HUB_USER=alice
+IMAGE_NAME=ghost-$$
+EOF
+    mkdir -p "${_tmp}/template/script/docker"
+    cp /source/script/docker/_lib.sh "${_tmp}/template/script/docker/_lib.sh"
+    cp /source/script/docker/i18n.sh "${_tmp}/template/script/docker/i18n.sh" 2>/dev/null || true
+    cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
+
+    run bash "${_tmp}/exec.sh" --dry-run
+    assert_success
+    assert_output --partial "[dry-run] docker compose"
+    assert_output --partial "exec"
+    rm -rf "${_tmp}"
+}
+
+# ════════════════════════════════════════════════════════════════════
 # i18n.sh shared module
 # ════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
Two debugging-friendliness improvements building on the `_lib.sh` refactor (#62):

### `--dry-run` (build/run/exec/stop)
When set, prints the `docker` / `docker compose` command that *would* run instead of executing it. Useful for validating `PROJECT_NAME`, `INSTANCE_SUFFIX`, env-file resolution, and compose flags without side effects.

```bash
$ ./run.sh --dry-run --instance dev2
[dry-run] docker compose -p alice-myrepo-dev2 -f /repo/compose.yaml --env-file /repo/.env up -d devel
[dry-run] docker compose -p alice-myrepo-dev2 -f /repo/compose.yaml --env-file /repo/.env exec devel bash
```

- `run.sh` additionally skips its "container already running" collision check under `--dry-run` (otherwise the check itself blocks dry-run).
- `build.sh` also gates the test-tools `docker build` call.

### `exec.sh` container precheck
Before invoking `compose exec`, verify the target container is in `docker ps`. If not, print a friendly error pointing the user at `./run.sh` (and `--instance NAME` when applicable) instead of letting compose emit `service "devel" is not running`.

```
$ ./exec.sh
[exec] ERROR: Container 'myrepo' is not running.
[exec] Start it first with './run.sh' (or use './run.sh --instance NAME' for a parallel one).
```

Skipped under `--dry-run`.

## Tests
233 → 246 (+13)
- +8 grep tests for `--dry-run` (presence in source + help text)
- +2 grep tests for precheck
- +2 e2e tests: precheck error in tmp repo, dry-run path
- +1 lib_spec sanity test for the non-DRY_RUN branch of `_compose`

## Style
Google Shell Style Guide. Help text updated in all 4 languages (en/zh/zh-CN/ja).

## Test plan
- [x] `make -f Makefile.ci test` 246/246 locally
- [ ] CI green
- [ ] integration-e2e green

🤖 Generated with [Claude Code](https://claude.com/claude-code)