### PR TITLE
docs: record Google Style alignment in CHANGELOG [Unreleased]

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Align `build.sh` / `run.sh` / `exec.sh` / `stop.sh` with Google Shell Style
+  Guide: wrap top-level logic in a `main()` function with `local` variables,
+  fix `case` indentation. Behavior unchanged.
+- `config/pip/setup.sh`, `config/shell/tmux/setup.sh`,
+  `config/shell/terminator/setup.sh`: drop `-x` from strict mode
+  (`set -eux` → `set -euo pipefail`) so docker build logs stay quieter.
+  Tracing can still be enabled on demand via `bash -x`.
+- `script/ci/ci.sh`: refactor kcov `--exclude-path` into a readable array
+  instead of one long comma-joined string. Behavior unchanged.
+
 ## [v0.7.1] - 2026-04-10
 
 ### Fixed


### PR DESCRIPTION
## Summary
- #65 merged as pure Google Shell Style alignment (main() wrap, case indent, drop `-x` from config setup scripts)
- Record under `[Unreleased]` so the next release picks it up automatically
- No code changes, just CHANGELOG

## Test plan
- [x] CHANGELOG renders (manual inspection)
- [ ] CI green (test job — docs-only but runs full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)