### PR TITLE
style: align template with Google Shell Style Guide

### DIFF
--- a/config/pip/setup.sh
+++ b/config/pip/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eux -o pipefail
+set -euo pipefail
 
 file_dir=$(dirname "$(readlink -f "${0}")")
 

--- a/config/shell/terminator/setup.sh
+++ b/config/shell/terminator/setup.sh
@@ -2,7 +2,7 @@
 
 # Only set strict mode when running directly
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
-  set -x -eu -o pipefail
+  set -euo pipefail
 fi
 
 check_deps() {

--- a/config/shell/tmux/setup.sh
+++ b/config/shell/tmux/setup.sh
@@ -2,7 +2,7 @@
 
 # Only set strict mode when running directly
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
-  set -x -eu -o pipefail
+  set -euo pipefail
 fi
 
 check_deps() {

--- a/init.sh
+++ b/init.sh
@@ -40,7 +40,9 @@ _create_symlinks() {
   _symlink "${TEMPLATE_REL}/script/docker/stop.sh" "stop.sh"
   _symlink "${TEMPLATE_REL}/script/docker/Makefile" "Makefile"
 
-  if [[ ! -f .hadolint.yaml ]] || diff -q .hadolint.yaml "${TEMPLATE_REL}/.hadolint.yaml" >/dev/null 2>&1; then
+  if [[ ! -f .hadolint.yaml ]] \
+    || diff -q .hadolint.yaml "${TEMPLATE_REL}/.hadolint.yaml" \
+      >/dev/null 2>&1; then
     _symlink "${TEMPLATE_REL}/.hadolint.yaml" ".hadolint.yaml"
   else
     _log "  Keeping custom .hadolint.yaml (differs from template)"

--- a/script/ci/ci.sh
+++ b/script/ci/ci.sh
@@ -77,10 +77,23 @@ _run_tests() {
 # ── Kcov coverage ────────────────────────────────────────────────────────────
 
 _run_coverage() {
+  local _excludes=(
+    "${REPO_ROOT}/test/"
+    "${REPO_ROOT}/script/ci/"
+    "${REPO_ROOT}/init.sh"
+    "${REPO_ROOT}/upgrade.sh"
+    "${REPO_ROOT}/config/shell/bashrc"
+    "${REPO_ROOT}/config/shell/terminator/config"
+    "${REPO_ROOT}/config/shell/tmux/tmux.conf"
+    "${REPO_ROOT}/.github/"
+  )
+  local _exclude_path
+  _exclude_path="$(IFS=,; printf '%s' "${_excludes[*]}")"
+
   echo "--- Running Tests with Kcov Coverage ---"
   kcov \
     --include-path="${REPO_ROOT}" \
-    --exclude-path="${REPO_ROOT}/test/,${REPO_ROOT}/script/ci/,${REPO_ROOT}/init.sh,${REPO_ROOT}/upgrade.sh,${REPO_ROOT}/config/shell/bashrc,${REPO_ROOT}/config/shell/terminator/config,${REPO_ROOT}/config/shell/tmux/tmux.conf,${REPO_ROOT}/.github/" \
+    --exclude-path="${_exclude_path}" \
     "${REPO_ROOT}/coverage" \
     bats "${REPO_ROOT}/test/unit/" "${REPO_ROOT}/test/integration/"
 }

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -101,74 +101,83 @@ EOF
   exit 0
 }
 
-SKIP_ENV=false
-NO_CACHE=false
-CLEAN_TOOLS=false
-DRY_RUN=false
-TARGET="devel"
+main() {
+  local SKIP_ENV=false
+  local NO_CACHE=false
+  local CLEAN_TOOLS=false
+  local TARGET="devel"
+  DRY_RUN=false
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -h|--help)
-      usage
-      ;;
-    --no-env)
-      SKIP_ENV=true
-      shift
-      ;;
-    --no-cache)
-      NO_CACHE=true
-      shift
-      ;;
-    --clean-tools)
-      CLEAN_TOOLS=true
-      shift
-      ;;
-    --dry-run)
-      DRY_RUN=true
-      shift
-      ;;
-    --lang)
-      _LANG="${2:?"--lang requires a value (en|zh|zh-CN|ja)"}"
-      shift 2
-      ;;
-    *)
-      TARGET="$1"
-      shift
-      ;;
-  esac
-done
-export DRY_RUN
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        usage
+        ;;
+      --no-env)
+        SKIP_ENV=true
+        shift
+        ;;
+      --no-cache)
+        NO_CACHE=true
+        shift
+        ;;
+      --clean-tools)
+        CLEAN_TOOLS=true
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --lang)
+        _LANG="${2:?"--lang requires a value (en|zh|zh-CN|ja)"}"
+        shift 2
+        ;;
+      *)
+        TARGET="$1"
+        shift
+        ;;
+    esac
+  done
+  export DRY_RUN
 
-# Generate / refresh .env
-if [[ "${SKIP_ENV}" == false ]]; then
-  "${FILE_PATH}/template/script/docker/setup.sh" --base-path "${FILE_PATH}" --lang "${_LANG}"
-fi
-
-# Load .env for project name
-_load_env "${FILE_PATH}/.env"
-_compute_project_name ""
-
-# Build test-tools image if Dockerfile exists
-_tools_dockerfile="${FILE_PATH}/template/dockerfile/Dockerfile.test-tools"
-_tools_args=()
-[[ "${NO_CACHE}" == true ]] && _tools_args+=(--no-cache)
-if [[ -f "${_tools_dockerfile}" ]]; then
-  if [[ "${DRY_RUN}" == true ]]; then
-    printf '[dry-run] docker build'
-    printf ' %q' "${_tools_args[@]}" -t test-tools:local -f "${_tools_dockerfile}" "${FILE_PATH}" -q
-    printf '\n'
-  else
-    docker build "${_tools_args[@]}" -t test-tools:local -f "${_tools_dockerfile}" "${FILE_PATH}" -q >/dev/null
+  # Generate / refresh .env
+  if [[ "${SKIP_ENV}" == false ]]; then
+    "${FILE_PATH}/template/script/docker/setup.sh" \
+      --base-path "${FILE_PATH}" --lang "${_LANG}"
   fi
-fi
 
-if [[ "${CLEAN_TOOLS}" == true ]]; then
-  _cleanup() { docker rmi test-tools:local 2>/dev/null || true; }
-  trap _cleanup EXIT
-fi
+  # Load .env for project name
+  _load_env "${FILE_PATH}/.env"
+  _compute_project_name ""
 
-_compose_args=()
-[[ "${NO_CACHE}" == true ]] && _compose_args+=(--no-cache)
+  # Build test-tools image if Dockerfile exists
+  local _tools_dockerfile="${FILE_PATH}/template/dockerfile/Dockerfile.test-tools"
+  local _tools_args=()
+  [[ "${NO_CACHE}" == true ]] && _tools_args+=(--no-cache)
+  if [[ -f "${_tools_dockerfile}" ]]; then
+    if [[ "${DRY_RUN}" == true ]]; then
+      printf '[dry-run] docker build'
+      printf ' %q' "${_tools_args[@]}" -t test-tools:local \
+        -f "${_tools_dockerfile}" "${FILE_PATH}" -q
+      printf '\n'
+    else
+      docker build "${_tools_args[@]}" \
+        -t test-tools:local \
+        -f "${_tools_dockerfile}" \
+        "${FILE_PATH}" -q >/dev/null
+    fi
+  fi
 
-_compose_project build "${_compose_args[@]}" "${TARGET}"
+  if [[ "${CLEAN_TOOLS}" == true ]]; then
+    _cleanup() { docker rmi test-tools:local 2>/dev/null || true; }
+    trap _cleanup EXIT
+  fi
+
+  local _compose_args=()
+  [[ "${NO_CACHE}" == true ]] && _compose_args+=(--no-cache)
+
+  _compose_project build "${_compose_args[@]}" "${TARGET}"
+}
+
+main "$@"

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -107,56 +107,62 @@ EOF
   exit 0
 }
 
-TARGET="devel"
-INSTANCE=""
-DRY_RUN=false
+main() {
+  local TARGET="devel"
+  local INSTANCE=""
+  DRY_RUN=false
 
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -h|--help)
-      usage
-      ;;
-    -t|--target)
-      TARGET="${2:?"--target requires a value"}"
-      shift 2
-      ;;
-    --instance)
-      INSTANCE="${2:?"--instance requires a value"}"
-      shift 2
-      ;;
-    --dry-run)
-      DRY_RUN=true
-      shift
-      ;;
-    *)
-      break
-      ;;
-  esac
-done
-export DRY_RUN
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        usage
+        ;;
+      -t|--target)
+        TARGET="${2:?"--target requires a value"}"
+        shift 2
+        ;;
+      --instance)
+        INSTANCE="${2:?"--instance requires a value"}"
+        shift 2
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+  export DRY_RUN
 
-# Default to bash when no command is supplied. Using an array preserves
-# arguments containing whitespace, unlike the previous `${CMD}` splitting.
-if [[ $# -eq 0 ]]; then
-  set -- bash
-fi
-
-# Load .env, derive PROJECT_NAME (sets/exports INSTANCE_SUFFIX too).
-_load_env "${FILE_PATH}/.env"
-_compute_project_name "${INSTANCE}"
-
-# Precheck: refuse with a friendly hint if the target container is not running.
-# Skipped under --dry-run since the user is asking what *would* run.
-_container_name="${IMAGE_NAME}${INSTANCE_SUFFIX}"
-if [[ "${DRY_RUN}" != true ]] \
-   && ! docker ps --format '{{.Names}}' | grep -qx "${_container_name}"; then
-  printf "[exec] ERROR: Container '%s' is not running.\n" "${_container_name}" >&2
-  if [[ -n "${INSTANCE}" ]]; then
-    printf "[exec] Start it first with './run.sh --instance %s'.\n" "${INSTANCE}" >&2
-  else
-    printf "[exec] Start it first with './run.sh' (or use './run.sh --instance NAME' for a parallel one).\n" >&2
+  # Default to bash when no command is supplied. Using an array preserves
+  # arguments containing whitespace, unlike the previous `${CMD}` splitting.
+  if [[ $# -eq 0 ]]; then
+    set -- bash
   fi
-  exit 1
-fi
 
-_compose_project exec "${TARGET}" "$@"
+  # Load .env, derive PROJECT_NAME (sets/exports INSTANCE_SUFFIX too).
+  _load_env "${FILE_PATH}/.env"
+  _compute_project_name "${INSTANCE}"
+
+  # Precheck: refuse with a friendly hint if the target container is not
+  # running. Skipped under --dry-run since the user is asking what *would* run.
+  local _container_name="${IMAGE_NAME}${INSTANCE_SUFFIX}"
+  if [[ "${DRY_RUN}" != true ]] \
+      && ! docker ps --format '{{.Names}}' | grep -qx "${_container_name}"; then
+    printf "[exec] ERROR: Container '%s' is not running.\n" \
+      "${_container_name}" >&2
+    if [[ -n "${INSTANCE}" ]]; then
+      printf "[exec] Start it first with './run.sh --instance %s'.\n" \
+        "${INSTANCE}" >&2
+    else
+      printf "[exec] Start it first with './run.sh' (or use './run.sh --instance NAME' for a parallel one).\n" >&2
+    fi
+    exit 1
+  fi
+
+  _compose_project exec "${TARGET}" "$@"
+}
+
+main "$@"

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -113,7 +113,7 @@ main() {
   DRY_RUN=false
 
   while [[ $# -gt 0 ]]; do
-  case "$1" in
+    case "$1" in
       -h|--help)
         usage
         ;;

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -95,77 +95,6 @@ EOF
   exit 0
 }
 
-# Parse arguments
-SKIP_ENV=false
-DETACH=false
-DRY_RUN=false
-TARGET="devel"
-INSTANCE=""
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -h|--help)
-      usage
-      ;;
-    -d|--detach)
-      DETACH=true
-      shift
-      ;;
-    --no-env)
-      SKIP_ENV=true
-      shift
-      ;;
-    --dry-run)
-      DRY_RUN=true
-      shift
-      ;;
-    --instance)
-      INSTANCE="${2:?"--instance requires a value"}"
-      shift 2
-      ;;
-    --lang)
-      _LANG="${2:?"--lang requires a value (en|zh|zh-CN|ja)"}"
-      shift 2
-      ;;
-    *)
-      TARGET="$1"
-      shift
-      ;;
-  esac
-done
-export DRY_RUN
-
-# Generate / refresh .env
-if [[ "${SKIP_ENV}" == false ]]; then
-  "${FILE_PATH}/template/script/docker/setup.sh" --base-path "${FILE_PATH}" --lang "${_LANG}"
-fi
-
-# Load .env, derive PROJECT_NAME (sets/exports INSTANCE_SUFFIX too).
-_load_env "${FILE_PATH}/.env"
-_compute_project_name "${INSTANCE}"
-
-# Allow X11 forwarding (X11 or XWayland)
-if [[ "${XDG_SESSION_TYPE:-x11}" == "wayland" ]]; then
-  xhost "+SI:localuser:${USER_NAME}" >/dev/null 2>&1 || true
-else
-  xhost +local: >/dev/null 2>&1 || true
-fi
-
-# Container name mirrors compose.yaml's `container_name:`.
-CONTAINER_NAME="${IMAGE_NAME}${INSTANCE_SUFFIX}"
-
-# Refuse to start if the target container is already running and user did not
-# explicitly opt into a parallel instance via --instance.
-# (For -d mode, the existing `down` step handles restart, so collision is OK.)
-if [[ "${DETACH}" != true && "${TARGET}" == "devel" && "${DRY_RUN}" != true ]]; then
-  if docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
-    printf "[run] ERROR: Container '%s' is already running.\n" "${CONTAINER_NAME}" >&2
-    printf "[run] Either stop it with './stop.sh%s' or start a parallel instance with './run.sh --instance NAME'.\n" \
-      "$([[ -n "${INSTANCE}" ]] && printf ' --instance %s' "${INSTANCE}")" >&2
-    exit 1
-  fi
-fi
-
 # _devel_cleanup tears down the project on shell exit so the container does
 # not outlive the foreground `./run.sh` session.
 #
@@ -176,17 +105,95 @@ _devel_cleanup() {
   _compose_project down -t 0 >/dev/null 2>&1 || true
 }
 
-if [[ "${DETACH}" == true ]]; then
-  _compose_project down 2>/dev/null || true
-  _compose_project up -d "${TARGET}"
-elif [[ "${TARGET}" == "devel" ]]; then
-  # Foreground devel: `up -d` + `exec` so a second terminal can join via
-  # `./exec.sh`. Trap auto-`down` on exit to preserve the
-  # "exit shell = container gone" semantic of the previous `compose run`.
-  trap _devel_cleanup EXIT
-  _compose_project up -d "${TARGET}"
-  _compose_project exec "${TARGET}" bash
-else
-  # Other one-shot stages (test, runtime, ...): keep `compose run --rm`.
-  _compose_project run --rm "${TARGET}"
-fi
+main() {
+  local SKIP_ENV=false
+  local DETACH=false
+  local TARGET="devel"
+  local INSTANCE=""
+  DRY_RUN=false
+
+  while [[ $# -gt 0 ]]; do
+  case "$1" in
+      -h|--help)
+        usage
+        ;;
+      -d|--detach)
+        DETACH=true
+        shift
+        ;;
+      --no-env)
+        SKIP_ENV=true
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --instance)
+        INSTANCE="${2:?"--instance requires a value"}"
+        shift 2
+        ;;
+      --lang)
+        _LANG="${2:?"--lang requires a value (en|zh|zh-CN|ja)"}"
+        shift 2
+        ;;
+      *)
+        TARGET="$1"
+        shift
+        ;;
+    esac
+  done
+  export DRY_RUN
+
+  # Generate / refresh .env
+  if [[ "${SKIP_ENV}" == false ]]; then
+    "${FILE_PATH}/template/script/docker/setup.sh" \
+      --base-path "${FILE_PATH}" --lang "${_LANG}"
+  fi
+
+  # Load .env, derive PROJECT_NAME (sets/exports INSTANCE_SUFFIX too).
+  _load_env "${FILE_PATH}/.env"
+  _compute_project_name "${INSTANCE}"
+
+  # Allow X11 forwarding (X11 or XWayland)
+  if [[ "${XDG_SESSION_TYPE:-x11}" == "wayland" ]]; then
+    xhost "+SI:localuser:${USER_NAME}" >/dev/null 2>&1 || true
+  else
+    xhost +local: >/dev/null 2>&1 || true
+  fi
+
+  # Container name mirrors compose.yaml's `container_name:`.
+  local CONTAINER_NAME="${IMAGE_NAME}${INSTANCE_SUFFIX}"
+
+  # Refuse to start if the target container is already running and user did
+  # not explicitly opt into a parallel instance via --instance.
+  # (For -d mode, the existing `down` step handles restart, so collision is OK.)
+  if [[ "${DETACH}" != true && "${TARGET}" == "devel" \
+      && "${DRY_RUN}" != true ]]; then
+    if docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+      printf "[run] ERROR: Container '%s' is already running.\n" \
+        "${CONTAINER_NAME}" >&2
+      printf "[run] Either stop it with './stop.sh%s'\n" \
+        "$([[ -n "${INSTANCE}" ]] && printf ' --instance %s' "${INSTANCE}")" >&2
+      printf "[run] or start a parallel instance with './run.sh --instance NAME'.\n" >&2
+      exit 1
+    fi
+  fi
+
+  if [[ "${DETACH}" == true ]]; then
+    _compose_project down 2>/dev/null || true
+    _compose_project up -d "${TARGET}"
+  elif [[ "${TARGET}" == "devel" ]]; then
+    # Foreground devel: `up -d` + `exec` so a second terminal can join via
+    # `./exec.sh`. Trap auto-`down` on exit to preserve the
+    # "exit shell = container gone" semantic of the previous `compose run`.
+    trap _devel_cleanup EXIT
+    _compose_project up -d "${TARGET}"
+    _compose_project exec "${TARGET}" bash
+  else
+    # Other one-shot stages (test, runtime, ...): keep `compose run --rm`.
+    _compose_project run --rm "${TARGET}"
+  fi
+}
+
+main "$@"

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -79,38 +79,7 @@ EOF
   exit 0
 }
 
-INSTANCE=""
-ALL_INSTANCES=false
-DRY_RUN=false
 PASSTHROUGH=()
-
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    -h|--help)
-      usage
-      ;;
-    --instance)
-      INSTANCE="${2:?"--instance requires a value"}"
-      shift 2
-      ;;
-    --all)
-      ALL_INSTANCES=true
-      shift
-      ;;
-    --dry-run)
-      DRY_RUN=true
-      shift
-      ;;
-    *)
-      PASSTHROUGH+=("$1")
-      shift
-      ;;
-  esac
-done
-export DRY_RUN
-
-# Load .env so DOCKER_HUB_USER / IMAGE_NAME are available below.
-_load_env "${FILE_PATH}/.env"
 
 # _down_one tears down a single instance. _compute_project_name sets and
 # exports INSTANCE_SUFFIX so compose.yaml resolves the matching container_name.
@@ -123,24 +92,62 @@ _down_one() {
   _compose_project down "${PASSTHROUGH[@]}"
 }
 
-if [[ "${ALL_INSTANCES}" == true ]]; then
-  # Find all docker compose projects whose name starts with our prefix.
-  _prefix="${DOCKER_HUB_USER}-${IMAGE_NAME}"
-  mapfile -t _projects < <(
-    docker ps -a --format '{{.Label "com.docker.compose.project"}}' \
-      | sort -u | grep -E "^${_prefix}(\$|-)" || true
-  )
-  if [[ ${#_projects[@]} -eq 0 ]]; then
-    printf "[stop] No instances found for %s\n" "${IMAGE_NAME}" >&2
-    exit 0
-  fi
-  for _proj in "${_projects[@]}"; do
-    _suffix="${_proj#"${_prefix}"}"
-    # _suffix is "" or "-name"; _down_one expects bare instance, strip the dash.
-    _down_one "${_suffix#-}"
+main() {
+  local INSTANCE=""
+  local ALL_INSTANCES=false
+  DRY_RUN=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        usage
+        ;;
+      --instance)
+        INSTANCE="${2:?"--instance requires a value"}"
+        shift 2
+        ;;
+      --all)
+        ALL_INSTANCES=true
+        shift
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      *)
+        PASSTHROUGH+=("$1")
+        shift
+        ;;
+    esac
   done
-elif [[ -n "${INSTANCE}" ]]; then
-  _down_one "${INSTANCE}"
-else
-  _down_one ""
-fi
+  export DRY_RUN
+
+  # Load .env so DOCKER_HUB_USER / IMAGE_NAME are available below.
+  _load_env "${FILE_PATH}/.env"
+
+  if [[ "${ALL_INSTANCES}" == true ]]; then
+    # Find all docker compose projects whose name starts with our prefix.
+    local _prefix="${DOCKER_HUB_USER}-${IMAGE_NAME}"
+    local _projects
+    mapfile -t _projects < <(
+      docker ps -a --format '{{.Label "com.docker.compose.project"}}' \
+        | sort -u | grep -E "^${_prefix}(\$|-)" || true
+    )
+    if [[ ${#_projects[@]} -eq 0 ]]; then
+      printf "[stop] No instances found for %s\n" "${IMAGE_NAME}" >&2
+      exit 0
+    fi
+    local _proj _suffix
+    for _proj in "${_projects[@]}"; do
+      _suffix="${_proj#"${_prefix}"}"
+      # _suffix is "" or "-name"; _down_one expects bare instance, strip dash.
+      _down_one "${_suffix#-}"
+    done
+  elif [[ -n "${INSTANCE}" ]]; then
+    _down_one "${INSTANCE}"
+  else
+    _down_one ""
+  fi
+}
+
+main "$@"

--- a/test/integration/init_new_repo_spec.bats
+++ b/test/integration/init_new_repo_spec.bats
@@ -11,24 +11,24 @@
 # separate self-test.yaml job that has access to the host Docker daemon.
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/../unit/test_helper"
+  load "${BATS_TEST_DIRNAME}/../unit/test_helper"
 
-    # Stage a fake repo dir whose basename will become IMAGE_NAME
-    REPO_NAME="myapp_test"
-    TMP_ROOT="$(mktemp -d)"
-    REPO_DIR="${TMP_ROOT}/${REPO_NAME}"
-    mkdir -p "${REPO_DIR}/template"
+  # Stage a fake repo dir whose basename will become IMAGE_NAME
+  REPO_NAME="myapp_test"
+  TMP_ROOT="$(mktemp -d)"
+  REPO_DIR="${TMP_ROOT}/${REPO_NAME}"
+  mkdir -p "${REPO_DIR}/template"
 
-    # Mirror the template into REPO_DIR/template/ so init.sh's TEMPLATE_DIR
-    # detection (../template relative to itself) works correctly. Use cp -a
-    # to preserve executable bits and symlinks.
-    cp -a /source/. "${REPO_DIR}/template/"
+  # Mirror the template into REPO_DIR/template/ so init.sh's TEMPLATE_DIR
+  # detection (../template relative to itself) works correctly. Use cp -a
+  # to preserve executable bits and symlinks.
+  cp -a /source/. "${REPO_DIR}/template/"
 
-    cd "${REPO_DIR}"
+  cd "${REPO_DIR}"
 }
 
 teardown() {
-    rm -rf "${TMP_ROOT}"
+  rm -rf "${TMP_ROOT}"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -36,130 +36,130 @@ teardown() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "init.sh detects empty dir and creates new repo skeleton" {
-    run bash template/init.sh
-    assert_success
-    assert_output --partial "Done"
+  run bash template/init.sh
+  assert_success
+  assert_output --partial "Done"
 }
 
 @test "new repo: Dockerfile is copied from template" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/Dockerfile" ]
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/Dockerfile" ]
 }
 
 @test "new repo: compose.yaml exists and references the repo name" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/compose.yaml" ]
-    run grep "${REPO_NAME}" "${REPO_DIR}/compose.yaml"
-    assert_success
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/compose.yaml" ]
+  run grep "${REPO_NAME}" "${REPO_DIR}/compose.yaml"
+  assert_success
 }
 
 @test "new repo: .env.example contains IMAGE_NAME=<reponame>" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/.env.example" ]
-    run grep "IMAGE_NAME=${REPO_NAME}" "${REPO_DIR}/.env.example"
-    assert_success
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/.env.example" ]
+  run grep "IMAGE_NAME=${REPO_NAME}" "${REPO_DIR}/.env.example"
+  assert_success
 }
 
 @test "new repo: script/entrypoint.sh exists and is executable" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/script/entrypoint.sh" ]
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/script/entrypoint.sh" ]
 }
 
 @test "new repo: smoke test skeleton exists for the repo" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/test/smoke/${REPO_NAME}_env.bats" ]
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/test/smoke/${REPO_NAME}_env.bats" ]
 }
 
 @test "new repo: .github/workflows/main.yaml exists with reusable workflow ref" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/.github/workflows/main.yaml" ]
-    run grep -E 'build-worker\.yaml@v' "${REPO_DIR}/.github/workflows/main.yaml"
-    assert_success
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/.github/workflows/main.yaml" ]
+  run grep -E 'build-worker\.yaml@v' "${REPO_DIR}/.github/workflows/main.yaml"
+  assert_success
 }
 
 @test "new repo: .gitignore exists" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/.gitignore" ]
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/.gitignore" ]
 }
 
 @test "new repo: doc/ tree exists with README translations" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/README.md" ]
-    assert [ -f "${REPO_DIR}/doc/README.zh-TW.md" ]
-    assert [ -f "${REPO_DIR}/doc/README.zh-CN.md" ]
-    assert [ -f "${REPO_DIR}/doc/README.ja.md" ]
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/README.md" ]
+  assert [ -f "${REPO_DIR}/doc/README.zh-TW.md" ]
+  assert [ -f "${REPO_DIR}/doc/README.zh-CN.md" ]
+  assert [ -f "${REPO_DIR}/doc/README.ja.md" ]
 }
 
 @test "new repo: doc/test/TEST.md exists" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/doc/test/TEST.md" ]
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/doc/test/TEST.md" ]
 }
 
 @test "new repo: doc/changelog/CHANGELOG.md exists" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/doc/changelog/CHANGELOG.md" ]
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/doc/changelog/CHANGELOG.md" ]
 }
 
 @test "new repo: build.sh symlink → template/script/docker/build.sh" {
-    bash template/init.sh
-    assert [ -L "${REPO_DIR}/build.sh" ]
-    run readlink "${REPO_DIR}/build.sh"
-    assert_output "template/script/docker/build.sh"
+  bash template/init.sh
+  assert [ -L "${REPO_DIR}/build.sh" ]
+  run readlink "${REPO_DIR}/build.sh"
+  assert_output "template/script/docker/build.sh"
 }
 
 @test "new repo: run.sh / exec.sh / stop.sh / Makefile symlinks correct" {
-    bash template/init.sh
-    for f in run.sh exec.sh stop.sh Makefile; do
-        assert [ -L "${REPO_DIR}/${f}" ]
-    done
-    run readlink "${REPO_DIR}/run.sh"
-    assert_output "template/script/docker/run.sh"
-    run readlink "${REPO_DIR}/exec.sh"
-    assert_output "template/script/docker/exec.sh"
-    run readlink "${REPO_DIR}/stop.sh"
-    assert_output "template/script/docker/stop.sh"
-    run readlink "${REPO_DIR}/Makefile"
-    assert_output "template/script/docker/Makefile"
+  bash template/init.sh
+  for f in run.sh exec.sh stop.sh Makefile; do
+    assert [ -L "${REPO_DIR}/${f}" ]
+  done
+  run readlink "${REPO_DIR}/run.sh"
+  assert_output "template/script/docker/run.sh"
+  run readlink "${REPO_DIR}/exec.sh"
+  assert_output "template/script/docker/exec.sh"
+  run readlink "${REPO_DIR}/stop.sh"
+  assert_output "template/script/docker/stop.sh"
+  run readlink "${REPO_DIR}/Makefile"
+  assert_output "template/script/docker/Makefile"
 }
 
 @test "new repo: .template_version exists and matches a known tag format" {
-    bash template/init.sh
-    assert [ -f "${REPO_DIR}/.template_version" ]
-    run cat "${REPO_DIR}/.template_version"
-    # Should be vX.Y.Z, "unknown", or "main"
-    assert_output --regexp '^(v[0-9]+\.[0-9]+\.[0-9]+|unknown|main)$'
+  bash template/init.sh
+  assert [ -f "${REPO_DIR}/.template_version" ]
+  run cat "${REPO_DIR}/.template_version"
+  # Should be vX.Y.Z, "unknown", or "main"
+  assert_output --regexp '^(v[0-9]+\.[0-9]+\.[0-9]+|unknown|main)$'
 }
 
 @test "new repo: re-running init.sh on the result is idempotent" {
-    bash template/init.sh
-    # Second run should hit _init_existing_repo (Dockerfile exists)
-    run bash template/init.sh
-    assert_success
+  bash template/init.sh
+  # Second run should hit _init_existing_repo (Dockerfile exists)
+  run bash template/init.sh
+  assert_success
 }
 
 @test "new repo: build.sh -h works against the generated symlink" {
-    bash template/init.sh
-    run bash "${REPO_DIR}/build.sh" -h
-    assert_success
-    assert_output --partial "Usage"
+  bash template/init.sh
+  run bash "${REPO_DIR}/build.sh" -h
+  assert_success
+  assert_output --partial "Usage"
 }
 
 @test "new repo: run.sh -h works against the generated symlink" {
-    bash template/init.sh
-    run bash "${REPO_DIR}/run.sh" -h
-    assert_success
+  bash template/init.sh
+  run bash "${REPO_DIR}/run.sh" -h
+  assert_success
 }
 
 @test "new repo: exec.sh -h works against the generated symlink" {
-    bash template/init.sh
-    run bash "${REPO_DIR}/exec.sh" -h
-    assert_success
+  bash template/init.sh
+  run bash "${REPO_DIR}/exec.sh" -h
+  assert_success
 }
 
 @test "new repo: stop.sh -h works against the generated symlink" {
-    bash template/init.sh
-    run bash "${REPO_DIR}/stop.sh" -h
-    assert_success
+  bash template/init.sh
+  run bash "${REPO_DIR}/stop.sh" -h
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -167,15 +167,15 @@ teardown() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "init.sh --gen-image-conf copies image_name.conf to repo root" {
-    bash template/init.sh        # generate skeleton first
-    bash template/init.sh --gen-image-conf
-    assert [ -f "${REPO_DIR}/image_name.conf" ]
+  bash template/init.sh        # generate skeleton first
+  bash template/init.sh --gen-image-conf
+  assert [ -f "${REPO_DIR}/image_name.conf" ]
 }
 
 @test "init.sh --gen-image-conf refuses to overwrite existing image_name.conf" {
-    bash template/init.sh
-    bash template/init.sh --gen-image-conf
-    run bash template/init.sh --gen-image-conf
-    assert_failure
-    assert_output --partial "already exists"
+  bash template/init.sh
+  bash template/init.sh --gen-image-conf
+  run bash template/init.sh --gen-image-conf
+  assert_failure
+  assert_output --partial "already exists"
 }

--- a/test/smoke/display_env.bats
+++ b/test/smoke/display_env.bats
@@ -1,144 +1,144 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
+  load "${BATS_TEST_DIRNAME}/test_helper"
 
-    # Detect GUI support: check if compose.yaml has display-related config
-    if [[ -f /lint/compose.yaml ]] && grep -q "WAYLAND_DISPLAY" /lint/compose.yaml 2>/dev/null; then
-        HAS_GUI=true
-    else
-        HAS_GUI=false
-    fi
+  # Detect GUI support: check if compose.yaml has display-related config
+  if [[ -f /lint/compose.yaml ]] && grep -q "WAYLAND_DISPLAY" /lint/compose.yaml 2>/dev/null; then
+    HAS_GUI=true
+  else
+    HAS_GUI=false
+  fi
 }
 
 # -------------------- compose.yaml: Wayland env vars --------------------
 
 @test "compose.yaml contains WAYLAND_DISPLAY env" {
-    [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
-    run grep "WAYLAND_DISPLAY" /lint/compose.yaml
-    assert_success
+  [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
+  run grep "WAYLAND_DISPLAY" /lint/compose.yaml
+  assert_success
 }
 
 @test "compose.yaml contains XDG_RUNTIME_DIR env" {
-    [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
-    run grep "XDG_RUNTIME_DIR" /lint/compose.yaml
-    assert_success
+  [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
+  run grep "XDG_RUNTIME_DIR" /lint/compose.yaml
+  assert_success
 }
 
 @test "compose.yaml contains XAUTHORITY env" {
-    [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
-    run grep "XAUTHORITY" /lint/compose.yaml
-    assert_success
+  [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
+  run grep "XAUTHORITY" /lint/compose.yaml
+  assert_success
 }
 
 # -------------------- compose.yaml: display mounts --------------------
 
 @test "compose.yaml mounts XDG_RUNTIME_DIR as rw" {
-    [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
-    run grep -E 'XDG_RUNTIME_DIR.*:.*XDG_RUNTIME_DIR.*:rw' /lint/compose.yaml
-    assert_success
+  [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
+  run grep -E 'XDG_RUNTIME_DIR.*:.*XDG_RUNTIME_DIR.*:rw' /lint/compose.yaml
+  assert_success
 }
 
 @test "compose.yaml mounts XAUTHORITY volume" {
-    [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
-    run grep -E 'XAUTHORITY.*:.*XAUTHORITY' /lint/compose.yaml
-    assert_success
+  [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
+  run grep -E 'XAUTHORITY.*:.*XAUTHORITY' /lint/compose.yaml
+  assert_success
 }
 
 @test "compose.yaml has no consecutive duplicate keys" {
-    [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
-    # Adjacent duplicate keys like two tmpfs: blocks = YAML error in docker compose
-    run bash -c "awk '/^ {4}[a-z]/{key=\$0} /^ {4}[a-z]/ && key==prev{print NR\": duplicate: \"\$0; found=1} {prev=key} END{exit found?1:0}' /lint/compose.yaml"
-    assert_success
+  [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
+  # Adjacent duplicate keys like two tmpfs: blocks = YAML error in docker compose
+  run bash -c "awk '/^ {4}[a-z]/{key=\$0} /^ {4}[a-z]/ && key==prev{print NR\": duplicate: \"\$0; found=1} {prev=key} END{exit found?1:0}' /lint/compose.yaml"
+  assert_success
 }
 
 @test "compose.yaml mounts X11-unix volume" {
-    [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
-    run grep "/tmp/.X11-unix" /lint/compose.yaml
-    assert_success
+  [[ "${HAS_GUI}" == false ]] && skip "No GUI config in compose.yaml"
+  run grep "/tmp/.X11-unix" /lint/compose.yaml
+  assert_success
 }
 
 # -------------------- run.sh: xhost branching --------------------
 
 @test "run.sh contains XDG_SESSION_TYPE check" {
-    run grep "XDG_SESSION_TYPE" /lint/run.sh
-    assert_success
+  run grep "XDG_SESSION_TYPE" /lint/run.sh
+  assert_success
 }
 
 @test "run.sh calls xhost +SI:localuser on wayland" {
-    local mock_dir="${BATS_TEST_TMPDIR}/bin"
-    local log="${BATS_TEST_TMPDIR}/xhost.log"
-    mkdir -p "${mock_dir}"
-    cat > "${mock_dir}/xhost" <<MOCK
+  local mock_dir="${BATS_TEST_TMPDIR}/bin"
+  local log="${BATS_TEST_TMPDIR}/xhost.log"
+  mkdir -p "${mock_dir}"
+  cat > "${mock_dir}/xhost" <<MOCK
 #!/bin/bash
 echo "\$*" >> "${log}"
 MOCK
-    chmod +x "${mock_dir}/xhost"
+  chmod +x "${mock_dir}/xhost"
 
-    env PATH="${mock_dir}:${PATH}" \
-        XDG_SESSION_TYPE=wayland \
-        USER_NAME=testuser \
-        bash -c '
-            if [[ "${XDG_SESSION_TYPE:-x11}" == "wayland" ]]; then
-                xhost "+SI:localuser:${USER_NAME}" >/dev/null 2>&1 || true
-            else
-                xhost +local: >/dev/null 2>&1 || true
-            fi
-        '
+  env PATH="${mock_dir}:${PATH}" \
+    XDG_SESSION_TYPE=wayland \
+    USER_NAME=testuser \
+    bash -c '
+      if [[ "${XDG_SESSION_TYPE:-x11}" == "wayland" ]]; then
+        xhost "+SI:localuser:${USER_NAME}" >/dev/null 2>&1 || true
+      else
+        xhost +local: >/dev/null 2>&1 || true
+      fi
+    '
 
-    run cat "${log}"
-    assert_success
-    assert_output --partial "+SI:localuser:testuser"
+  run cat "${log}"
+  assert_success
+  assert_output --partial "+SI:localuser:testuser"
 }
 
 @test "run.sh calls xhost +local: on X11" {
-    local mock_dir="${BATS_TEST_TMPDIR}/bin"
-    local log="${BATS_TEST_TMPDIR}/xhost.log"
-    mkdir -p "${mock_dir}"
-    cat > "${mock_dir}/xhost" <<MOCK
+  local mock_dir="${BATS_TEST_TMPDIR}/bin"
+  local log="${BATS_TEST_TMPDIR}/xhost.log"
+  mkdir -p "${mock_dir}"
+  cat > "${mock_dir}/xhost" <<MOCK
 #!/bin/bash
 echo "\$*" >> "${log}"
 MOCK
-    chmod +x "${mock_dir}/xhost"
+  chmod +x "${mock_dir}/xhost"
 
-    env PATH="${mock_dir}:${PATH}" \
-        XDG_SESSION_TYPE=x11 \
-        USER_NAME=testuser \
-        bash -c '
-            if [[ "${XDG_SESSION_TYPE:-x11}" == "wayland" ]]; then
-                xhost "+SI:localuser:${USER_NAME}" >/dev/null 2>&1 || true
-            else
-                xhost +local: >/dev/null 2>&1 || true
-            fi
-        '
+  env PATH="${mock_dir}:${PATH}" \
+    XDG_SESSION_TYPE=x11 \
+    USER_NAME=testuser \
+    bash -c '
+      if [[ "${XDG_SESSION_TYPE:-x11}" == "wayland" ]]; then
+        xhost "+SI:localuser:${USER_NAME}" >/dev/null 2>&1 || true
+      else
+        xhost +local: >/dev/null 2>&1 || true
+      fi
+    '
 
-    run cat "${log}"
-    assert_success
-    assert_output --partial "+local:"
+  run cat "${log}"
+  assert_success
+  assert_output --partial "+local:"
 }
 
 @test "run.sh defaults to X11 xhost when XDG_SESSION_TYPE unset" {
-    local mock_dir="${BATS_TEST_TMPDIR}/bin"
-    local log="${BATS_TEST_TMPDIR}/xhost.log"
-    mkdir -p "${mock_dir}"
-    cat > "${mock_dir}/xhost" <<MOCK
+  local mock_dir="${BATS_TEST_TMPDIR}/bin"
+  local log="${BATS_TEST_TMPDIR}/xhost.log"
+  mkdir -p "${mock_dir}"
+  cat > "${mock_dir}/xhost" <<MOCK
 #!/bin/bash
 echo "\$*" >> "${log}"
 MOCK
-    chmod +x "${mock_dir}/xhost"
+  chmod +x "${mock_dir}/xhost"
 
-    env -u XDG_SESSION_TYPE \
-        PATH="${mock_dir}:${PATH}" \
-        USER_NAME=testuser \
-        bash -c '
-            if [[ "${XDG_SESSION_TYPE:-x11}" == "wayland" ]]; then
-                xhost "+SI:localuser:${USER_NAME}" >/dev/null 2>&1 || true
-            else
-                xhost +local: >/dev/null 2>&1 || true
-            fi
-        '
+  env -u XDG_SESSION_TYPE \
+    PATH="${mock_dir}:${PATH}" \
+    USER_NAME=testuser \
+    bash -c '
+      if [[ "${XDG_SESSION_TYPE:-x11}" == "wayland" ]]; then
+        xhost "+SI:localuser:${USER_NAME}" >/dev/null 2>&1 || true
+      else
+        xhost +local: >/dev/null 2>&1 || true
+      fi
+    '
 
-    run cat "${log}"
-    assert_success
-    assert_output --partial "+local:"
+  run cat "${log}"
+  assert_success
+  assert_output --partial "+local:"
 }

--- a/test/smoke/script_help.bats
+++ b/test/smoke/script_help.bats
@@ -1,99 +1,99 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
+  load "${BATS_TEST_DIRNAME}/test_helper"
 }
 
 # -------------------- build.sh --------------------
 
 @test "build.sh -h exits 0" {
-    run bash /lint/build.sh -h
-    assert_success
+  run bash /lint/build.sh -h
+  assert_success
 }
 
 @test "build.sh --help exits 0" {
-    run bash /lint/build.sh --help
-    assert_success
+  run bash /lint/build.sh --help
+  assert_success
 }
 
 @test "build.sh -h prints usage" {
-    run bash /lint/build.sh -h
-    assert_line --partial "Usage:"
+  run bash /lint/build.sh -h
+  assert_line --partial "Usage:"
 }
 
 # -------------------- run.sh --------------------
 
 @test "run.sh -h exits 0" {
-    run bash /lint/run.sh -h
-    assert_success
+  run bash /lint/run.sh -h
+  assert_success
 }
 
 @test "run.sh --help exits 0" {
-    run bash /lint/run.sh --help
-    assert_success
+  run bash /lint/run.sh --help
+  assert_success
 }
 
 @test "run.sh -h prints usage" {
-    run bash /lint/run.sh -h
-    assert_line --partial "Usage:"
+  run bash /lint/run.sh -h
+  assert_line --partial "Usage:"
 }
 
 # -------------------- exec.sh --------------------
 
 @test "exec.sh -h exits 0" {
-    run bash /lint/exec.sh -h
-    assert_success
+  run bash /lint/exec.sh -h
+  assert_success
 }
 
 @test "exec.sh --help exits 0" {
-    run bash /lint/exec.sh --help
-    assert_success
+  run bash /lint/exec.sh --help
+  assert_success
 }
 
 @test "exec.sh -h prints usage" {
-    run bash /lint/exec.sh -h
-    assert_line --partial "Usage:"
+  run bash /lint/exec.sh -h
+  assert_line --partial "Usage:"
 }
 
 # -------------------- stop.sh --------------------
 
 @test "stop.sh -h exits 0" {
-    run bash /lint/stop.sh -h
-    assert_success
+  run bash /lint/stop.sh -h
+  assert_success
 }
 
 @test "stop.sh --help exits 0" {
-    run bash /lint/stop.sh --help
-    assert_success
+  run bash /lint/stop.sh --help
+  assert_success
 }
 
 @test "stop.sh -h prints usage" {
-    run bash /lint/stop.sh -h
-    assert_line --partial "Usage:"
+  run bash /lint/stop.sh -h
+  assert_line --partial "Usage:"
 }
 
 # -------------------- LANG auto-detect --------------------
 
 @test "build.sh detects zh from LANG=zh_TW.UTF-8" {
-    run env LANG=zh_TW.UTF-8 bash /lint/build.sh -h
-    assert_success
-    assert_line --partial "用法:"
+  run env LANG=zh_TW.UTF-8 bash /lint/build.sh -h
+  assert_success
+  assert_line --partial "用法:"
 }
 
 @test "build.sh detects ja from LANG=ja_JP.UTF-8" {
-    run env LANG=ja_JP.UTF-8 bash /lint/build.sh -h
-    assert_success
-    assert_line --partial "使用法:"
+  run env LANG=ja_JP.UTF-8 bash /lint/build.sh -h
+  assert_success
+  assert_line --partial "使用法:"
 }
 
 @test "build.sh defaults to en for LANG=en_US.UTF-8" {
-    run env LANG=en_US.UTF-8 bash /lint/build.sh -h
-    assert_success
-    assert_line --partial "Usage:"
+  run env LANG=en_US.UTF-8 bash /lint/build.sh -h
+  assert_success
+  assert_line --partial "Usage:"
 }
 
 @test "build.sh SETUP_LANG overrides LANG" {
-    run env LANG=ja_JP.UTF-8 SETUP_LANG=zh bash /lint/build.sh -h
-    assert_success
-    assert_line --partial "用法:"
+  run env LANG=ja_JP.UTF-8 SETUP_LANG=zh bash /lint/build.sh -h
+  assert_success
+  assert_line --partial "用法:"
 }

--- a/test/unit/bashrc_spec.bats
+++ b/test/unit/bashrc_spec.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
-    RC="/source/config/shell/bashrc"
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  RC="/source/config/shell/bashrc"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -10,28 +10,28 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "defines alias_func" {
-    run grep -q "^alias_func()" "${RC}"
-    assert_success
+  run grep -q "^alias_func()" "${RC}"
+  assert_success
 }
 
 @test "defines swc" {
-    run grep -q "^swc()" "${RC}"
-    assert_success
+  run grep -q "^swc()" "${RC}"
+  assert_success
 }
 
 @test "defines color_git_branch" {
-    run grep -q "^color_git_branch()" "${RC}"
-    assert_success
+  run grep -q "^color_git_branch()" "${RC}"
+  assert_success
 }
 
 @test "defines ros_complete" {
-    run grep -q "^ros_complete()" "${RC}"
-    assert_success
+  run grep -q "^ros_complete()" "${RC}"
+  assert_success
 }
 
 @test "defines ros_source" {
-    run grep -q "^ros_source()" "${RC}"
-    assert_success
+  run grep -q "^ros_source()" "${RC}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -39,13 +39,13 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "defines ebc alias" {
-    run grep -q "alias ebc=" "${RC}"
-    assert_success
+  run grep -q "alias ebc=" "${RC}"
+  assert_success
 }
 
 @test "defines sbc alias" {
-    run grep -q "alias sbc=" "${RC}"
-    assert_success
+  run grep -q "alias sbc=" "${RC}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -53,23 +53,23 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "alias_func is called" {
-    run grep -q "^alias_func()" "${RC}"
-    assert_success
+  run grep -q "^alias_func()" "${RC}"
+  assert_success
 }
 
 @test "color_git_branch is called" {
-    run grep -q "^color_git_branch()" "${RC}"
-    assert_success
+  run grep -q "^color_git_branch()" "${RC}"
+  assert_success
 }
 
 @test "ros_complete is called" {
-    run grep -q "^ros_complete()" "${RC}"
-    assert_success
+  run grep -q "^ros_complete()" "${RC}"
+  assert_success
 }
 
 @test "ros_source is called" {
-    run grep -q "^ros_source()" "${RC}"
-    assert_success
+  run grep -q "^ros_source()" "${RC}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -77,16 +77,16 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "swc searches for catkin devel/setup.bash" {
-    run grep -q "devel" "${RC}"
-    assert_success
+  run grep -q "devel" "${RC}"
+  assert_success
 }
 
 @test "ros_source references ROS_DISTRO" {
-    run grep -q "ROS_DISTRO" "${RC}"
-    assert_success
+  run grep -q "ROS_DISTRO" "${RC}"
+  assert_success
 }
 
 @test "color_git_branch sets PS1" {
-    run grep -q "PS1=" "${RC}"
-    assert_success
+  run grep -q "PS1=" "${RC}"
+  assert_success
 }

--- a/test/unit/lib_spec.bats
+++ b/test/unit/lib_spec.bats
@@ -6,143 +6,143 @@
 # the bash branches actually run (kcov can then attribute coverage).
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
-    LIB="/source/script/docker/_lib.sh"
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  LIB="/source/script/docker/_lib.sh"
 }
 
 # ── _detect_lang / _LANG ────────────────────────────────────────────────────
 
 @test "_lib.sh sets _LANG to 'en' when LANG is unset" {
-    run bash -c "unset LANG SETUP_LANG; source ${LIB}; echo \"\${_LANG}\""
-    assert_success
-    assert_output "en"
+  run bash -c "unset LANG SETUP_LANG; source ${LIB}; echo \"\${_LANG}\""
+  assert_success
+  assert_output "en"
 }
 
 @test "_lib.sh sets _LANG to 'zh' for zh_TW.UTF-8" {
-    run bash -c "unset SETUP_LANG; LANG=zh_TW.UTF-8 source ${LIB}; echo \"\${_LANG}\""
-    assert_success
-    assert_output "zh"
+  run bash -c "unset SETUP_LANG; LANG=zh_TW.UTF-8 source ${LIB}; echo \"\${_LANG}\""
+  assert_success
+  assert_output "zh"
 }
 
 @test "_lib.sh sets _LANG to 'zh-CN' for zh_CN.UTF-8" {
-    run bash -c "unset SETUP_LANG; LANG=zh_CN.UTF-8 source ${LIB}; echo \"\${_LANG}\""
-    assert_success
-    assert_output "zh-CN"
+  run bash -c "unset SETUP_LANG; LANG=zh_CN.UTF-8 source ${LIB}; echo \"\${_LANG}\""
+  assert_success
+  assert_output "zh-CN"
 }
 
 @test "_lib.sh sets _LANG to 'zh-CN' for zh_SG (Singapore)" {
-    run bash -c "unset SETUP_LANG; LANG=zh_SG.UTF-8 source ${LIB}; echo \"\${_LANG}\""
-    assert_success
-    assert_output "zh-CN"
+  run bash -c "unset SETUP_LANG; LANG=zh_SG.UTF-8 source ${LIB}; echo \"\${_LANG}\""
+  assert_success
+  assert_output "zh-CN"
 }
 
 @test "_lib.sh sets _LANG to 'ja' for ja_JP.UTF-8" {
-    run bash -c "unset SETUP_LANG; LANG=ja_JP.UTF-8 source ${LIB}; echo \"\${_LANG}\""
-    assert_success
-    assert_output "ja"
+  run bash -c "unset SETUP_LANG; LANG=ja_JP.UTF-8 source ${LIB}; echo \"\${_LANG}\""
+  assert_success
+  assert_output "ja"
 }
 
 @test "_lib.sh honors SETUP_LANG override" {
-    run bash -c "SETUP_LANG=ja LANG=en_US.UTF-8 source ${LIB}; echo \"\${_LANG}\""
-    assert_success
-    assert_output "ja"
+  run bash -c "SETUP_LANG=ja LANG=en_US.UTF-8 source ${LIB}; echo \"\${_LANG}\""
+  assert_success
+  assert_output "ja"
 }
 
 # ── double-source guard ─────────────────────────────────────────────────────
 
 @test "_lib.sh is idempotent when sourced twice" {
-    run bash -c "source ${LIB}; source ${LIB}; echo \"\${_DOCKER_LIB_SOURCED}\""
-    assert_success
-    assert_output "1"
+  run bash -c "source ${LIB}; source ${LIB}; echo \"\${_DOCKER_LIB_SOURCED}\""
+  assert_success
+  assert_output "1"
 }
 
 # ── _load_env ───────────────────────────────────────────────────────────────
 
 @test "_load_env exports variables from a .env file" {
-    local _tmp
-    _tmp="$(mktemp)"
-    cat > "${_tmp}" <<EOF
+  local _tmp
+  _tmp="$(mktemp)"
+  cat > "${_tmp}" <<EOF
 FOO=bar
 BAZ=qux
 EOF
-    run bash -c "source ${LIB}; _load_env '${_tmp}'; echo \"\${FOO}-\${BAZ}\""
-    assert_success
-    assert_output "bar-qux"
-    rm -f "${_tmp}"
+  run bash -c "source ${LIB}; _load_env '${_tmp}'; echo \"\${FOO}-\${BAZ}\""
+  assert_success
+  assert_output "bar-qux"
+  rm -f "${_tmp}"
 }
 
 @test "_load_env errors when no path is given" {
-    run bash -c "source ${LIB}; _load_env"
-    assert_failure
+  run bash -c "source ${LIB}; _load_env"
+  assert_failure
 }
 
 # ── _compute_project_name ───────────────────────────────────────────────────
 
 @test "_compute_project_name with empty instance produces clean PROJECT_NAME" {
-    run bash -c "
-        source ${LIB}
-        DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
-        _compute_project_name ''
-        echo \"\${PROJECT_NAME}|\${INSTANCE_SUFFIX}\"
-    "
-    assert_success
-    assert_output "alice-myrepo|"
+  run bash -c "
+    source ${LIB}
+    DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
+    _compute_project_name ''
+    echo \"\${PROJECT_NAME}|\${INSTANCE_SUFFIX}\"
+  "
+  assert_success
+  assert_output "alice-myrepo|"
 }
 
 @test "_compute_project_name with named instance suffixes both" {
-    run bash -c "
-        source ${LIB}
-        DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
-        _compute_project_name 'dev2'
-        echo \"\${PROJECT_NAME}|\${INSTANCE_SUFFIX}\"
-    "
-    assert_success
-    assert_output "alice-myrepo-dev2|-dev2"
+  run bash -c "
+    source ${LIB}
+    DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
+    _compute_project_name 'dev2'
+    echo \"\${PROJECT_NAME}|\${INSTANCE_SUFFIX}\"
+  "
+  assert_success
+  assert_output "alice-myrepo-dev2|-dev2"
 }
 
 @test "_compute_project_name exports INSTANCE_SUFFIX so child processes see it" {
-    run bash -c "
-        source ${LIB}
-        DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
-        _compute_project_name 'foo'
-        bash -c 'echo \"\${INSTANCE_SUFFIX}\"'
-    "
-    assert_success
-    assert_output "-foo"
+  run bash -c "
+    source ${LIB}
+    DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
+    _compute_project_name 'foo'
+    bash -c 'echo \"\${INSTANCE_SUFFIX}\"'
+  "
+  assert_success
+  assert_output "-foo"
 }
 
 # ── _compose / _compose_project (DRY_RUN path) ──────────────────────────────
 
 @test "_compose with DRY_RUN=true prints command instead of running" {
-    run bash -c "source ${LIB}; DRY_RUN=true _compose ps --all"
-    assert_success
-    assert_output --partial "[dry-run] docker compose"
-    assert_output --partial "ps"
-    assert_output --partial "--all"
+  run bash -c "source ${LIB}; DRY_RUN=true _compose ps --all"
+  assert_success
+  assert_output --partial "[dry-run] docker compose"
+  assert_output --partial "ps"
+  assert_output --partial "--all"
 }
 
 @test "_compose without DRY_RUN tries to invoke docker compose (sanity)" {
-    # When DRY_RUN is unset/false, _compose calls real docker compose; on a
-    # CI runner without docker the command exits non-zero, but we just want
-    # to confirm the false branch executes (kcov coverage).
-    run bash -c "source ${LIB}; PATH=/nonexistent _compose version"
-    # Either docker compose ran (rc 0) or PATH lookup failed (rc 127);
-    # both are fine. We assert the script *attempted* the call by checking
-    # we did not see the dry-run prefix in output.
-    refute_output --partial "[dry-run]"
+  # When DRY_RUN is unset/false, _compose calls real docker compose; on a
+  # CI runner without docker the command exits non-zero, but we just want
+  # to confirm the false branch executes (kcov coverage).
+  run bash -c "source ${LIB}; PATH=/nonexistent _compose version"
+  # Either docker compose ran (rc 0) or PATH lookup failed (rc 127);
+  # both are fine. We assert the script *attempted* the call by checking
+  # we did not see the dry-run prefix in output.
+  refute_output --partial "[dry-run]"
 }
 
 @test "_compose_project pre-fills -p / -f / --env-file from PROJECT_NAME and FILE_PATH" {
-    run bash -c "
-        source ${LIB}
-        DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
-        _compute_project_name ''
-        FILE_PATH=/tmp/fakerepo
-        DRY_RUN=true _compose_project ps
-    "
-    assert_success
-    assert_output --partial "-p alice-myrepo"
-    assert_output --partial "-f /tmp/fakerepo/compose.yaml"
-    assert_output --partial "--env-file /tmp/fakerepo/.env"
-    assert_output --partial " ps"
+  run bash -c "
+    source ${LIB}
+    DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
+    _compute_project_name ''
+    FILE_PATH=/tmp/fakerepo
+    DRY_RUN=true _compose_project ps
+  "
+  assert_success
+  assert_output --partial "-p alice-myrepo"
+  assert_output --partial "-f /tmp/fakerepo/compose.yaml"
+  assert_output --partial "--env-file /tmp/fakerepo/.env"
+  assert_output --partial " ps"
 }

--- a/test/unit/pip_setup_spec.bats
+++ b/test/unit/pip_setup_spec.bats
@@ -1,20 +1,20 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
-    create_mock_dir
-    TEMP_DIR="$(mktemp -d)"
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  create_mock_dir
+  TEMP_DIR="$(mktemp -d)"
 
-    # Create a fake requirements.txt alongside the script for testing
-    FAKE_SCRIPT_DIR="${TEMP_DIR}/pip"
-    mkdir -p "${FAKE_SCRIPT_DIR}"
-    cp /source/config/pip/setup.sh "${FAKE_SCRIPT_DIR}/setup.sh"
-    echo "# empty requirements" > "${FAKE_SCRIPT_DIR}/requirements.txt"
+  # Create a fake requirements.txt alongside the script for testing
+  FAKE_SCRIPT_DIR="${TEMP_DIR}/pip"
+  mkdir -p "${FAKE_SCRIPT_DIR}"
+  cp /source/config/pip/setup.sh "${FAKE_SCRIPT_DIR}/setup.sh"
+  echo "# empty requirements" > "${FAKE_SCRIPT_DIR}/requirements.txt"
 }
 
 teardown() {
-    cleanup_mock_dir
-    rm -rf "${TEMP_DIR}"
+  cleanup_mock_dir
+  rm -rf "${TEMP_DIR}"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -22,23 +22,23 @@ teardown() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "pip setup.sh runs pip install with requirements.txt" {
-    mock_cmd "pip" '
+  mock_cmd "pip" '
 echo "pip called with: $*"
 exit 0'
-    run bash "${FAKE_SCRIPT_DIR}/setup.sh"
-    assert_success
-    assert_output --partial "pip called with: install -r"
+  run bash "${FAKE_SCRIPT_DIR}/setup.sh"
+  assert_success
+  assert_output --partial "pip called with: install -r"
 }
 
 @test "pip setup.sh sets PIP_BREAK_SYSTEM_PACKAGES=1" {
-    mock_cmd "pip" 'echo "PIP_BREAK=${PIP_BREAK_SYSTEM_PACKAGES}"; exit 0'
-    run bash "${FAKE_SCRIPT_DIR}/setup.sh"
-    assert_success
-    assert_output --partial "PIP_BREAK=1"
+  mock_cmd "pip" 'echo "PIP_BREAK=${PIP_BREAK_SYSTEM_PACKAGES}"; exit 0'
+  run bash "${FAKE_SCRIPT_DIR}/setup.sh"
+  assert_success
+  assert_output --partial "PIP_BREAK=1"
 }
 
 @test "pip setup.sh fails when pip is not available" {
-    mock_cmd "pip" 'exit 127'
-    run bash "${FAKE_SCRIPT_DIR}/setup.sh"
-    assert_failure
+  mock_cmd "pip" 'exit 127'
+  run bash "${FAKE_SCRIPT_DIR}/setup.sh"
+  assert_failure
 }

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -1,19 +1,19 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
+  load "${BATS_TEST_DIRNAME}/test_helper"
 
-    # Source setup.sh functions only (main is guarded)
-    # shellcheck disable=SC1091
-    source /source/script/docker/setup.sh
+  # Source setup.sh functions only (main is guarded)
+  # shellcheck disable=SC1091
+  source /source/script/docker/setup.sh
 
-    create_mock_dir
-    TEMP_DIR="$(mktemp -d)"
+  create_mock_dir
+  TEMP_DIR="$(mktemp -d)"
 }
 
 teardown() {
-    cleanup_mock_dir
-    rm -rf "${TEMP_DIR}"
+  cleanup_mock_dir
+  rm -rf "${TEMP_DIR}"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -21,38 +21,38 @@ teardown() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "detect_user_info uses USER env when set" {
-    local _user _group _uid _gid
-    USER="mockuser" detect_user_info _user _group _uid _gid
-    assert_equal "${_user}" "mockuser"
+  local _user _group _uid _gid
+  USER="mockuser" detect_user_info _user _group _uid _gid
+  assert_equal "${_user}" "mockuser"
 }
 
 @test "detect_user_info falls back to id -un when USER unset" {
-    local _user _group _uid _gid
-    mock_cmd "id" '
+  local _user _group _uid _gid
+  mock_cmd "id" '
 case "$1" in
-    -un) echo "fallbackuser" ;;
-    -u)  echo "1001" ;;
-    -gn) echo "fallbackgroup" ;;
-    -g)  echo "1001" ;;
+  -un) echo "fallbackuser" ;;
+  -u)  echo "1001" ;;
+  -gn) echo "fallbackgroup" ;;
+  -g)  echo "1001" ;;
 esac'
-    unset USER
-    detect_user_info _user _group _uid _gid
-    assert_equal "${_user}" "fallbackuser"
+  unset USER
+  detect_user_info _user _group _uid _gid
+  assert_equal "${_user}" "fallbackuser"
 }
 
 @test "detect_user_info sets group uid gid correctly" {
-    local _user _group _uid _gid
-    mock_cmd "id" '
+  local _user _group _uid _gid
+  mock_cmd "id" '
 case "$1" in
-    -un) echo "testuser" ;;
-    -u)  echo "1234" ;;
-    -gn) echo "testgroup" ;;
-    -g)  echo "5678" ;;
+  -un) echo "testuser" ;;
+  -u)  echo "1234" ;;
+  -gn) echo "testgroup" ;;
+  -g)  echo "5678" ;;
 esac'
-    USER="testuser" detect_user_info _user _group _uid _gid
-    assert_equal "${_group}" "testgroup"
-    assert_equal "${_uid}" "1234"
-    assert_equal "${_gid}" "5678"
+  USER="testuser" detect_user_info _user _group _uid _gid
+  assert_equal "${_group}" "testgroup"
+  assert_equal "${_uid}" "1234"
+  assert_equal "${_gid}" "5678"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -60,10 +60,10 @@ esac'
 # ════════════════════════════════════════════════════════════════════
 
 @test "detect_hardware returns uname -m output" {
-    local _hw
-    mock_cmd "uname" 'echo "aarch64"'
-    detect_hardware _hw
-    assert_equal "${_hw}" "aarch64"
+  local _hw
+  mock_cmd "uname" 'echo "aarch64"'
+  detect_hardware _hw
+  assert_equal "${_hw}" "aarch64"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -71,29 +71,29 @@ esac'
 # ════════════════════════════════════════════════════════════════════
 
 @test "detect_docker_hub_user uses docker info username when logged in" {
-    local _result
-    mock_cmd "docker" 'echo " Username: dockerhubuser"'
-    detect_docker_hub_user _result
-    assert_equal "${_result}" "dockerhubuser"
+  local _result
+  mock_cmd "docker" 'echo " Username: dockerhubuser"'
+  detect_docker_hub_user _result
+  assert_equal "${_result}" "dockerhubuser"
 }
 
 @test "detect_docker_hub_user falls back to USER when docker returns empty" {
-    local _result
-    mock_cmd "docker" 'echo "no username line here"'
-    USER="localuser" detect_docker_hub_user _result
-    assert_equal "${_result}" "localuser"
+  local _result
+  mock_cmd "docker" 'echo "no username line here"'
+  USER="localuser" detect_docker_hub_user _result
+  assert_equal "${_result}" "localuser"
 }
 
 @test "detect_docker_hub_user falls back to id -un when USER also unset" {
-    local _result
-    mock_cmd "docker" 'echo "no username line here"'
-    mock_cmd "id" '
+  local _result
+  mock_cmd "docker" 'echo "no username line here"'
+  mock_cmd "id" '
 case "$1" in
-    -un) echo "iduser" ;;
+  -un) echo "iduser" ;;
 esac'
-    unset USER
-    detect_docker_hub_user _result
-    assert_equal "${_result}" "iduser"
+  unset USER
+  detect_docker_hub_user _result
+  assert_equal "${_result}" "iduser"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -101,17 +101,17 @@ esac'
 # ════════════════════════════════════════════════════════════════════
 
 @test "detect_gpu returns true when nvidia-container-toolkit is installed" {
-    local _result
-    mock_cmd "dpkg-query" 'echo "ii"'
-    detect_gpu _result
-    assert_equal "${_result}" "true"
+  local _result
+  mock_cmd "dpkg-query" 'echo "ii"'
+  detect_gpu _result
+  assert_equal "${_result}" "true"
 }
 
 @test "detect_gpu returns false when nvidia-container-toolkit is not installed" {
-    local _result
-    mock_cmd "dpkg-query" 'echo "un"'
-    detect_gpu _result
-    assert_equal "${_result}" "false"
+  local _result
+  mock_cmd "dpkg-query" 'echo "un"'
+  detect_gpu _result
+  assert_equal "${_result}" "false"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -119,52 +119,52 @@ esac'
 # ════════════════════════════════════════════════════════════════════
 
 @test "detect_image_name finds *_ws in path" {
-    local _result
-    detect_image_name _result "/home/user/myapp_ws/src/docker"
-    assert_equal "${_result}" "myapp"
+  local _result
+  detect_image_name _result "/home/user/myapp_ws/src/docker"
+  assert_equal "${_result}" "myapp"
 }
 
 @test "detect_image_name finds *_ws at end of path" {
-    local _result
-    detect_image_name _result "/home/user/projects/myapp_ws"
-    assert_equal "${_result}" "myapp"
+  local _result
+  detect_image_name _result "/home/user/projects/myapp_ws"
+  assert_equal "${_result}" "myapp"
 }
 
 @test "detect_image_name prefers docker_* over *_ws in path" {
-    local _result
-    detect_image_name _result "/home/user/robot_ws/src/docker_nav"
-    assert_equal "${_result}" "nav"
+  local _result
+  detect_image_name _result "/home/user/robot_ws/src/docker_nav"
+  assert_equal "${_result}" "nav"
 }
 
 @test "detect_image_name strips docker_ prefix from last dir" {
-    local _result
-    detect_image_name _result "/home/user/projects/docker_myapp"
-    assert_equal "${_result}" "myapp"
+  local _result
+  detect_image_name _result "/home/user/projects/docker_myapp"
+  assert_equal "${_result}" "myapp"
 }
 
 @test "detect_image_name strips docker_ from absolute root" {
-    local _result
-    detect_image_name _result "/docker_project"
-    assert_equal "${_result}" "project"
+  local _result
+  detect_image_name _result "/docker_project"
+  assert_equal "${_result}" "project"
 }
 
 @test "detect_image_name returns unknown for plain directory (default conf)" {
-    # default conf only has @env_example/prefix:docker_/suffix:_ws (no @basename)
-    local _result
-    detect_image_name _result "/home/user/projects/ros_noetic"
-    assert_equal "${_result}" "unknown"
+  # default conf only has @env_example/prefix:docker_/suffix:_ws (no @basename)
+  local _result
+  detect_image_name _result "/home/user/projects/ros_noetic"
+  assert_equal "${_result}" "unknown"
 }
 
 @test "detect_image_name returns unknown for generic path (default conf)" {
-    local _result
-    detect_image_name _result "/home/user/myproject"
-    assert_equal "${_result}" "unknown"
+  local _result
+  detect_image_name _result "/home/user/myproject"
+  assert_equal "${_result}" "unknown"
 }
 
 @test "detect_image_name lowercases the result" {
-    local _result
-    detect_image_name _result "/home/user/MyApp_ws/src/docker"
-    assert_equal "${_result}" "myapp"
+  local _result
+  detect_image_name _result "/home/user/MyApp_ws/src/docker"
+  assert_equal "${_result}" "myapp"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -172,116 +172,116 @@ esac'
 # ════════════════════════════════════════════════════════════════════
 
 @test "detect_image_name uses repo-level image_name.conf when present" {
-    local _conf="${TEMP_DIR}/image_name.conf"
-    cat > "${_conf}" <<EOF
+  local _conf="${TEMP_DIR}/image_name.conf"
+  cat > "${_conf}" <<EOF
 prefix:foo_
 @basename
 EOF
-    local _result
-    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_myapp"
-    assert_equal "${_result}" "myapp"
+  local _result
+  IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_myapp"
+  assert_equal "${_result}" "myapp"
 }
 
 @test "detect_image_name auto-discovers image_name.conf via BASE_PATH" {
-    cat > "${TEMP_DIR}/image_name.conf" <<EOF
+  cat > "${TEMP_DIR}/image_name.conf" <<EOF
 prefix:bar_
 @basename
 EOF
-    local _result
-    BASE_PATH="${TEMP_DIR}" detect_image_name _result "/home/user/bar_myapp"
-    assert_equal "${_result}" "myapp"
+  local _result
+  BASE_PATH="${TEMP_DIR}" detect_image_name _result "/home/user/bar_myapp"
+  assert_equal "${_result}" "myapp"
 }
 
 @test "detect_image_name reads env_example rule from conf" {
-    local _conf="${TEMP_DIR}/image_name.conf"
-    local _example="${TEMP_DIR}/.env.example"
-    cat > "${_conf}" <<EOF
+  local _conf="${TEMP_DIR}/image_name.conf"
+  local _example="${TEMP_DIR}/.env.example"
+  cat > "${_conf}" <<EOF
 @env_example
 @basename
 EOF
-    echo "IMAGE_NAME=from_example" > "${_example}"
-    local _result
-    BASE_PATH="${TEMP_DIR}" IMAGE_NAME_CONF="${_conf}" \
-        detect_image_name _result "/home/user/some_dir"
-    assert_equal "${_result}" "from_example"
+  echo "IMAGE_NAME=from_example" > "${_example}"
+  local _result
+  BASE_PATH="${TEMP_DIR}" IMAGE_NAME_CONF="${_conf}" \
+    detect_image_name _result "/home/user/some_dir"
+  assert_equal "${_result}" "from_example"
 }
 
 @test "detect_image_name applies rules in order (first match wins)" {
-    local _conf="${TEMP_DIR}/image_name.conf"
-    cat > "${_conf}" <<EOF
+  local _conf="${TEMP_DIR}/image_name.conf"
+  cat > "${_conf}" <<EOF
 prefix:docker_
 suffix:_ws
 @basename
 EOF
-    local _result
-    # path has both docker_ and _ws — prefix wins
-    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/myapp_ws/src/docker_nav"
-    assert_equal "${_result}" "nav"
+  local _result
+  # path has both docker_ and _ws — prefix wins
+  IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/myapp_ws/src/docker_nav"
+  assert_equal "${_result}" "nav"
 }
 
 @test "detect_image_name skips comments and empty lines in conf" {
-    local _conf="${TEMP_DIR}/image_name.conf"
-    cat > "${_conf}" <<EOF
+  local _conf="${TEMP_DIR}/image_name.conf"
+  cat > "${_conf}" <<EOF
 # This is a comment
 prefix:foo_
 
 # Another comment
 @basename
 EOF
-    local _result
-    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_myapp"
-    assert_equal "${_result}" "myapp"
+  local _result
+  IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_myapp"
+  assert_equal "${_result}" "myapp"
 }
 
 @test "detect_image_name skips whitespace-only lines in conf" {
-    local _conf="${TEMP_DIR}/image_name.conf"
-    printf 'prefix:foo_\n   \n\t\n@basename\n' > "${_conf}"
-    local _result
-    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_myapp"
-    assert_equal "${_result}" "myapp"
+  local _conf="${TEMP_DIR}/image_name.conf"
+  printf 'prefix:foo_\n   \n\t\n@basename\n' > "${_conf}"
+  local _result
+  IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_myapp"
+  assert_equal "${_result}" "myapp"
 }
 
 @test "detect_image_name returns unknown when no rule matches and no basename" {
-    local _conf="${TEMP_DIR}/image_name.conf"
-    cat > "${_conf}" <<EOF
+  local _conf="${TEMP_DIR}/image_name.conf"
+  cat > "${_conf}" <<EOF
 prefix:nonexistent_
 EOF
-    local _result
-    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/myapp"
-    assert_equal "${_result}" "unknown"
+  local _result
+  IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/myapp"
+  assert_equal "${_result}" "unknown"
 }
 
 @test "detect_image_name uses @basename when no other rule matches" {
-    local _conf="${TEMP_DIR}/image_name.conf"
-    cat > "${_conf}" <<EOF
+  local _conf="${TEMP_DIR}/image_name.conf"
+  cat > "${_conf}" <<EOF
 prefix:nonexistent_
 @basename
 EOF
-    local _result
-    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/myapp"
-    assert_equal "${_result}" "myapp"
+  local _result
+  IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/myapp"
+  assert_equal "${_result}" "myapp"
 }
 
 @test "detect_image_name applies @default:<value> as fallback" {
-    local _conf="${TEMP_DIR}/image_name.conf"
-    cat > "${_conf}" <<EOF
+  local _conf="${TEMP_DIR}/image_name.conf"
+  cat > "${_conf}" <<EOF
 prefix:nonexistent_
 @default:my_repo
 EOF
-    local _result
-    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/myapp"
-    assert_equal "${_result}" "my_repo"
+  local _result
+  IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/myapp"
+  assert_equal "${_result}" "my_repo"
 }
 
 @test "detect_image_name @default:<value> is skipped if earlier rule matches" {
-    local _conf="${TEMP_DIR}/image_name.conf"
-    cat > "${_conf}" <<EOF
+  local _conf="${TEMP_DIR}/image_name.conf"
+  cat > "${_conf}" <<EOF
 prefix:foo_
 @default:my_repo
 EOF
-    local _result
-    IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_realname"
-    assert_equal "${_result}" "realname"
+  local _result
+  IMAGE_NAME_CONF="${_conf}" detect_image_name _result "/home/user/foo_realname"
+  assert_equal "${_result}" "realname"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -289,38 +289,38 @@ EOF
 # ════════════════════════════════════════════════════════════════════
 
 @test "detect_ws_path strategy 1: docker_* finds sibling *_ws" {
-    local _ws_dir="${TEMP_DIR}/myapp_ws"
-    local _proj_dir="${TEMP_DIR}/docker_myapp"
-    mkdir -p "${_ws_dir}" "${_proj_dir}"
-    local _result
-    detect_ws_path _result "${_proj_dir}"
-    assert_equal "${_result}" "${_ws_dir}"
+  local _ws_dir="${TEMP_DIR}/myapp_ws"
+  local _proj_dir="${TEMP_DIR}/docker_myapp"
+  mkdir -p "${_ws_dir}" "${_proj_dir}"
+  local _result
+  detect_ws_path _result "${_proj_dir}"
+  assert_equal "${_result}" "${_ws_dir}"
 }
 
 @test "detect_ws_path strategy 1: docker_* without sibling falls through" {
-    local _proj_dir="${TEMP_DIR}/docker_nosibling"
-    mkdir -p "${_proj_dir}"
-    local _result
-    detect_ws_path _result "${_proj_dir}"
-    # No sibling *_ws, no *_ws in path → falls back to parent
-    assert_equal "${_result}" "${TEMP_DIR}"
+  local _proj_dir="${TEMP_DIR}/docker_nosibling"
+  mkdir -p "${_proj_dir}"
+  local _result
+  detect_ws_path _result "${_proj_dir}"
+  # No sibling *_ws, no *_ws in path → falls back to parent
+  assert_equal "${_result}" "${TEMP_DIR}"
 }
 
 @test "detect_ws_path strategy 2: finds _ws component in path" {
-    local _ws_dir="${TEMP_DIR}/myproject_ws"
-    local _sub_dir="${_ws_dir}/docker_ros"
-    mkdir -p "${_sub_dir}"
-    local _result
-    detect_ws_path _result "${_sub_dir}"
-    assert_equal "${_result}" "${_ws_dir}"
+  local _ws_dir="${TEMP_DIR}/myproject_ws"
+  local _sub_dir="${_ws_dir}/docker_ros"
+  mkdir -p "${_sub_dir}"
+  local _result
+  detect_ws_path _result "${_sub_dir}"
+  assert_equal "${_result}" "${_ws_dir}"
 }
 
 @test "detect_ws_path strategy 3: falls back to parent directory" {
-    local _no_ws="${TEMP_DIR}/no_ws_here"
-    mkdir -p "${_no_ws}"
-    local _result
-    detect_ws_path _result "${_no_ws}"
-    assert_equal "${_result}" "${TEMP_DIR}"
+  local _no_ws="${TEMP_DIR}/no_ws_here"
+  mkdir -p "${_no_ws}"
+  local _result
+  detect_ws_path _result "${_no_ws}"
+  assert_equal "${_result}" "${TEMP_DIR}"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -328,41 +328,41 @@ EOF
 # ════════════════════════════════════════════════════════════════════
 
 @test "write_env creates .env with all required variables" {
-    local _env_file="${TEMP_DIR}/.env"
-    write_env "${_env_file}" \
-        "testuser" "testgroup" "1001" "1001" \
-        "x86_64" "dockerhub" "false" \
-        "ros_noetic" "/workspace" \
-        "tw.archive.ubuntu.com" "mirror.twds.com.tw"
+  local _env_file="${TEMP_DIR}/.env"
+  write_env "${_env_file}" \
+    "testuser" "testgroup" "1001" "1001" \
+    "x86_64" "dockerhub" "false" \
+    "ros_noetic" "/workspace" \
+    "tw.archive.ubuntu.com" "mirror.twds.com.tw"
 
-    assert [ -f "${_env_file}" ]
-    run grep "USER_NAME=testuser"        "${_env_file}"; assert_success
-    run grep "USER_GROUP=testgroup"      "${_env_file}"; assert_success
-    run grep "USER_UID=1001"             "${_env_file}"; assert_success
-    run grep "USER_GID=1001"             "${_env_file}"; assert_success
-    run grep "HARDWARE=x86_64"           "${_env_file}"; assert_success
-    run grep "DOCKER_HUB_USER=dockerhub" "${_env_file}"; assert_success
-    run grep "GPU_ENABLED=false"         "${_env_file}"; assert_success
-    run grep "IMAGE_NAME=ros_noetic"     "${_env_file}"; assert_success
-    run grep "WS_PATH=/workspace"        "${_env_file}"; assert_success
+  assert [ -f "${_env_file}" ]
+  run grep "USER_NAME=testuser"        "${_env_file}"; assert_success
+  run grep "USER_GROUP=testgroup"      "${_env_file}"; assert_success
+  run grep "USER_UID=1001"             "${_env_file}"; assert_success
+  run grep "USER_GID=1001"             "${_env_file}"; assert_success
+  run grep "HARDWARE=x86_64"           "${_env_file}"; assert_success
+  run grep "DOCKER_HUB_USER=dockerhub" "${_env_file}"; assert_success
+  run grep "GPU_ENABLED=false"         "${_env_file}"; assert_success
+  run grep "IMAGE_NAME=ros_noetic"     "${_env_file}"; assert_success
+  run grep "WS_PATH=/workspace"        "${_env_file}"; assert_success
 }
 
 @test "write_env includes APT_MIRROR_UBUNTU" {
-    local _env_file="${TEMP_DIR}/.env"
-    write_env "${_env_file}" \
-        "u" "g" "1000" "1000" "x86_64" "hub" "false" "img" "/ws" \
-        "tw.archive.ubuntu.com" "mirror.twds.com.tw"
-    run grep "APT_MIRROR_UBUNTU=tw.archive.ubuntu.com" "${_env_file}"
-    assert_success
+  local _env_file="${TEMP_DIR}/.env"
+  write_env "${_env_file}" \
+    "u" "g" "1000" "1000" "x86_64" "hub" "false" "img" "/ws" \
+    "tw.archive.ubuntu.com" "mirror.twds.com.tw"
+  run grep "APT_MIRROR_UBUNTU=tw.archive.ubuntu.com" "${_env_file}"
+  assert_success
 }
 
 @test "write_env includes APT_MIRROR_DEBIAN" {
-    local _env_file="${TEMP_DIR}/.env"
-    write_env "${_env_file}" \
-        "u" "g" "1000" "1000" "x86_64" "hub" "false" "img" "/ws" \
-        "tw.archive.ubuntu.com" "mirror.twds.com.tw"
-    run grep "APT_MIRROR_DEBIAN=mirror.twds.com.tw" "${_env_file}"
-    assert_success
+  local _env_file="${TEMP_DIR}/.env"
+  write_env "${_env_file}" \
+    "u" "g" "1000" "1000" "x86_64" "hub" "false" "img" "/ws" \
+    "tw.archive.ubuntu.com" "mirror.twds.com.tw"
+  run grep "APT_MIRROR_DEBIAN=mirror.twds.com.tw" "${_env_file}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -370,180 +370,180 @@ EOF
 # ════════════════════════════════════════════════════════════════════
 
 @test "main creates .env when it does not exist" {
-    local _ws="${TEMP_DIR}/test_ws"
-    mkdir -p "${_ws}"
-    run bash -c "
-        source /source/script/docker/setup.sh
-        detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
-        main --base-path '${TEMP_DIR}'
-    "
-    assert_success
-    assert [ -f "${TEMP_DIR}/.env" ]
+  local _ws="${TEMP_DIR}/test_ws"
+  mkdir -p "${_ws}"
+  run bash -c "
+    source /source/script/docker/setup.sh
+    detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
+    main --base-path '${TEMP_DIR}'
+  "
+  assert_success
+  assert [ -f "${TEMP_DIR}/.env" ]
 }
 
 @test "main sources existing .env and reuses valid WS_PATH" {
-    local _ws="${TEMP_DIR}/existing_ws"
-    mkdir -p "${_ws}"
-    cat > "${TEMP_DIR}/.env" << EOF
+  local _ws="${TEMP_DIR}/existing_ws"
+  mkdir -p "${_ws}"
+  cat > "${TEMP_DIR}/.env" << EOF
 WS_PATH=${_ws}
 EOF
-    run bash -c "
-        source /source/script/docker/setup.sh
-        main --base-path '${TEMP_DIR}'
-    "
-    assert_success
-    run grep "WS_PATH=${_ws}" "${TEMP_DIR}/.env"
-    assert_success
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main --base-path '${TEMP_DIR}'
+  "
+  assert_success
+  run grep "WS_PATH=${_ws}" "${TEMP_DIR}/.env"
+  assert_success
 }
 
 @test "main re-detects WS_PATH when path in .env no longer exists" {
-    local _new_ws="${TEMP_DIR}/new_ws"
-    mkdir -p "${_new_ws}"
-    cat > "${TEMP_DIR}/.env" << EOF
+  local _new_ws="${TEMP_DIR}/new_ws"
+  mkdir -p "${_new_ws}"
+  cat > "${TEMP_DIR}/.env" << EOF
 WS_PATH=/this/path/does/not/exist
 EOF
-    run bash -c "
-        source /source/script/docker/setup.sh
-        detect_ws_path() { local -n _o=\$1; _o='${_new_ws}'; }
-        main --base-path '${TEMP_DIR}'
-    "
-    assert_success
-    run grep "WS_PATH=${_new_ws}" "${TEMP_DIR}/.env"
-    assert_success
+  run bash -c "
+    source /source/script/docker/setup.sh
+    detect_ws_path() { local -n _o=\$1; _o='${_new_ws}'; }
+    main --base-path '${TEMP_DIR}'
+  "
+  assert_success
+  run grep "WS_PATH=${_new_ws}" "${TEMP_DIR}/.env"
+  assert_success
 }
 
 @test "main: env_example rule reads IMAGE_NAME from .env.example" {
-    # Default conf has env_example before basename, so .env.example wins
-    local _ws="${TEMP_DIR}/test_ws"
-    local _proj="${TEMP_DIR}/my_generic_project"
-    mkdir -p "${_ws}" "${_proj}"
+  # Default conf has env_example before basename, so .env.example wins
+  local _ws="${TEMP_DIR}/test_ws"
+  local _proj="${TEMP_DIR}/my_generic_project"
+  mkdir -p "${_ws}" "${_proj}"
 
-    echo "IMAGE_NAME=my_custom_image" > "${_proj}/.env.example"
+  echo "IMAGE_NAME=my_custom_image" > "${_proj}/.env.example"
 
-    run bash -c "
-        source /source/script/docker/setup.sh
-        detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
-        main --base-path '${_proj}'
-    "
-    assert_success
-    run grep 'IMAGE_NAME=my_custom_image' "${_proj}/.env"
-    assert_success
+  run bash -c "
+    source /source/script/docker/setup.sh
+    detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
+    main --base-path '${_proj}'
+  "
+  assert_success
+  run grep 'IMAGE_NAME=my_custom_image' "${_proj}/.env"
+  assert_success
 }
 
 @test "main warns when conf has no fallback and detection fails" {
-    # Custom conf without basename rule, no .env.example, no matching prefix/suffix
-    local _ws="${TEMP_DIR}/test_ws"
-    local _proj="${TEMP_DIR}/my_generic_project"
-    mkdir -p "${_ws}" "${_proj}"
+  # Custom conf without basename rule, no .env.example, no matching prefix/suffix
+  local _ws="${TEMP_DIR}/test_ws"
+  local _proj="${TEMP_DIR}/my_generic_project"
+  mkdir -p "${_ws}" "${_proj}"
 
-    cat > "${_proj}/image_name.conf" <<EOF
+  cat > "${_proj}/image_name.conf" <<EOF
 prefix:nonexistent_
 EOF
 
-    run bash -c "
-        source /source/script/docker/setup.sh
-        detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
-        main --base-path '${_proj}'
-    "
-    assert_success
-    assert_line --partial "WARNING"
-    run grep 'IMAGE_NAME=unknown' "${_proj}/.env"
-    assert_success
+  run bash -c "
+    source /source/script/docker/setup.sh
+    detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
+    main --base-path '${_proj}'
+  "
+  assert_success
+  assert_line --partial "WARNING"
+  run grep 'IMAGE_NAME=unknown' "${_proj}/.env"
+  assert_success
 }
 
 @test "main: default conf @default:unknown applies for repo without docker_/_ws naming" {
-    local _ws="${TEMP_DIR}/test_ws"
-    local _proj="${TEMP_DIR}/my_generic_project"
-    mkdir -p "${_ws}" "${_proj}"
+  local _ws="${TEMP_DIR}/test_ws"
+  local _proj="${TEMP_DIR}/my_generic_project"
+  mkdir -p "${_ws}" "${_proj}"
 
-    run bash -c "
-        source /source/script/docker/setup.sh
-        detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
-        main --base-path '${_proj}'
-    "
-    assert_success
-    assert_line --partial "INFO"
-    assert_line --partial "@default"
-    run grep 'IMAGE_NAME=unknown' "${_proj}/.env"
-    assert_success
+  run bash -c "
+    source /source/script/docker/setup.sh
+    detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
+    main --base-path '${_proj}'
+  "
+  assert_success
+  assert_line --partial "INFO"
+  assert_line --partial "@default"
+  run grep 'IMAGE_NAME=unknown' "${_proj}/.env"
+  assert_success
 }
 
 @test "main uses BASH_SOURCE fallback when --base-path not given" {
-    local _ws="${TEMP_DIR}/test_ws"
-    mkdir -p "${_ws}"
-    detect_ws_path() { local -n _o=$1; _o="${_ws}"; }
-    run main
-    assert_success
+  local _ws="${TEMP_DIR}/test_ws"
+  mkdir -p "${_ws}"
+  detect_ws_path() { local -n _o=$1; _o="${_ws}"; }
+  run main
+  assert_success
 }
 
 @test "default _base_path resolves to repo root, not script dir" {
-    # Regression: setup.sh lives at template/script/docker/setup.sh
-    # Default _base_path must go up 3 levels to repo root
-    local _repo_root="${TEMP_DIR}/docker_myapp"
-    mkdir -p "${_repo_root}/template/script/docker" "${_repo_root}/template/config"
-    cp /source/script/docker/setup.sh "${_repo_root}/template/script/docker/setup.sh"
-    cp /source/script/docker/i18n.sh "${_repo_root}/template/script/docker/i18n.sh"
-    cp /source/config/image_name.conf "${_repo_root}/template/config/image_name.conf"
+  # Regression: setup.sh lives at template/script/docker/setup.sh
+  # Default _base_path must go up 3 levels to repo root
+  local _repo_root="${TEMP_DIR}/docker_myapp"
+  mkdir -p "${_repo_root}/template/script/docker" "${_repo_root}/template/config"
+  cp /source/script/docker/setup.sh "${_repo_root}/template/script/docker/setup.sh"
+  cp /source/script/docker/i18n.sh "${_repo_root}/template/script/docker/i18n.sh"
+  cp /source/config/image_name.conf "${_repo_root}/template/config/image_name.conf"
 
-    # Create a dummy ws for detect_ws_path
-    local _ws="${TEMP_DIR}/myapp_ws"
-    mkdir -p "${_ws}"
+  # Create a dummy ws for detect_ws_path
+  local _ws="${TEMP_DIR}/myapp_ws"
+  mkdir -p "${_ws}"
 
-    # Run setup.sh directly (no --base-path), simulating user calling it
-    run bash -c "cd '${_repo_root}' && bash template/script/docker/setup.sh"
-    assert_success
+  # Run setup.sh directly (no --base-path), simulating user calling it
+  run bash -c "cd '${_repo_root}' && bash template/script/docker/setup.sh"
+  assert_success
 
-    # .env should be at repo root, not in template/script/
-    assert [ -f "${_repo_root}/.env" ]
-    assert [ ! -f "${_repo_root}/template/.env" ]
+  # .env should be at repo root, not in template/script/
+  assert [ -f "${_repo_root}/.env" ]
+  assert [ ! -f "${_repo_root}/template/.env" ]
 
-    # IMAGE_NAME should derive from repo root dir (docker_myapp → myapp)
-    run grep "IMAGE_NAME=myapp" "${_repo_root}/.env"
-    assert_success
+  # IMAGE_NAME should derive from repo root dir (docker_myapp → myapp)
+  run grep "IMAGE_NAME=myapp" "${_repo_root}/.env"
+  assert_success
 }
 
 @test "main returns error on unknown argument" {
-    run bash -c "source /source/script/docker/setup.sh; main --invalid-arg"
-    assert_failure
+  run bash -c "source /source/script/docker/setup.sh; main --invalid-arg"
+  assert_failure
 }
 
 @test "main returns error when --base-path value is missing" {
-    run bash -c "source /source/script/docker/setup.sh; main --base-path"
-    assert_failure
+  run bash -c "source /source/script/docker/setup.sh; main --base-path"
+  assert_failure
 }
 
 @test "main sets APT_MIRROR defaults in fresh .env" {
-    local _ws="${TEMP_DIR}/test_ws"
-    mkdir -p "${_ws}"
-    run bash -c "
-        source /source/script/docker/setup.sh
-        detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
-        main --base-path '${TEMP_DIR}'
-    "
-    assert_success
-    run grep "APT_MIRROR_UBUNTU=tw.archive.ubuntu.com" "${TEMP_DIR}/.env"
-    assert_success
-    run grep "APT_MIRROR_DEBIAN=mirror.twds.com.tw" "${TEMP_DIR}/.env"
-    assert_success
+  local _ws="${TEMP_DIR}/test_ws"
+  mkdir -p "${_ws}"
+  run bash -c "
+    source /source/script/docker/setup.sh
+    detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
+    main --base-path '${TEMP_DIR}'
+  "
+  assert_success
+  run grep "APT_MIRROR_UBUNTU=tw.archive.ubuntu.com" "${TEMP_DIR}/.env"
+  assert_success
+  run grep "APT_MIRROR_DEBIAN=mirror.twds.com.tw" "${TEMP_DIR}/.env"
+  assert_success
 }
 
 @test "main preserves existing APT_MIRROR values from .env" {
-    local _ws="${TEMP_DIR}/existing_ws"
-    mkdir -p "${_ws}"
-    cat > "${TEMP_DIR}/.env" << EOF
+  local _ws="${TEMP_DIR}/existing_ws"
+  mkdir -p "${_ws}"
+  cat > "${TEMP_DIR}/.env" << EOF
 WS_PATH=${_ws}
 APT_MIRROR_UBUNTU=us.archive.ubuntu.com
 APT_MIRROR_DEBIAN=deb.debian.org
 EOF
-    run bash -c "
-        source /source/script/docker/setup.sh
-        main --base-path '${TEMP_DIR}'
-    "
-    assert_success
-    run grep "APT_MIRROR_UBUNTU=us.archive.ubuntu.com" "${TEMP_DIR}/.env"
-    assert_success
-    run grep "APT_MIRROR_DEBIAN=deb.debian.org" "${TEMP_DIR}/.env"
-    assert_success
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main --base-path '${TEMP_DIR}'
+  "
+  assert_success
+  run grep "APT_MIRROR_UBUNTU=us.archive.ubuntu.com" "${TEMP_DIR}/.env"
+  assert_success
+  run grep "APT_MIRROR_DEBIAN=deb.debian.org" "${TEMP_DIR}/.env"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -551,31 +551,31 @@ EOF
 # ════════════════════════════════════════════════════════════════════
 
 @test "_msg returns English messages by default" {
-    _LANG="en"
-    assert_equal "$(_msg env_done)"     ".env updated"
-    assert_equal "$(_msg env_comment)"  "Auto-detected fields, do not edit manually. Edit WS_PATH if needed"
-    assert_equal "$(_msg unknown_arg)"  "Unknown argument"
+  _LANG="en"
+  assert_equal "$(_msg env_done)"     ".env updated"
+  assert_equal "$(_msg env_comment)"  "Auto-detected fields, do not edit manually. Edit WS_PATH if needed"
+  assert_equal "$(_msg unknown_arg)"  "Unknown argument"
 }
 
 @test "_msg returns Chinese messages when _LANG=zh" {
-    _LANG="zh"
-    assert_equal "$(_msg env_done)"     ".env 更新完成"
-    assert_equal "$(_msg env_comment)"  "自動偵測欄位請勿手動修改，如需變更 WS_PATH 可直接編輯此檔案"
-    assert_equal "$(_msg unknown_arg)"  "未知參數"
+  _LANG="zh"
+  assert_equal "$(_msg env_done)"     ".env 更新完成"
+  assert_equal "$(_msg env_comment)"  "自動偵測欄位請勿手動修改，如需變更 WS_PATH 可直接編輯此檔案"
+  assert_equal "$(_msg unknown_arg)"  "未知參數"
 }
 
 @test "_msg returns Simplified Chinese messages when _LANG=zh-CN" {
-    _LANG="zh-CN"
-    assert_equal "$(_msg env_done)"     ".env 更新完成"
-    assert_equal "$(_msg env_comment)"  "自动检测字段请勿手动修改，如需变更 WS_PATH 可直接编辑此文件"
-    assert_equal "$(_msg unknown_arg)"  "未知参数"
+  _LANG="zh-CN"
+  assert_equal "$(_msg env_done)"     ".env 更新完成"
+  assert_equal "$(_msg env_comment)"  "自动检测字段请勿手动修改，如需变更 WS_PATH 可直接编辑此文件"
+  assert_equal "$(_msg unknown_arg)"  "未知参数"
 }
 
 @test "_msg returns Japanese messages when _LANG=ja" {
-    _LANG="ja"
-    assert_equal "$(_msg env_done)"     ".env 更新完了"
-    assert_equal "$(_msg env_comment)"  "自動検出フィールドは手動で編集しないでください。WS_PATH の変更はこのファイルを直接編集してください"
-    assert_equal "$(_msg unknown_arg)"  "不明な引数"
+  _LANG="ja"
+  assert_equal "$(_msg env_done)"     ".env 更新完了"
+  assert_equal "$(_msg env_comment)"  "自動検出フィールドは手動で編集しないでください。WS_PATH の変更はこのファイルを直接編集してください"
+  assert_equal "$(_msg unknown_arg)"  "不明な引数"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -583,36 +583,36 @@ EOF
 # ════════════════════════════════════════════════════════════════════
 
 @test "_detect_lang returns zh for zh_TW.UTF-8" {
-    LANG="zh_TW.UTF-8"
-    assert_equal "$(_detect_lang)" "zh"
+  LANG="zh_TW.UTF-8"
+  assert_equal "$(_detect_lang)" "zh"
 }
 
 @test "_detect_lang returns zh-CN for zh_CN.UTF-8" {
-    LANG="zh_CN.UTF-8"
-    assert_equal "$(_detect_lang)" "zh-CN"
+  LANG="zh_CN.UTF-8"
+  assert_equal "$(_detect_lang)" "zh-CN"
 }
 
 @test "_detect_lang returns ja for ja_JP.UTF-8" {
-    LANG="ja_JP.UTF-8"
-    assert_equal "$(_detect_lang)" "ja"
+  LANG="ja_JP.UTF-8"
+  assert_equal "$(_detect_lang)" "ja"
 }
 
 @test "_detect_lang returns en for en_US.UTF-8" {
-    LANG="en_US.UTF-8"
-    assert_equal "$(_detect_lang)" "en"
+  LANG="en_US.UTF-8"
+  assert_equal "$(_detect_lang)" "en"
 }
 
 @test "_detect_lang returns en when LANG is unset" {
-    unset LANG
-    assert_equal "$(_detect_lang)" "en"
+  unset LANG
+  assert_equal "$(_detect_lang)" "en"
 }
 
 @test "_detect_lang is overridden by SETUP_LANG" {
-    LANG="ja_JP.UTF-8"
-    SETUP_LANG="zh"
-    # Re-evaluate _LANG as setup.sh would
-    _LANG="${SETUP_LANG:-$(_detect_lang)}"
-    assert_equal "${_LANG}" "zh"
+  LANG="ja_JP.UTF-8"
+  SETUP_LANG="zh"
+  # Re-evaluate _LANG as setup.sh would
+  _LANG="${SETUP_LANG:-$(_detect_lang)}"
+  assert_equal "${_LANG}" "zh"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -620,18 +620,18 @@ EOF
 # ════════════════════════════════════════════════════════════════════
 
 @test "main --lang zh sets Chinese messages" {
-    local _ws="${TEMP_DIR}/test_ws"
-    mkdir -p "${_ws}"
-    run bash -c "
-        source /source/script/docker/setup.sh
-        detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
-        main --base-path '${TEMP_DIR}' --lang zh
-    "
-    assert_success
-    assert_output --partial ".env 更新完成"
+  local _ws="${TEMP_DIR}/test_ws"
+  mkdir -p "${_ws}"
+  run bash -c "
+    source /source/script/docker/setup.sh
+    detect_ws_path() { local -n _o=\$1; _o='${_ws}'; }
+    main --base-path '${TEMP_DIR}' --lang zh
+  "
+  assert_success
+  assert_output --partial ".env 更新完成"
 }
 
 @test "main --lang requires a value" {
-    run bash -c "source /source/script/docker/setup.sh; main --lang"
-    assert_failure
+  run bash -c "source /source/script/docker/setup.sh; main --lang"
+  assert_failure
 }

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
+  load "${BATS_TEST_DIRNAME}/test_helper"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -9,28 +9,28 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "build.sh exists and is executable" {
-    assert [ -f /source/script/docker/build.sh ]
-    assert [ -x /source/script/docker/build.sh ]
+  assert [ -f /source/script/docker/build.sh ]
+  assert [ -x /source/script/docker/build.sh ]
 }
 
 @test "run.sh exists and is executable" {
-    assert [ -f /source/script/docker/run.sh ]
-    assert [ -x /source/script/docker/run.sh ]
+  assert [ -f /source/script/docker/run.sh ]
+  assert [ -x /source/script/docker/run.sh ]
 }
 
 @test "exec.sh exists and is executable" {
-    assert [ -f /source/script/docker/exec.sh ]
-    assert [ -x /source/script/docker/exec.sh ]
+  assert [ -f /source/script/docker/exec.sh ]
+  assert [ -x /source/script/docker/exec.sh ]
 }
 
 @test "stop.sh exists and is executable" {
-    assert [ -f /source/script/docker/stop.sh ]
-    assert [ -x /source/script/docker/stop.sh ]
+  assert [ -f /source/script/docker/stop.sh ]
+  assert [ -x /source/script/docker/stop.sh ]
 }
 
 @test "setup.sh exists and is executable" {
-    assert [ -f /source/script/docker/setup.sh ]
-    assert [ -x /source/script/docker/setup.sh ]
+  assert [ -f /source/script/docker/setup.sh ]
+  assert [ -x /source/script/docker/setup.sh ]
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -38,36 +38,36 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "ci.sh exists and is executable" {
-    assert [ -f /source/script/ci/ci.sh ]
-    assert [ -x /source/script/ci/ci.sh ]
+  assert [ -f /source/script/ci/ci.sh ]
+  assert [ -x /source/script/ci/ci.sh ]
 }
 
 @test "ci.sh uses set -euo pipefail" {
-    run grep "set -euo pipefail" /source/script/ci/ci.sh
-    assert_success
+  run grep "set -euo pipefail" /source/script/ci/ci.sh
+  assert_success
 }
 
 @test "Makefile exists (repo entry)" {
-    assert [ -f /source/script/docker/Makefile ]
+  assert [ -f /source/script/docker/Makefile ]
 }
 
 @test "Makefile has build target" {
-    run grep -E '^build:' /source/script/docker/Makefile
-    assert_success
+  run grep -E '^build:' /source/script/docker/Makefile
+  assert_success
 }
 
 @test "Makefile.ci exists (template CI)" {
-    assert [ -f /source/Makefile.ci ]
+  assert [ -f /source/Makefile.ci ]
 }
 
 @test "Makefile.ci has test target" {
-    run grep -E '^test:' /source/Makefile.ci
-    assert_success
+  run grep -E '^test:' /source/Makefile.ci
+  assert_success
 }
 
 @test "Makefile.ci has lint target" {
-    run grep -E '^lint:' /source/Makefile.ci
-    assert_success
+  run grep -E '^lint:' /source/Makefile.ci
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -75,19 +75,19 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "test/smoke/test_helper.bash exists" {
-    assert [ -f /source/test/smoke/test_helper.bash ]
+  assert [ -f /source/test/smoke/test_helper.bash ]
 }
 
 @test "test/smoke/script_help.bats exists" {
-    assert [ -f /source/test/smoke/script_help.bats ]
+  assert [ -f /source/test/smoke/script_help.bats ]
 }
 
 @test "test/smoke/display_env.bats exists" {
-    assert [ -f /source/test/smoke/display_env.bats ]
+  assert [ -f /source/test/smoke/display_env.bats ]
 }
 
 @test "test/unit/ directory exists" {
-    assert [ -d /source/test/unit ]
+  assert [ -d /source/test/unit ]
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -95,15 +95,15 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "doc/readme/ directory exists" {
-    assert [ -d /source/doc/readme ]
+  assert [ -d /source/doc/readme ]
 }
 
 @test "doc/test/ directory exists" {
-    assert [ -d /source/doc/test ]
+  assert [ -d /source/doc/test ]
 }
 
 @test "doc/changelog/ directory exists" {
-    assert [ -d /source/doc/changelog ]
+  assert [ -d /source/doc/changelog ]
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -111,13 +111,13 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "build.sh references template/script/docker/setup.sh" {
-    run grep "template/script/docker/setup.sh" /source/script/docker/build.sh
-    assert_success
+  run grep "template/script/docker/setup.sh" /source/script/docker/build.sh
+  assert_success
 }
 
 @test "run.sh references template/script/docker/setup.sh" {
-    run grep "template/script/docker/setup.sh" /source/script/docker/run.sh
-    assert_success
+  run grep "template/script/docker/setup.sh" /source/script/docker/run.sh
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -125,50 +125,50 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "build.sh uses set -euo pipefail" {
-    run grep "set -euo pipefail" /source/script/docker/build.sh
-    assert_success
+  run grep "set -euo pipefail" /source/script/docker/build.sh
+  assert_success
 }
 
 @test "build.sh supports --no-cache flag" {
-    run grep -E '\-\-no-cache' /source/script/docker/build.sh
-    assert_success
+  run grep -E '\-\-no-cache' /source/script/docker/build.sh
+  assert_success
 }
 
 @test "build.sh passes --no-cache to docker compose build when set" {
-    run grep -E 'NO_CACHE.*=.*true' /source/script/docker/build.sh
-    assert_success
+  run grep -E 'NO_CACHE.*=.*true' /source/script/docker/build.sh
+  assert_success
 }
 
 @test "build.sh keeps test-tools image by default (cleanup gated by CLEAN_TOOLS)" {
-    # Default behavior: do NOT auto-remove test-tools:local
-    # cleanup must be conditional on CLEAN_TOOLS
-    run grep -E 'CLEAN_TOOLS.*==.*true' /source/script/docker/build.sh
-    assert_success
+  # Default behavior: do NOT auto-remove test-tools:local
+  # cleanup must be conditional on CLEAN_TOOLS
+  run grep -E 'CLEAN_TOOLS.*==.*true' /source/script/docker/build.sh
+  assert_success
 }
 
 @test "build.sh supports --clean-tools flag" {
-    run grep -E '\-\-clean-tools' /source/script/docker/build.sh
-    assert_success
+  run grep -E '\-\-clean-tools' /source/script/docker/build.sh
+  assert_success
 }
 
 @test "build.sh removes test-tools image when --clean-tools is set" {
-    run grep -E 'CLEAN_TOOLS.*=.*true' /source/script/docker/build.sh
-    assert_success
+  run grep -E 'CLEAN_TOOLS.*=.*true' /source/script/docker/build.sh
+  assert_success
 }
 
 @test "run.sh uses set -euo pipefail" {
-    run grep "set -euo pipefail" /source/script/docker/run.sh
-    assert_success
+  run grep "set -euo pipefail" /source/script/docker/run.sh
+  assert_success
 }
 
 @test "exec.sh uses set -euo pipefail" {
-    run grep "set -euo pipefail" /source/script/docker/exec.sh
-    assert_success
+  run grep "set -euo pipefail" /source/script/docker/exec.sh
+  assert_success
 }
 
 @test "stop.sh uses set -euo pipefail" {
-    run grep "set -euo pipefail" /source/script/docker/stop.sh
-    assert_success
+  run grep "set -euo pipefail" /source/script/docker/stop.sh
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -176,110 +176,110 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "_lib.sh derives PROJECT_NAME from DOCKER_HUB_USER and IMAGE_NAME" {
-    # Project name derivation lives in _lib.sh and is shared by all callers.
-    run grep -E 'PROJECT_NAME=.*DOCKER_HUB_USER.*IMAGE_NAME' /source/script/docker/_lib.sh
-    assert_success
+  # Project name derivation lives in _lib.sh and is shared by all callers.
+  run grep -E 'PROJECT_NAME=.*DOCKER_HUB_USER.*IMAGE_NAME' /source/script/docker/_lib.sh
+  assert_success
 }
 
 @test "_lib.sh _compose_project wraps -p with PROJECT_NAME" {
-    run grep -E '\-p .*PROJECT_NAME' /source/script/docker/_lib.sh
-    assert_success
+  run grep -E '\-p .*PROJECT_NAME' /source/script/docker/_lib.sh
+  assert_success
 }
 
 @test "build.sh routes compose call through _compose_project" {
-    run grep -E '_compose_project ' /source/script/docker/build.sh
-    assert_success
+  run grep -E '_compose_project ' /source/script/docker/build.sh
+  assert_success
 }
 
 @test "run.sh routes compose calls through _compose_project" {
-    run grep -E '_compose_project ' /source/script/docker/run.sh
-    assert_success
+  run grep -E '_compose_project ' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "exec.sh routes compose call through _compose_project" {
-    run grep -E '_compose_project ' /source/script/docker/exec.sh
-    assert_success
+  run grep -E '_compose_project ' /source/script/docker/exec.sh
+  assert_success
 }
 
 @test "stop.sh routes compose call through _compose_project" {
-    run grep -E '_compose_project ' /source/script/docker/stop.sh
-    assert_success
+  run grep -E '_compose_project ' /source/script/docker/stop.sh
+  assert_success
 }
 
 @test "exec.sh loads .env via _load_env helper" {
-    run grep -E '_load_env .*\.env' /source/script/docker/exec.sh
-    assert_success
+  run grep -E '_load_env .*\.env' /source/script/docker/exec.sh
+  assert_success
 }
 
 @test "stop.sh loads .env via _load_env helper" {
-    run grep -E '_load_env .*\.env' /source/script/docker/stop.sh
-    assert_success
+  run grep -E '_load_env .*\.env' /source/script/docker/stop.sh
+  assert_success
 }
 
 @test "_lib.sh defines _load_env helper" {
-    run grep -E '^_load_env\(\)' /source/script/docker/_lib.sh
-    assert_success
+  run grep -E '^_load_env\(\)' /source/script/docker/_lib.sh
+  assert_success
 }
 
 @test "_lib.sh defines _compute_project_name helper" {
-    run grep -E '^_compute_project_name\(\)' /source/script/docker/_lib.sh
-    assert_success
+  run grep -E '^_compute_project_name\(\)' /source/script/docker/_lib.sh
+  assert_success
 }
 
 @test "_lib.sh defines _compose wrapper" {
-    run grep -E '^_compose\(\)' /source/script/docker/_lib.sh
-    assert_success
+  run grep -E '^_compose\(\)' /source/script/docker/_lib.sh
+  assert_success
 }
 
 @test "stop.sh no longer needs orphan cleanup (run.sh devel uses up not run)" {
-    # v0.6.6: run.sh devel switched to compose up + exec, so no more orphan
-    # containers from `compose run --name`. The orphan cleanup line is removed.
-    run grep -E 'docker rm.*-f.*IMAGE_NAME' /source/script/docker/stop.sh
-    assert_failure
+  # v0.6.6: run.sh devel switched to compose up + exec, so no more orphan
+  # containers from `compose run --name`. The orphan cleanup line is removed.
+  run grep -E 'docker rm.*-f.*IMAGE_NAME' /source/script/docker/stop.sh
+  assert_failure
 }
 
 @test "run.sh devel target uses compose up -d (not compose run --name)" {
-    # Regression: foreground devel previously used `compose run --name` which
-    # created a one-off container that `./exec.sh` (compose exec) couldn't see,
-    # producing "service devel is not running". Switched to up + exec.
-    run grep -E 'up -d' /source/script/docker/run.sh
-    assert_success
+  # Regression: foreground devel previously used `compose run --name` which
+  # created a one-off container that `./exec.sh` (compose exec) couldn't see,
+  # producing "service devel is not running". Switched to up + exec.
+  run grep -E 'up -d' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "run.sh devel branch uses compose exec to enter shell" {
-    # Refactored: now goes through `_compose_project exec` wrapper.
-    run grep -E '_compose_project exec' /source/script/docker/run.sh
-    assert_success
+  # Refactored: now goes through `_compose_project exec` wrapper.
+  run grep -E '_compose_project exec' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "run.sh devel branch installs trap to auto-down on exit" {
-    # Refactored: trap calls _devel_cleanup which runs compose down.
-    run grep -E 'trap _devel_cleanup EXIT' /source/script/docker/run.sh
-    assert_success
-    run grep -E '_devel_cleanup\(\)' /source/script/docker/run.sh
-    assert_success
+  # Refactored: trap calls _devel_cleanup which runs compose down.
+  run grep -E 'trap _devel_cleanup EXIT' /source/script/docker/run.sh
+  assert_success
+  run grep -E '_devel_cleanup\(\)' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "run.sh _devel_cleanup uses short timeout to avoid 10s grace period" {
-    # Regression: compose down's default 10s SIGTERM grace makes ./run.sh
-    # appear to hang for ~10s after the user exits the bash shell. Interactive
-    # devel doesn't need graceful shutdown — the user already exited.
-    run grep -E '_devel_cleanup\(\)' /source/script/docker/run.sh
-    assert_success
-    run grep -E 'down -t 0|down --timeout 0' /source/script/docker/run.sh
-    assert_success
+  # Regression: compose down's default 10s SIGTERM grace makes ./run.sh
+  # appear to hang for ~10s after the user exits the bash shell. Interactive
+  # devel doesn't need graceful shutdown — the user already exited.
+  run grep -E '_devel_cleanup\(\)' /source/script/docker/run.sh
+  assert_success
+  run grep -E 'down -t 0|down --timeout 0' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "run.sh non-devel TARGET still uses compose run --rm" {
-    # test/runtime/etc one-shots stay on compose run --rm (no exec needed)
-    run grep -E 'run --rm' /source/script/docker/run.sh
-    assert_success
+  # test/runtime/etc one-shots stay on compose run --rm (no exec needed)
+  run grep -E 'run --rm' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "run.sh devel branch does not use 'compose run --name'" {
-    # The old buggy pattern must be gone for devel; only run --rm for one-shots
-    run grep -E 'run .*--name' /source/script/docker/run.sh
-    assert_failure
+  # The old buggy pattern must be gone for devel; only run --rm for one-shots
+  run grep -E 'run .*--name' /source/script/docker/run.sh
+  assert_failure
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -287,66 +287,66 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "run.sh supports --instance flag" {
-    run grep -E '\-\-instance' /source/script/docker/run.sh
-    assert_success
+  run grep -E '\-\-instance' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "exec.sh supports --instance flag" {
-    run grep -E '\-\-instance' /source/script/docker/exec.sh
-    assert_success
+  run grep -E '\-\-instance' /source/script/docker/exec.sh
+  assert_success
 }
 
 @test "stop.sh supports --instance flag" {
-    run grep -E '\-\-instance' /source/script/docker/stop.sh
-    assert_success
+  run grep -E '\-\-instance' /source/script/docker/stop.sh
+  assert_success
 }
 
 @test "stop.sh supports --all flag" {
-    run grep -E '\-\-all' /source/script/docker/stop.sh
-    assert_success
+  run grep -E '\-\-all' /source/script/docker/stop.sh
+  assert_success
 }
 
 @test "run.sh exports INSTANCE_SUFFIX env var to compose" {
-    # Compose YAML resolves ${INSTANCE_SUFFIX:-} from this env var
-    run grep -E 'INSTANCE_SUFFIX' /source/script/docker/run.sh
-    assert_success
+  # Compose YAML resolves ${INSTANCE_SUFFIX:-} from this env var
+  run grep -E 'INSTANCE_SUFFIX' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "exec.sh exports INSTANCE_SUFFIX env var to compose" {
-    run grep -E 'INSTANCE_SUFFIX' /source/script/docker/exec.sh
-    assert_success
+  run grep -E 'INSTANCE_SUFFIX' /source/script/docker/exec.sh
+  assert_success
 }
 
 @test "stop.sh exports INSTANCE_SUFFIX env var to compose" {
-    run grep -E 'INSTANCE_SUFFIX' /source/script/docker/stop.sh
-    assert_success
+  run grep -E 'INSTANCE_SUFFIX' /source/script/docker/stop.sh
+  assert_success
 }
 
 @test "run.sh refuses when default container already running and no --instance" {
-    # The script should grep docker ps for existing container with the
-    # default name and exit non-zero with a helpful message
-    run grep -E 'already running|already exists' /source/script/docker/run.sh
-    assert_success
+  # The script should grep docker ps for existing container with the
+  # default name and exit non-zero with a helpful message
+  run grep -E 'already running|already exists' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "init.sh-generated compose.yaml uses parameterized container_name" {
-    run grep 'INSTANCE_SUFFIX' /source/init.sh
-    assert_success
+  run grep 'INSTANCE_SUFFIX' /source/init.sh
+  assert_success
 }
 
 @test "run.sh -h shows --instance in help" {
-    run bash -c "bash /source/script/docker/run.sh -h 2>&1"
-    assert_output --partial "--instance"
+  run bash -c "bash /source/script/docker/run.sh -h 2>&1"
+  assert_output --partial "--instance"
 }
 
 @test "exec.sh -h shows --instance in help" {
-    run bash -c "bash /source/script/docker/exec.sh -h 2>&1"
-    assert_output --partial "--instance"
+  run bash -c "bash /source/script/docker/exec.sh -h 2>&1"
+  assert_output --partial "--instance"
 }
 
 @test "stop.sh -h shows --instance in help" {
-    run bash -c "bash /source/script/docker/stop.sh -h 2>&1"
-    assert_output --partial "--instance"
+  run bash -c "bash /source/script/docker/stop.sh -h 2>&1"
+  assert_output --partial "--instance"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -354,43 +354,43 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "build.sh supports --dry-run flag" {
-    run grep -E '\-\-dry-run' /source/script/docker/build.sh
-    assert_success
+  run grep -E '\-\-dry-run' /source/script/docker/build.sh
+  assert_success
 }
 
 @test "run.sh supports --dry-run flag" {
-    run grep -E '\-\-dry-run' /source/script/docker/run.sh
-    assert_success
+  run grep -E '\-\-dry-run' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "exec.sh supports --dry-run flag" {
-    run grep -E '\-\-dry-run' /source/script/docker/exec.sh
-    assert_success
+  run grep -E '\-\-dry-run' /source/script/docker/exec.sh
+  assert_success
 }
 
 @test "stop.sh supports --dry-run flag" {
-    run grep -E '\-\-dry-run' /source/script/docker/stop.sh
-    assert_success
+  run grep -E '\-\-dry-run' /source/script/docker/stop.sh
+  assert_success
 }
 
 @test "build.sh -h shows --dry-run in help" {
-    run bash -c "bash /source/script/docker/build.sh -h 2>&1"
-    assert_output --partial "--dry-run"
+  run bash -c "bash /source/script/docker/build.sh -h 2>&1"
+  assert_output --partial "--dry-run"
 }
 
 @test "run.sh -h shows --dry-run in help" {
-    run bash -c "bash /source/script/docker/run.sh -h 2>&1"
-    assert_output --partial "--dry-run"
+  run bash -c "bash /source/script/docker/run.sh -h 2>&1"
+  assert_output --partial "--dry-run"
 }
 
 @test "exec.sh -h shows --dry-run in help" {
-    run bash -c "bash /source/script/docker/exec.sh -h 2>&1"
-    assert_output --partial "--dry-run"
+  run bash -c "bash /source/script/docker/exec.sh -h 2>&1"
+  assert_output --partial "--dry-run"
 }
 
 @test "stop.sh -h shows --dry-run in help" {
-    run bash -c "bash /source/script/docker/stop.sh -h 2>&1"
-    assert_output --partial "--dry-run"
+  run bash -c "bash /source/script/docker/stop.sh -h 2>&1"
+  assert_output --partial "--dry-run"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -398,55 +398,55 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "exec.sh checks container is running before exec" {
-    # Should reference docker ps / docker inspect or similar precheck
-    run grep -E 'docker (ps|inspect)' /source/script/docker/exec.sh
-    assert_success
+  # Should reference docker ps / docker inspect or similar precheck
+  run grep -E 'docker (ps|inspect)' /source/script/docker/exec.sh
+  assert_success
 }
 
 @test "exec.sh precheck error mentions run.sh hint" {
-    # Friendly error pointing user at ./run.sh or --instance
-    run grep -E 'run\.sh|--instance' /source/script/docker/exec.sh
-    assert_success
+  # Friendly error pointing user at ./run.sh or --instance
+  run grep -E 'run\.sh|--instance' /source/script/docker/exec.sh
+  assert_success
 }
 
 @test "exec.sh exits non-zero with friendly hint when container not running" {
-    # Simulate a tmp repo with .env so exec.sh gets past _load_env, then call
-    # without docker on PATH so the precheck fails (no container can be found).
-    local _tmp
-    _tmp="$(mktemp -d)"
-    cat > "${_tmp}/.env" <<EOF
+  # Simulate a tmp repo with .env so exec.sh gets past _load_env, then call
+  # without docker on PATH so the precheck fails (no container can be found).
+  local _tmp
+  _tmp="$(mktemp -d)"
+  cat > "${_tmp}/.env" <<EOF
 DOCKER_HUB_USER=alice
 IMAGE_NAME=missing-image-$$
 EOF
-    mkdir -p "${_tmp}/template/script/docker"
-    cp /source/script/docker/_lib.sh "${_tmp}/template/script/docker/_lib.sh"
-    cp /source/script/docker/i18n.sh "${_tmp}/template/script/docker/i18n.sh" 2>/dev/null || true
-    cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
+  mkdir -p "${_tmp}/template/script/docker"
+  cp /source/script/docker/_lib.sh "${_tmp}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/template/script/docker/i18n.sh" 2>/dev/null || true
+  cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
 
-    run bash "${_tmp}/exec.sh"
-    assert_failure
-    assert_output --partial "is not running"
-    assert_output --partial "run.sh"
-    rm -rf "${_tmp}"
+  run bash "${_tmp}/exec.sh"
+  assert_failure
+  assert_output --partial "is not running"
+  assert_output --partial "run.sh"
+  rm -rf "${_tmp}"
 }
 
 @test "exec.sh --dry-run skips precheck and prints compose command" {
-    local _tmp
-    _tmp="$(mktemp -d)"
-    cat > "${_tmp}/.env" <<EOF
+  local _tmp
+  _tmp="$(mktemp -d)"
+  cat > "${_tmp}/.env" <<EOF
 DOCKER_HUB_USER=alice
 IMAGE_NAME=ghost-$$
 EOF
-    mkdir -p "${_tmp}/template/script/docker"
-    cp /source/script/docker/_lib.sh "${_tmp}/template/script/docker/_lib.sh"
-    cp /source/script/docker/i18n.sh "${_tmp}/template/script/docker/i18n.sh" 2>/dev/null || true
-    cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
+  mkdir -p "${_tmp}/template/script/docker"
+  cp /source/script/docker/_lib.sh "${_tmp}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/template/script/docker/i18n.sh" 2>/dev/null || true
+  cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
 
-    run bash "${_tmp}/exec.sh" --dry-run
-    assert_success
-    assert_output --partial "[dry-run] docker compose"
-    assert_output --partial "exec"
-    rm -rf "${_tmp}"
+  run bash "${_tmp}/exec.sh" --dry-run
+  assert_success
+  assert_output --partial "[dry-run] docker compose"
+  assert_output --partial "exec"
+  rm -rf "${_tmp}"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -454,93 +454,93 @@ EOF
 # ════════════════════════════════════════════════════════════════════
 
 @test "script/docker/i18n.sh exists" {
-    assert [ -f /source/script/docker/i18n.sh ]
+  assert [ -f /source/script/docker/i18n.sh ]
 }
 
 @test "Dockerfile.test-tools includes bats-mock" {
-    run grep 'bats-mock' /source/dockerfile/Dockerfile.test-tools
-    assert_success
+  run grep 'bats-mock' /source/dockerfile/Dockerfile.test-tools
+  assert_success
 }
 
 @test "i18n.sh defines _detect_lang function" {
-    run grep -E '^_detect_lang\(\)' /source/script/docker/i18n.sh
-    assert_success
+  run grep -E '^_detect_lang\(\)' /source/script/docker/i18n.sh
+  assert_success
 }
 
 @test "build.sh sources _lib.sh" {
-    run grep -E 'source.*_lib\.sh' /source/script/docker/build.sh
-    assert_success
+  run grep -E 'source.*_lib\.sh' /source/script/docker/build.sh
+  assert_success
 }
 
 @test "run.sh sources _lib.sh" {
-    run grep -E 'source.*_lib\.sh' /source/script/docker/run.sh
-    assert_success
+  run grep -E 'source.*_lib\.sh' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "exec.sh sources _lib.sh" {
-    run grep -E 'source.*_lib\.sh' /source/script/docker/exec.sh
-    assert_success
+  run grep -E 'source.*_lib\.sh' /source/script/docker/exec.sh
+  assert_success
 }
 
 @test "stop.sh sources _lib.sh" {
-    run grep -E 'source.*_lib\.sh' /source/script/docker/stop.sh
-    assert_success
+  run grep -E 'source.*_lib\.sh' /source/script/docker/stop.sh
+  assert_success
 }
 
 @test "_lib.sh sources i18n.sh (delegates language detection)" {
-    run grep -E 'source.*i18n\.sh' /source/script/docker/_lib.sh
-    assert_success
+  run grep -E 'source.*i18n\.sh' /source/script/docker/_lib.sh
+  assert_success
 }
 
 @test "setup.sh sources i18n.sh" {
-    run grep -E 'source.*i18n\.sh' /source/script/docker/setup.sh
-    assert_success
+  run grep -E 'source.*i18n\.sh' /source/script/docker/setup.sh
+  assert_success
 }
 
 @test "build.sh -h works when i18n.sh is missing (consumer Dockerfile /lint scenario)" {
-    # Regression: consumer Dockerfile copies *.sh into /lint without template/
-    # tree, so sourcing template/script/docker/i18n.sh fails. build.sh must
-    # gracefully fall back to inline _detect_lang so smoke tests pass.
-    local _tmp
-    _tmp="$(mktemp -d)"
-    cp /source/script/docker/build.sh "${_tmp}/build.sh"
-    run bash "${_tmp}/build.sh" -h
-    assert_success
-    assert_output --partial "Usage"
-    rm -rf "${_tmp}"
+  # Regression: consumer Dockerfile copies *.sh into /lint without template/
+  # tree, so sourcing template/script/docker/i18n.sh fails. build.sh must
+  # gracefully fall back to inline _detect_lang so smoke tests pass.
+  local _tmp
+  _tmp="$(mktemp -d)"
+  cp /source/script/docker/build.sh "${_tmp}/build.sh"
+  run bash "${_tmp}/build.sh" -h
+  assert_success
+  assert_output --partial "Usage"
+  rm -rf "${_tmp}"
 }
 
 @test "run.sh -h works when i18n.sh is missing" {
-    local _tmp
-    _tmp="$(mktemp -d)"
-    cp /source/script/docker/run.sh "${_tmp}/run.sh"
-    run bash "${_tmp}/run.sh" -h
-    assert_success
-    rm -rf "${_tmp}"
+  local _tmp
+  _tmp="$(mktemp -d)"
+  cp /source/script/docker/run.sh "${_tmp}/run.sh"
+  run bash "${_tmp}/run.sh" -h
+  assert_success
+  rm -rf "${_tmp}"
 }
 
 @test "exec.sh -h works when i18n.sh is missing" {
-    local _tmp
-    _tmp="$(mktemp -d)"
-    cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
-    run bash "${_tmp}/exec.sh" -h
-    assert_success
-    rm -rf "${_tmp}"
+  local _tmp
+  _tmp="$(mktemp -d)"
+  cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
+  run bash "${_tmp}/exec.sh" -h
+  assert_success
+  rm -rf "${_tmp}"
 }
 
 @test "stop.sh -h works when i18n.sh is missing" {
-    local _tmp
-    _tmp="$(mktemp -d)"
-    cp /source/script/docker/stop.sh "${_tmp}/stop.sh"
-    run bash "${_tmp}/stop.sh" -h
-    assert_success
-    rm -rf "${_tmp}"
+  local _tmp
+  _tmp="$(mktemp -d)"
+  cp /source/script/docker/stop.sh "${_tmp}/stop.sh"
+  run bash "${_tmp}/stop.sh" -h
+  assert_success
+  rm -rf "${_tmp}"
 }
 
 @test "setup.sh does not redefine _detect_lang" {
-    # setup.sh is not COPY'd into consumer /lint stage, so no fallback needed
-    run grep -cE '^_detect_lang\(\)' /source/script/docker/setup.sh
-    assert_output "0"
+  # setup.sh is not COPY'd into consumer /lint stage, so no fallback needed
+  run grep -cE '^_detect_lang\(\)' /source/script/docker/setup.sh
+  assert_output "0"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -548,71 +548,71 @@ EOF
 # ════════════════════════════════════════════════════════════════════
 
 @test "upgrade.sh runs init.sh after subtree pull" {
-    run grep -E 'init\.sh' /source/upgrade.sh
-    assert_success
+  run grep -E 'init\.sh' /source/upgrade.sh
+  assert_success
 }
 
 @test "upgrade.sh supports --gen-image-conf flag" {
-    run grep -E '\-\-gen-image-conf' /source/upgrade.sh
-    assert_success
+  run grep -E '\-\-gen-image-conf' /source/upgrade.sh
+  assert_success
 }
 
 @test "upgrade.sh --gen-image-conf delegates to init.sh --gen-image-conf" {
-    run grep -E 'init\.sh.*--gen-image-conf' /source/upgrade.sh
-    assert_success
+  run grep -E 'init\.sh.*--gen-image-conf' /source/upgrade.sh
+  assert_success
 }
 
 @test "upgrade.sh --help mentions --gen-image-conf" {
-    run bash -c "bash /source/upgrade.sh --help 2>&1"
-    assert_success
-    assert_output --partial "--gen-image-conf"
+  run bash -c "bash /source/upgrade.sh --help 2>&1"
+  assert_success
+  assert_output --partial "--gen-image-conf"
 }
 
 @test "upgrade.sh updates main.yaml @tag without clobbering release-worker.yaml" {
-    # Regression: a greedy sed pattern .*@v[0-9.]* matched both build-worker
-    # and release-worker references, replacing both with build-worker.yaml@<ver>
-    local _tmp _yaml
-    _tmp="$(mktemp -d)"
-    _yaml="${_tmp}/main.yaml"
-    mkdir -p "${_tmp}/template" "${_tmp}/.github/workflows"
-    cat > "${_yaml}" <<'EOF'
+  # Regression: a greedy sed pattern .*@v[0-9.]* matched both build-worker
+  # and release-worker references, replacing both with build-worker.yaml@<ver>
+  local _tmp _yaml
+  _tmp="$(mktemp -d)"
+  _yaml="${_tmp}/main.yaml"
+  mkdir -p "${_tmp}/template" "${_tmp}/.github/workflows"
+  cat > "${_yaml}" <<'EOF'
 jobs:
   call-docker-build:
     uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v0.5.0
   call-release:
     uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@v0.5.0
 EOF
-    # Source upgrade.sh and exercise just the sed block by inlining the
-    # production sed commands here, mirroring what upgrade.sh does.
-    # We do this by extracting and running the sed commands from upgrade.sh.
-    local _seds
-    _seds="$(grep -E "^[[:space:]]*sed -i" /source/upgrade.sh)"
-    while IFS= read -r _line; do
-        # shellcheck disable=SC2001
-        _line="$(echo "${_line}" | sed "s|\${main_yaml}|${_yaml}|g; s|\${target_ver}|v0.6.4|g")"
-        eval "${_line}"
-    done <<< "${_seds}"
+  # Source upgrade.sh and exercise just the sed block by inlining the
+  # production sed commands here, mirroring what upgrade.sh does.
+  # We do this by extracting and running the sed commands from upgrade.sh.
+  local _seds
+  _seds="$(grep -E "^[[:space:]]*sed -i" /source/upgrade.sh)"
+  while IFS= read -r _line; do
+    # shellcheck disable=SC2001
+    _line="$(echo "${_line}" | sed "s|\${main_yaml}|${_yaml}|g; s|\${target_ver}|v0.6.4|g")"
+    eval "${_line}"
+  done <<< "${_seds}"
 
-    run grep "build-worker.yaml@v0.6.4" "${_yaml}"
-    assert_success
-    run grep "release-worker.yaml@v0.6.4" "${_yaml}"
-    assert_success
-    # Critical: release-worker must NOT be replaced by build-worker
-    run grep -c "build-worker.yaml" "${_yaml}"
-    assert_output "1"
+  run grep "build-worker.yaml@v0.6.4" "${_yaml}"
+  assert_success
+  run grep "release-worker.yaml@v0.6.4" "${_yaml}"
+  assert_success
+  # Critical: release-worker must NOT be replaced by build-worker
+  run grep -c "build-worker.yaml" "${_yaml}"
+  assert_output "1"
 
-    rm -rf "${_tmp}"
+  rm -rf "${_tmp}"
 }
 
 @test "upgrade.sh writes target_ver after init.sh (to override init's latest detection)" {
-    # init.sh writes latest tag to .template_version, but upgrade may target older version
-    # so upgrade.sh must overwrite .template_version AFTER init.sh runs
-    run bash -c "grep -n 'init\.sh\|VERSION_FILE' /source/upgrade.sh | grep -v '^[0-9]*:#'"
-    assert_success
-    # Check that init.sh appears before the final VERSION_FILE write
-    init_line=$(grep -n 'init\.sh' /source/upgrade.sh | head -1 | cut -d: -f1)
-    write_line=$(grep -n 'echo.*target_ver.*>.*VERSION_FILE\|echo.*"\${target_ver}".*VERSION_FILE' /source/upgrade.sh | tail -1 | cut -d: -f1)
-    [[ -n "${init_line}" && -n "${write_line}" && "${init_line}" -lt "${write_line}" ]]
+  # init.sh writes latest tag to .template_version, but upgrade may target older version
+  # so upgrade.sh must overwrite .template_version AFTER init.sh runs
+  run bash -c "grep -n 'init\.sh\|VERSION_FILE' /source/upgrade.sh | grep -v '^[0-9]*:#'"
+  assert_success
+  # Check that init.sh appears before the final VERSION_FILE write
+  init_line=$(grep -n 'init\.sh' /source/upgrade.sh | head -1 | cut -d: -f1)
+  write_line=$(grep -n 'echo.*target_ver.*>.*VERSION_FILE\|echo.*"\${target_ver}".*VERSION_FILE' /source/upgrade.sh | tail -1 | cut -d: -f1)
+  [[ -n "${init_line}" && -n "${write_line}" && "${init_line}" -lt "${write_line}" ]]
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -620,18 +620,18 @@ EOF
 # ════════════════════════════════════════════════════════════════════
 
 @test "run.sh contains XDG_SESSION_TYPE check" {
-    run grep "XDG_SESSION_TYPE" /source/script/docker/run.sh
-    assert_success
+  run grep "XDG_SESSION_TYPE" /source/script/docker/run.sh
+  assert_success
 }
 
 @test "run.sh contains xhost +SI:localuser for wayland" {
-    run grep 'xhost "+SI:localuser' /source/script/docker/run.sh
-    assert_success
+  run grep 'xhost "+SI:localuser' /source/script/docker/run.sh
+  assert_success
 }
 
 @test "run.sh contains xhost +local: for X11" {
-    run grep 'xhost +local:' /source/script/docker/run.sh
-    assert_success
+  run grep 'xhost +local:' /source/script/docker/run.sh
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -639,13 +639,13 @@ EOF
 # ════════════════════════════════════════════════════════════════════
 
 @test "setup.sh default _base_path uses /.." {
-    # In template, setup.sh is at template/script/docker/setup.sh
-    # So it should go up 1 level (/..) to reach repo root
-    run grep -E '\.\./\.\.' /source/script/docker/setup.sh
-    assert_success  # Should have ../../ ../../ (that was old docker_setup_helper/src/ pattern)
+  # In template, setup.sh is at template/script/docker/setup.sh
+  # So it should go up 1 level (/..) to reach repo root
+  run grep -E '\.\./\.\.' /source/script/docker/setup.sh
+  assert_success  # Should have ../../ ../../ (that was old docker_setup_helper/src/ pattern)
 }
 
 @test "setup.sh default _base_path uses double parent traversal" {
-    run grep -E "dirname.*BASH_SOURCE.*\.\..*\.\." /source/script/docker/setup.sh
-    assert_success
+  run grep -E "dirname.*BASH_SOURCE.*\.\..*\.\." /source/script/docker/setup.sh
+  assert_success
 }

--- a/test/unit/terminator_config_spec.bats
+++ b/test/unit/terminator_config_spec.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
-    CONFIG="/source/config/shell/terminator/config"
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  CONFIG="/source/config/shell/terminator/config"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -10,28 +10,28 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "has [global_config] section" {
-    run grep -q "^\[global_config\]" "${CONFIG}"
-    assert_success
+  run grep -q "^\[global_config\]" "${CONFIG}"
+  assert_success
 }
 
 @test "has [keybindings] section" {
-    run grep -q "^\[keybindings\]" "${CONFIG}"
-    assert_success
+  run grep -q "^\[keybindings\]" "${CONFIG}"
+  assert_success
 }
 
 @test "has [profiles] section" {
-    run grep -q "^\[profiles\]" "${CONFIG}"
-    assert_success
+  run grep -q "^\[profiles\]" "${CONFIG}"
+  assert_success
 }
 
 @test "has [layouts] section" {
-    run grep -q "^\[layouts\]" "${CONFIG}"
-    assert_success
+  run grep -q "^\[layouts\]" "${CONFIG}"
+  assert_success
 }
 
 @test "has [plugins] section" {
-    run grep -q "^\[plugins\]" "${CONFIG}"
-    assert_success
+  run grep -q "^\[plugins\]" "${CONFIG}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -39,18 +39,18 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "profiles has [[default]]" {
-    run grep -q "\[\[default\]\]" "${CONFIG}"
-    assert_success
+  run grep -q "\[\[default\]\]" "${CONFIG}"
+  assert_success
 }
 
 @test "default profile disables system font" {
-    run grep -q "use_system_font = False" "${CONFIG}"
-    assert_success
+  run grep -q "use_system_font = False" "${CONFIG}"
+  assert_success
 }
 
 @test "default profile has infinite scrollback" {
-    run grep -q "scrollback_infinite = True" "${CONFIG}"
-    assert_success
+  run grep -q "scrollback_infinite = True" "${CONFIG}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -58,11 +58,11 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "layouts has Window type" {
-    run grep -q "type = Window" "${CONFIG}"
-    assert_success
+  run grep -q "type = Window" "${CONFIG}"
+  assert_success
 }
 
 @test "layouts has Terminal type" {
-    run grep -q "type = Terminal" "${CONFIG}"
-    assert_success
+  run grep -q "type = Terminal" "${CONFIG}"
+  assert_success
 }

--- a/test/unit/terminator_setup_spec.bats
+++ b/test/unit/terminator_setup_spec.bats
@@ -1,18 +1,18 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
-    create_mock_dir
-    TEMP_DIR="$(mktemp -d)"
-    export HOME="${TEMP_DIR}"
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  create_mock_dir
+  TEMP_DIR="$(mktemp -d)"
+  export HOME="${TEMP_DIR}"
 
-    # shellcheck disable=SC1091
-    source /source/config/shell/terminator/setup.sh
+  # shellcheck disable=SC1091
+  source /source/config/shell/terminator/setup.sh
 }
 
 teardown() {
-    cleanup_mock_dir
-    rm -rf "${TEMP_DIR}"
+  cleanup_mock_dir
+  rm -rf "${TEMP_DIR}"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -20,15 +20,15 @@ teardown() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "check_deps returns 0 when terminator is installed" {
-    mock_cmd "terminator" 'exit 0'
-    run check_deps
-    assert_success
+  mock_cmd "terminator" 'exit 0'
+  run check_deps
+  assert_success
 }
 
 @test "check_deps fails when terminator is not installed" {
-    PATH="${MOCK_DIR}" run check_deps
-    assert_failure
-    assert_output --partial "Error:"
+  PATH="${MOCK_DIR}" run check_deps
+  assert_failure
+  assert_output --partial "Error:"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -36,16 +36,16 @@ teardown() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "_entry_point calls main when deps pass" {
-    mock_cmd "terminator" 'exit 0'
-    mock_cmd "chown" 'exit 0'
-    run _entry_point
-    assert_success
+  mock_cmd "terminator" 'exit 0'
+  mock_cmd "chown" 'exit 0'
+  run _entry_point
+  assert_success
 }
 
 @test "_entry_point fails when deps missing" {
-    PATH="${MOCK_DIR}" run _entry_point
-    assert_failure
-    assert_output --partial "Missing dependencies"
+  PATH="${MOCK_DIR}" run _entry_point
+  assert_failure
+  assert_output --partial "Missing dependencies"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -53,27 +53,27 @@ teardown() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "main creates terminator config directory" {
-    mock_cmd "chown" 'exit 0'
-    run main
-    assert [ -d "${TEMP_DIR}/.config/terminator" ]
+  mock_cmd "chown" 'exit 0'
+  run main
+  assert [ -d "${TEMP_DIR}/.config/terminator" ]
 }
 
 @test "main copies terminator config file" {
-    mock_cmd "chown" 'exit 0'
-    run main
-    assert [ -f "${TEMP_DIR}/.config/terminator/config" ]
+  mock_cmd "chown" 'exit 0'
+  run main
+  assert [ -f "${TEMP_DIR}/.config/terminator/config" ]
 }
 
 @test "main calls chown with correct user and group" {
-    mock_cmd "chown" 'echo "chown called: $*"; exit 0'
-    run main
-    assert_success
-    assert_output --partial "chown called:"
+  mock_cmd "chown" 'echo "chown called: $*"; exit 0'
+  run main
+  assert_success
+  assert_output --partial "chown called:"
 }
 
 @test "script runs entry_point when executed directly" {
-    mock_cmd "terminator" 'exit 0'
-    mock_cmd "chown" 'exit 0'
-    run bash /source/config/shell/terminator/setup.sh
-    assert_success
+  mock_cmd "terminator" 'exit 0'
+  mock_cmd "chown" 'exit 0'
+  run bash /source/config/shell/terminator/setup.sh
+  assert_success
 }

--- a/test/unit/tmux_conf_spec.bats
+++ b/test/unit/tmux_conf_spec.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
-    CONF="/source/config/shell/tmux/tmux.conf"
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  CONF="/source/config/shell/tmux/tmux.conf"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -10,23 +10,23 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "defines prefix key" {
-    run grep -q "set-option -g prefix" "${CONF}"
-    assert_success
+  run grep -q "set-option -g prefix" "${CONF}"
+  assert_success
 }
 
 @test "sets default shell to bash" {
-    run grep -q 'default-shell.*bash' "${CONF}"
-    assert_success
+  run grep -q 'default-shell.*bash' "${CONF}"
+  assert_success
 }
 
 @test "sets default terminal" {
-    run grep -q "set -g default-terminal" "${CONF}"
-    assert_success
+  run grep -q "set -g default-terminal" "${CONF}"
+  assert_success
 }
 
 @test "enables mouse support" {
-    run grep -q "set -g mouse on" "${CONF}"
-    assert_success
+  run grep -q "set -g mouse on" "${CONF}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -34,13 +34,13 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "enables vi status-keys" {
-    run grep -q "status-keys vi" "${CONF}"
-    assert_success
+  run grep -q "status-keys vi" "${CONF}"
+  assert_success
 }
 
 @test "enables vi mode-keys" {
-    run grep -q "mode-keys vi" "${CONF}"
-    assert_success
+  run grep -q "mode-keys vi" "${CONF}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -48,13 +48,13 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "defines split-window bindings" {
-    run grep -q "split-window" "${CONF}"
-    assert_success
+  run grep -q "split-window" "${CONF}"
+  assert_success
 }
 
 @test "defines reload config binding" {
-    run grep -q "source-file" "${CONF}"
-    assert_success
+  run grep -q "source-file" "${CONF}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -62,13 +62,13 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "enables status bar" {
-    run grep -q "set-option -g status on" "${CONF}"
-    assert_success
+  run grep -q "set-option -g status on" "${CONF}"
+  assert_success
 }
 
 @test "sets status bar position" {
-    run grep -q "status-position" "${CONF}"
-    assert_success
+  run grep -q "status-position" "${CONF}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -76,11 +76,11 @@ setup() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "declares tpm plugin" {
-    run grep -q "@plugin 'tmux-plugins/tpm'" "${CONF}"
-    assert_success
+  run grep -q "@plugin 'tmux-plugins/tpm'" "${CONF}"
+  assert_success
 }
 
 @test "initializes tpm at end of file" {
-    run grep -q "tpm/tpm" "${CONF}"
-    assert_success
+  run grep -q "tpm/tpm" "${CONF}"
+  assert_success
 }

--- a/test/unit/tmux_setup_spec.bats
+++ b/test/unit/tmux_setup_spec.bats
@@ -1,18 +1,18 @@
 #!/usr/bin/env bats
 
 setup() {
-    load "${BATS_TEST_DIRNAME}/test_helper"
-    create_mock_dir
-    TEMP_DIR="$(mktemp -d)"
-    export HOME="${TEMP_DIR}"
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  create_mock_dir
+  TEMP_DIR="$(mktemp -d)"
+  export HOME="${TEMP_DIR}"
 
-    # shellcheck disable=SC1091
-    source /source/config/shell/tmux/setup.sh
+  # shellcheck disable=SC1091
+  source /source/config/shell/tmux/setup.sh
 }
 
 teardown() {
-    cleanup_mock_dir
-    rm -rf "${TEMP_DIR}"
+  cleanup_mock_dir
+  rm -rf "${TEMP_DIR}"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -20,24 +20,24 @@ teardown() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "check_deps returns 0 when tmux and git are installed" {
-    mock_cmd "tmux" 'exit 0'
-    mock_cmd "git" 'exit 0'
-    run check_deps
-    assert_success
+  mock_cmd "tmux" 'exit 0'
+  mock_cmd "git" 'exit 0'
+  run check_deps
+  assert_success
 }
 
 @test "check_deps fails when tmux is not installed" {
-    mock_cmd "git" 'exit 0'
-    PATH="${MOCK_DIR}" run check_deps
-    assert_failure
-    assert_output --partial "Error:"
+  mock_cmd "git" 'exit 0'
+  PATH="${MOCK_DIR}" run check_deps
+  assert_failure
+  assert_output --partial "Error:"
 }
 
 @test "check_deps fails when git is not installed" {
-    mock_cmd "tmux" 'exit 0'
-    PATH="${MOCK_DIR}" run check_deps
-    assert_failure
-    assert_output --partial "Error:"
+  mock_cmd "tmux" 'exit 0'
+  PATH="${MOCK_DIR}" run check_deps
+  assert_failure
+  assert_output --partial "Error:"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -45,22 +45,22 @@ teardown() {
 # ════════════════════════════════════════════════════════════════════
 
 @test "_entry_point calls main when deps pass" {
-    mock_cmd "tmux" 'exit 0'
-    mock_cmd "git" '
+  mock_cmd "tmux" 'exit 0'
+  mock_cmd "git" '
 if [[ "$1" == "clone" ]]; then
-    mkdir -p "${@: -1}/scripts"
-    echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
-    chmod +x "${@: -1}/scripts/install_plugins.sh"
+  mkdir -p "${@: -1}/scripts"
+  echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
+  chmod +x "${@: -1}/scripts/install_plugins.sh"
 fi
 exit 0'
-    run _entry_point
-    assert_success
+  run _entry_point
+  assert_success
 }
 
 @test "_entry_point fails when deps missing" {
-    PATH="${MOCK_DIR}" run _entry_point
-    assert_failure
-    assert_output --partial "Missing dependencies"
+  PATH="${MOCK_DIR}" run _entry_point
+  assert_failure
+  assert_output --partial "Missing dependencies"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -68,53 +68,53 @@ exit 0'
 # ════════════════════════════════════════════════════════════════════
 
 @test "main clones tpm repository" {
-    mock_cmd "tmux" 'exit 0'
-    mock_cmd "git" '
+  mock_cmd "tmux" 'exit 0'
+  mock_cmd "git" '
 if [[ "$1" == "clone" ]]; then
-    mkdir -p "${@: -1}/scripts"
-    echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
-    chmod +x "${@: -1}/scripts/install_plugins.sh"
+  mkdir -p "${@: -1}/scripts"
+  echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
+  chmod +x "${@: -1}/scripts/install_plugins.sh"
 fi
 exit 0'
-    run main
-    assert [ -d "${TEMP_DIR}/.tmux/plugins/tpm" ]
+  run main
+  assert [ -d "${TEMP_DIR}/.tmux/plugins/tpm" ]
 }
 
 @test "main creates tmux config directory" {
-    mock_cmd "tmux" 'exit 0'
-    mock_cmd "git" '
+  mock_cmd "tmux" 'exit 0'
+  mock_cmd "git" '
 if [[ "$1" == "clone" ]]; then
-    mkdir -p "${@: -1}/scripts"
-    echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
-    chmod +x "${@: -1}/scripts/install_plugins.sh"
+  mkdir -p "${@: -1}/scripts"
+  echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
+  chmod +x "${@: -1}/scripts/install_plugins.sh"
 fi
 exit 0'
-    run main
-    assert [ -d "${TEMP_DIR}/.config/tmux" ]
+  run main
+  assert [ -d "${TEMP_DIR}/.config/tmux" ]
 }
 
 @test "main copies tmux.conf to config directory" {
-    mock_cmd "tmux" 'exit 0'
-    mock_cmd "git" '
+  mock_cmd "tmux" 'exit 0'
+  mock_cmd "git" '
 if [[ "$1" == "clone" ]]; then
-    mkdir -p "${@: -1}/scripts"
-    echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
-    chmod +x "${@: -1}/scripts/install_plugins.sh"
+  mkdir -p "${@: -1}/scripts"
+  echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
+  chmod +x "${@: -1}/scripts/install_plugins.sh"
 fi
 exit 0'
-    run main
-    assert [ -f "${TEMP_DIR}/.config/tmux/tmux.conf" ]
+  run main
+  assert [ -f "${TEMP_DIR}/.config/tmux/tmux.conf" ]
 }
 
 @test "script runs entry_point when executed directly" {
-    mock_cmd "tmux" 'exit 0'
-    mock_cmd "git" '
+  mock_cmd "tmux" 'exit 0'
+  mock_cmd "git" '
 if [[ "$1" == "clone" ]]; then
-    mkdir -p "${@: -1}/scripts"
-    echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
-    chmod +x "${@: -1}/scripts/install_plugins.sh"
+  mkdir -p "${@: -1}/scripts"
+  echo "exit 0" > "${@: -1}/scripts/install_plugins.sh"
+  chmod +x "${@: -1}/scripts/install_plugins.sh"
 fi
 exit 0'
-    run bash /source/config/shell/tmux/setup.sh
-    assert_success
+  run bash /source/config/shell/tmux/setup.sh
+  assert_success
 }


### PR DESCRIPTION
## Summary
- Wrap top-level logic of `build/run/exec/stop.sh` in `main()` (Google rule: scripts containing functions need a `main()`)
- Remove default `set -x` debug tracing from `config/{pip,shell/tmux,shell/terminator}/setup.sh`
- Split lines exceeding the 80-col soft limit in `ci.sh` (kcov `--exclude-path`), `init.sh` (hadolint diff), and `build.sh` (dry-run printf)
- Re-indent all 12 `.bats` files from 4-space to 2-space (Google Shell standard); heredoc bodies preserved untouched

## Notes
- Case-statement indentation was flagged in the audit but verified to already be Google-compliant — no change needed.
- 5 pre-existing Bats `BW01` warnings are out of scope for this PR; tracked in `TODO.md`.

## Test plan
- [x] `make -f Makefile.ci test` — 247/247 pass
- [x] `make -f Makefile.ci lint` — ShellCheck clean
- [x] `bash script/docker/{build,run,exec,stop}.sh -h` — all print usage