### PR TITLE
fix: avoid 10s hang on ./run.sh exit (compose down -t 0)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.1] - 2026-04-10
+
+### Fixed
+- `run.sh` foreground devel: `./run.sh` appeared to hang for ~10s after the
+  user typed `exit` because the cleanup trap ran `compose down` with the
+  default 10s SIGTERM grace period. Pass `-t 0` so the already-exited
+  interactive container is killed immediately.
+
 ## [v0.7.0] - 2026-04-09
 
 ### Added

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **246 tests** total (225 unit + 21 integration).
+Template self-tests: **247 tests** total (226 unit + 21 integration).
 
 ## Test Files
 
@@ -87,7 +87,7 @@ Template self-tests: **246 tests** total (225 unit + 21 integration).
 | `main --lang zh sets Chinese messages` | --lang flag |
 | `main --lang requires a value` | Missing --lang value |
 
-### test/unit/template_spec.bats (96)
+### test/unit/template_spec.bats (97)
 
 | Test | Description |
 |------|-------------|
@@ -136,6 +136,7 @@ Template self-tests: **246 tests** total (225 unit + 21 integration).
 | `run.sh devel target uses compose up -d (not compose run --name)` | up + exec model |
 | `run.sh devel branch uses compose exec to enter shell` | up + exec model |
 | `run.sh devel branch installs trap to auto-down on exit` | Auto cleanup |
+| `run.sh _devel_cleanup uses short timeout to avoid 10s grace period` | Fast exit |
 | `run.sh non-devel TARGET still uses compose run --rm` | One-shot stages |
 | `run.sh devel branch does not use 'compose run --name'` | Old pattern gone |
 | `run.sh supports --instance flag` | --instance |

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -168,8 +168,12 @@ fi
 
 # _devel_cleanup tears down the project on shell exit so the container does
 # not outlive the foreground `./run.sh` session.
+#
+# `down -t 0` skips the default 10s SIGTERM grace period: the user already
+# exited the interactive bash, so there is nothing to drain gracefully —
+# without -t 0 the script appears to hang for ~10s after `exit`.
 _devel_cleanup() {
-  _compose_project down >/dev/null 2>&1 || true
+  _compose_project down -t 0 >/dev/null 2>&1 || true
 }
 
 if [[ "${DETACH}" == true ]]; then

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -260,6 +260,16 @@ setup() {
     assert_success
 }
 
+@test "run.sh _devel_cleanup uses short timeout to avoid 10s grace period" {
+    # Regression: compose down's default 10s SIGTERM grace makes ./run.sh
+    # appear to hang for ~10s after the user exits the bash shell. Interactive
+    # devel doesn't need graceful shutdown — the user already exited.
+    run grep -E '_devel_cleanup\(\)' /source/script/docker/run.sh
+    assert_success
+    run grep -E 'down -t 0|down --timeout 0' /source/script/docker/run.sh
+    assert_success
+}
+
 @test "run.sh non-devel TARGET still uses compose run --rm" {
     # test/runtime/etc one-shots stay on compose run --rm (no exec needed)
     run grep -E 'run --rm' /source/script/docker/run.sh


### PR DESCRIPTION
## Summary
After v0.6.6 switched foreground devel from \`compose run --rm\` to \`compose up -d\` + \`exec\`, the EXIT trap runs \`compose down\` to clean up. But \`compose down\` defaults to a **10s SIGTERM grace period per service**, so \`./run.sh\` appears to hang for ~10s after the user types \`exit\`.

The interactive bash has already exited — there is nothing to drain gracefully. Pass \`-t 0\` so the orphaned container is killed immediately.

User-reported regression in v0.7.0 (verified in env/ros2_humble after PR #30).

## Test plan
- [x] Regression test added: greps run.sh for \`down -t 0\`
- [x] Local: 247/247 tests pass
- [ ] CI green
- [ ] Manual: \`./run.sh\` then \`exit\` returns immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)