### PR TITLE
docs: note .bats re-indent in Unreleased CHANGELOG

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Tracing can still be enabled on demand via `bash -x`.
 - `script/ci/ci.sh`: refactor kcov `--exclude-path` into a readable array
   instead of one long comma-joined string. Behavior unchanged.
+- Re-indent all `.bats` files under `test/smoke/`, `test/unit/`, and
+  `test/integration/` from 4-space to 2-space per Google Shell Style Guide.
+  Heredoc bodies untouched. Behavior unchanged; all 247 tests still pass.
 
 ## [v0.7.1] - 2026-04-10
 


### PR DESCRIPTION
## Summary
- The Google Shell Style alignment commit (#65) also re-indented every `.bats` file under `test/smoke/`, `test/unit/`, and `test/integration/` from 4-space to 2-space, but the `[Unreleased]` CHANGELOG entry only listed `build.sh` / `run.sh` / `exec.sh` / `stop.sh`.
- Add one bullet so the upcoming release notes reflect the full scope before tagging `v0.7.2-rc1`.

## Test plan
- [x] CHANGELOG renders correctly (no syntax change, just one extra bullet).
- [x] No code/behavior change; existing CI suffices.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>