### PR TITLE
feat: runtime smoke helpers + expand template self-test coverage to 292

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,63 @@ flowchart LR
 | `exec.sh` | Exec into running containers |
 | `stop.sh` | Stop and remove containers |
 | `script/docker/setup.sh` | Auto-detect system parameters and generate `.env` |
-| `config/` | Shell configs (bashrc, tmux, terminator, pip) |
-| `test/smoke/` | Shared smoke tests for repos |
+| `script/docker/_lib.sh` | Shared helpers (`_load_env`, `_compose`, `_compose_project`, ...) |
+| `script/docker/i18n.sh` | Shared language detection (`_detect_lang`, `_LANG`) |
+| `config/` | Shell configs (bashrc, tmux, terminator, pip) + IMAGE_NAME rules |
+| `test/smoke/` | Shared smoke tests + runtime assertion helpers (see below) |
+| `test/unit/` | Template self-tests (bats + kcov) |
+| `test/integration/` | Level-1 `init.sh` end-to-end tests |
 | `.hadolint.yaml` | Shared Hadolint rules |
 | `Makefile` | Repo entry (`make build`, `make run`, `make stop`, etc.) |
 | `Makefile.ci` | Template CI entry (`make test`, `make -f Makefile.ci lint`, etc.) |
-| `init.sh` | First-time symlink setup |
+| `init.sh` | First-time symlink setup + new-repo scaffolding |
 | `upgrade.sh` | Subtree version upgrade |
 | `script/ci/ci.sh` | CI pipeline (local + remote) |
+| `dockerfile/Dockerfile.example` | Multi-stage Dockerfile template for new repos |
+| `dockerfile/Dockerfile.test-tools` | Pre-built lint/test tools image (shellcheck, hadolint, bats, bats-mock) |
 | `.github/workflows/` | Reusable CI workflows (build + release) |
+
+### Dockerfile stages (convention)
+
+Downstream repos follow a standard multi-stage layout, defined in
+`dockerfile/Dockerfile.example`. All stages share a common base image
+parameterized by `ARG BASE_IMAGE`.
+
+| Stage | Parent | Purpose | Shipped? |
+|-------|--------|---------|----------|
+| `sys` | `${BASE_IMAGE}` | User/group, sudo, timezone, locale, APT mirror | intermediate |
+| `base` | `sys` | Development tools and language packages | intermediate |
+| `devel` | `base` | App-specific tools + `entrypoint.sh` + PlotJuggler (env repos) | **yes** (primary artifact) |
+| `test` | `devel` | Ephemeral: ShellCheck + Hadolint + Bats smoke (all from `test-tools:local`) | no (discarded) |
+| `runtime-base` (optional) | `sys` | Minimal runtime deps (sudo, tini) | intermediate |
+| `runtime` (optional) | `runtime-base` | Slim runtime image (application repos only) | yes, when enabled |
+
+Notes:
+- Repos that only ship a developer image (`env/*`) skip `runtime-base` /
+  `runtime` — the section stays commented in `Dockerfile.example`.
+- `test` is always built from `devel`, so runtime assertions inside
+  `test/smoke/<repo>_env.bats` see the same binaries / files a user would
+  find after `docker run ... <repo>:devel`.
+- `Dockerfile.test-tools` builds a separate `test-tools:local` image (not
+  part of the stage chain above) that the `test` stage copies bats /
+  shellcheck / hadolint binaries from via `COPY --from=test-tools:local`.
+
+### Smoke test helpers (for downstream repos)
+
+`test/smoke/test_helper.bash` (loaded by every smoke spec via
+`load "${BATS_TEST_DIRNAME}/test_helper"`) ships a small set of runtime
+assertion helpers. Downstream repos should prefer these over ad-hoc
+`[ -f ... ]` / `command -v` checks so failures produce decorated
+diagnostics pointing at the missing artifact.
+
+| Helper | Usage |
+|--------|-------|
+| `assert_cmd_installed <cmd>` | Fails unless `<cmd>` is on `PATH` |
+| `assert_cmd_runs <cmd> [flag]` | Fails unless `<cmd> <flag>` exits 0 (default flag: `--version`) |
+| `assert_file_exists <path>` | Fails unless `<path>` is a regular file |
+| `assert_dir_exists <path>` | Fails unless `<path>` is a directory |
+| `assert_file_owned_by <user> <path>` | Fails unless `<path>`'s owner is `<user>` |
+| `assert_pip_pkg <pkg>` | Fails unless `pip show <pkg>` returns 0 |
 
 ### What stays in each repo (not shared)
 
@@ -230,37 +278,59 @@ template/
 │   │   ├── exec.sh
 │   │   ├── stop.sh
 │   │   ├── setup.sh                  # .env generator
+│   │   ├── _lib.sh                   # Shared helpers (_load_env, _compose, _compose_project)
+│   │   ├── i18n.sh                   # Shared language detection (_detect_lang, _LANG)
 │   │   └── Makefile
 │   └── ci/
 │       └── ci.sh                     # CI pipeline (local + remote)
 ├── dockerfile/
-│   ├── Dockerfile.test-tools         # Pre-built test tools image
-│   └── Dockerfile.example            # Dockerfile template for new repos
+│   ├── Dockerfile.test-tools         # Pre-built lint/test tools image
+│   └── Dockerfile.example            # Dockerfile template for new repos (sys → base → devel → test → [runtime])
 ├── config/                           # Shell/tool configs + IMAGE_NAME rules
 │   ├── image_name.conf               # Default IMAGE_NAME detection rules
 │   ├── pip/
+│   │   ├── setup.sh
+│   │   └── requirements.txt
 │   └── shell/
 │       ├── bashrc
 │       ├── terminator/
+│       │   ├── setup.sh
+│       │   └── config
 │       └── tmux/
+│           ├── setup.sh
+│           └── tmux.conf
 ├── test/
-│   ├── smoke/                        # Shared tests for repos
-│   │   ├── test_helper.bash
+│   ├── smoke/                        # Shared smoke tests + runtime assertion helpers
+│   │   ├── test_helper.bash          #  → assert_cmd_installed / _runs / file / dir / owned_by / pip_pkg
 │   │   ├── script_help.bats
 │   │   └── display_env.bats
-│   └── unit/                         # Template self-tests
+│   ├── unit/                         # Template self-tests (bats + kcov)
+│   │   ├── test_helper.bash
+│   │   ├── bashrc_spec.bats
+│   │   ├── ci_spec.bats              # ci.sh _install_deps
+│   │   ├── lib_spec.bats             # _lib.sh
+│   │   ├── pip_setup_spec.bats
+│   │   ├── setup_spec.bats
+│   │   ├── smoke_helper_spec.bats    # Runtime assertion helpers
+│   │   ├── template_spec.bats
+│   │   ├── terminator_config_spec.bats
+│   │   ├── terminator_setup_spec.bats
+│   │   ├── tmux_conf_spec.bats
+│   │   └── tmux_setup_spec.bats
+│   └── integration/
+│       └── init_new_repo_spec.bats   # Level-1 init.sh end-to-end
 ├── Makefile.ci                       # Template CI entry (make test/lint/...)
 ├── compose.yaml                      # Docker CI runner
 ├── .hadolint.yaml                    # Shared Hadolint rules
+├── codecov.yml
 ├── .github/workflows/
 │   ├── self-test.yaml                # Template CI
 │   ├── build-worker.yaml             # Reusable build workflow
 │   └── release-worker.yaml           # Reusable release workflow
 ├── doc/
-│   ├── readme/                       # README translations
-│   ├── test/                         # TEST.md
-│   └── changelog/                    # CHANGELOG.md
-├── .codecov.yaml
+│   ├── readme/                       # README translations (zh-TW / zh-CN / ja)
+│   ├── test/TEST.md                  # Test catalog (spec tables)
+│   └── changelog/CHANGELOG.md        # Release notes
 ├── .gitignore
 ├── LICENSE
 └── README.md

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `test/smoke/test_helper.bash`: shared runtime assertion helpers for
+  downstream-repo smoke specs — `assert_cmd_installed`, `assert_cmd_runs`,
+  `assert_file_exists`, `assert_dir_exists`, `assert_file_owned_by`,
+  `assert_pip_pkg`. Each prints a decorated diagnostic on failure so the
+  bats log points at the exact missing artifact. Keeps downstream smoke
+  specs terse and self-documenting.
+- `init.sh` new-repo skeleton now emits two sample smoke assertions
+  (`entrypoint.sh is installed and executable`, `bash is available on
+  PATH`) demonstrating the shared helpers, instead of one bare
+  `[ -x /entrypoint.sh ]` assertion.
+- `test/unit/ci_spec.bats` (5 tests): covers `script/ci/ci.sh`
+  `_install_deps` — happy path plus the three explicit error branches
+  for `apt-get update` / `apt-get install` / `git clone bats-mock`.
+- `test/unit/smoke_helper_spec.bats` (19 tests): unit coverage for every
+  runtime assertion helper above, including failure paths.
+- `test/unit/setup_spec.bats`: 3 new `detect_ws_path` cases — explicit
+  ERROR on missing `base_path`, and path-normalization coverage for
+  strategies 1 and 3 when the input contains `..` segments.
+- `test/unit/init_spec.bats` (15 tests): unit coverage for `init.sh`
+  helpers previously reachable only through the Level-1 integration
+  test — `_detect_template_version` (git-remote parsing, failure
+  paths, rc-tag filtering), `_create_version_file` (parameterized
+  version, `unknown` fallback, overwrite), `_create_new_repo`
+  (workflow `@ref` threading including empty-ref → `@main` fallback),
+  and `_create_symlinks` (full symlink set, stale-file replacement,
+  custom `.hadolint.yaml` preservation).
+- `test/unit/ci_spec.bats`: 3 new `_run_shellcheck` tests — wired-file
+  regression guard, `script/docker/*.sh` discovery via `find`, and
+  strict-mode propagation on lint failure.
+
+### Fixed
+- `init.sh`: stop hard-coding `v0.5.0` as the fallback version in the
+  generated `main.yaml`. Workflow refs now fall back to the `main` branch
+  (a valid git ref) when no tag is detected, instead of an arbitrary old
+  tag. Version detection is done once up-front and shared between
+  `.template_version` and the reusable-workflow `@ref`.
+- `script/docker/setup.sh` `detect_ws_path`: normalize `base_path` with
+  `cd ... && pwd -P` before composing sibling/parent paths, so relative
+  or `..`-laden inputs do not produce surprising matches. Emits a clear
+  error when the base path does not exist.
+- `script/docker/setup.sh`: use `${0:-}` consistently in the
+  `BASH_SOURCE == $0` guard (line 400) for parity with line 51.
+- `script/ci/ci.sh` `_install_deps`: emit explicit error messages when
+  `apt-get update`, `apt-get install`, or `git clone bats-mock` fails,
+  instead of relying on `set -e` to exit silently.
+
+### Changed
+- `script/ci/ci.sh`: guard `main "$@"` and `set -euo pipefail` behind a
+  `BASH_SOURCE == $0` check so the helpers (`_install_deps`, `_die`) can
+  be sourced by unit tests without executing the CI pipeline. Matches
+  the pattern already used in `script/docker/setup.sh`.
+- `init.sh`: wrap top-level flow in `main()` + `BASH_SOURCE == $0` guard
+  so helpers (`_detect_template_version`, `_create_version_file`,
+  `_create_new_repo`, `_create_symlinks`) are sourceable from unit
+  tests without triggering a full `init.sh` run. Strict mode is also
+  gated so sourcing respects the caller's settings. Behaviour when
+  invoked directly is unchanged.
+
 ## [v0.7.2] - 2026-04-14
 
 ### Changed

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -112,15 +112,65 @@ flowchart LR
 | `exec.sh` | 実行中のコンテナに入る |
 | `stop.sh` | コンテナの停止・削除 |
 | `script/docker/setup.sh` | システムパラメータの自動検出と `.env` 生成 |
-| `config/` | シェル設定ファイル（bashrc、tmux、terminator、pip） |
-| `test/smoke/` | 各 Docker repo 用の共有テスト |
+| `script/docker/_lib.sh` | 共有 helper（`_load_env`、`_compose`、`_compose_project` など） |
+| `script/docker/i18n.sh` | 共有言語検出（`_detect_lang`、`_LANG`） |
+| `config/` | シェル設定ファイル（bashrc、tmux、terminator、pip）+ IMAGE_NAME ルール |
+| `test/smoke/` | 共有 smoke テスト + runtime assertion helpers（下記参照） |
+| `test/unit/` | Template 自身のテスト（bats + kcov） |
+| `test/integration/` | Level-1 `init.sh` 統合テスト |
 | `.hadolint.yaml` | 共有 Hadolint ルール |
 | `Makefile` | Repo コマンドエントリ（`make build`、`make run`、`make stop` 等） |
 | `Makefile.ci` | Template CI コマンドエントリ（`make test`、`make lint` 等） |
-| `init.sh` | 初回 symlink セットアップ |
+| `init.sh` | 初回 symlink セットアップ + 新 repo スケルトン生成 |
 | `upgrade.sh` | Subtree バージョンアップグレード |
 | `script/ci/ci.sh` | CI パイプライン（ローカル + リモート） |
+| `dockerfile/Dockerfile.example` | 新 repo のマルチステージ Dockerfile テンプレート |
+| `dockerfile/Dockerfile.test-tools` | プリビルド lint/test ツール image（shellcheck、hadolint、bats、bats-mock） |
 | `.github/workflows/` | 再利用可能な CI workflows（build + release） |
+
+### Dockerfile ステージ（規約）
+
+ダウンストリーム repo は `dockerfile/Dockerfile.example` で定義される標準のマルチステージ構成に従います。
+すべてのステージは `ARG BASE_IMAGE` で指定されるベース image を共有します。
+
+| ステージ | 親ステージ | 用途 | 出荷 |
+|----------|------------|------|------|
+| `sys` | `${BASE_IMAGE}` | ユーザー/グループ、sudo、タイムゾーン、ロケール、APT mirror | 中間 |
+| `base` | `sys` | 開発ツールと言語パッケージ | 中間 |
+| `devel` | `base` | アプリ固有ツール + `entrypoint.sh` + PlotJuggler（env repos） | **はい**（主成果物） |
+| `test` | `devel` | 一時的：ShellCheck + Hadolint + Bats smoke（いずれも `test-tools:local` から） | いいえ（build 後破棄） |
+| `runtime-base`（任意） | `sys` | 最小 runtime 依存（sudo、tini） | 中間 |
+| `runtime`（任意） | `runtime-base` | 軽量 runtime image（application repos で使用） | 有効時に出荷 |
+
+補足：
+- developer image のみを出荷する repo（`env/*`）は `runtime-base` /
+  `runtime` をスキップし、該当セクションは `Dockerfile.example` 内で
+  コメントアウトしたままにします。
+- `test` は常に `devel` を継承するため、`test/smoke/<repo>_env.bats` の
+  runtime assertion が確認するバイナリやファイルは、ユーザーが
+  `docker run ... <repo>:devel` で目にするものと一致します。
+- `Dockerfile.test-tools` は別途 `test-tools:local` image をビルドし
+  （上記ステージ連鎖には含まれません）、`test` ステージが
+  `COPY --from=test-tools:local` で bats / shellcheck / hadolint
+  バイナリを取り込みます。
+
+### Smoke test ヘルパー（ダウンストリーム repo 用）
+
+`test/smoke/test_helper.bash`（各 smoke spec が
+`load "${BATS_TEST_DIRNAME}/test_helper"` で読み込み）が runtime
+assertion helpers のセットを提供します。ダウンストリーム repo は
+素の `[ -f ... ]` / `command -v` より優先してこれらの helper を使用
+すべきです。失敗時は欠落している成果物を直接指し示す decorated な
+診断メッセージを出力します。
+
+| Helper | 用法 |
+|--------|------|
+| `assert_cmd_installed <cmd>` | `<cmd>` が `PATH` 上にない場合に失敗 |
+| `assert_cmd_runs <cmd> [flag]` | `<cmd> <flag>` が 0 以外で終了した場合に失敗（flag のデフォルトは `--version`） |
+| `assert_file_exists <path>` | `<path>` が通常ファイルでない場合に失敗 |
+| `assert_dir_exists <path>` | `<path>` がディレクトリでない場合に失敗 |
+| `assert_file_owned_by <user> <path>` | `<path>` の所有者が `<user>` でない場合に失敗 |
+| `assert_pip_pkg <pkg>` | `pip show <pkg>` が 0 以外で終了した場合に失敗 |
 
 ### 各 repo で個別管理するファイル（共有しない）
 
@@ -230,37 +280,59 @@ template/
 │   │   ├── exec.sh
 │   │   ├── stop.sh
 │   │   ├── setup.sh                  # .env ジェネレータ
+│   │   ├── _lib.sh                   # 共有 helper（_load_env、_compose、_compose_project）
+│   │   ├── i18n.sh                   # 共有言語検出（_detect_lang、_LANG）
 │   │   └── Makefile
 │   └── ci/
 │       └── ci.sh                     # CI パイプライン（ローカル + リモート）
 ├── dockerfile/
-│   ├── Dockerfile.test-tools         # プリビルドテストツール image
-│   └── Dockerfile.example            # 新 repo の Dockerfile テンプレート
+│   ├── Dockerfile.test-tools         # プリビルド lint/test ツール image
+│   └── Dockerfile.example            # 新 repo の Dockerfile テンプレート（sys → base → devel → test → [runtime]）
 ├── config/                           # シェル/ツール設定 + IMAGE_NAME ルール
 │   ├── image_name.conf               # デフォルト IMAGE_NAME 検出ルール
 │   ├── pip/
+│   │   ├── setup.sh
+│   │   └── requirements.txt
 │   └── shell/
 │       ├── bashrc
 │       ├── terminator/
+│       │   ├── setup.sh
+│       │   └── config
 │       └── tmux/
+│           ├── setup.sh
+│           └── tmux.conf
 ├── test/
-│   ├── smoke/                        # 各 repo 用の共有テスト
-│   │   ├── test_helper.bash
+│   ├── smoke/                        # 共有 smoke テスト + runtime assertion helpers
+│   │   ├── test_helper.bash          #  → assert_cmd_installed / _runs / file / dir / owned_by / pip_pkg
 │   │   ├── script_help.bats
 │   │   └── display_env.bats
-│   └── unit/                         # テンプレート自身のテスト
+│   ├── unit/                         # テンプレート自身のテスト（bats + kcov）
+│   │   ├── test_helper.bash
+│   │   ├── bashrc_spec.bats
+│   │   ├── ci_spec.bats              # ci.sh _install_deps
+│   │   ├── lib_spec.bats             # _lib.sh
+│   │   ├── pip_setup_spec.bats
+│   │   ├── setup_spec.bats
+│   │   ├── smoke_helper_spec.bats    # Runtime assertion helpers
+│   │   ├── template_spec.bats
+│   │   ├── terminator_config_spec.bats
+│   │   ├── terminator_setup_spec.bats
+│   │   ├── tmux_conf_spec.bats
+│   │   └── tmux_setup_spec.bats
+│   └── integration/
+│       └── init_new_repo_spec.bats   # Level-1 init.sh 統合テスト
 ├── Makefile.ci                       # テンプレート CI エントリ（make test/lint/...）
 ├── compose.yaml                      # Docker CI ランナー
 ├── .hadolint.yaml                    # 共有 Hadolint ルール
+├── codecov.yml
 ├── .github/workflows/
 │   ├── self-test.yaml                # テンプレート CI
 │   ├── build-worker.yaml             # 再利用可能なビルド workflow
 │   └── release-worker.yaml           # 再利用可能なリリース workflow
 ├── doc/
-│   ├── readme/                       # README 翻訳
-│   ├── test/                         # TEST.md
-│   └── changelog/                    # CHANGELOG.md
-├── .codecov.yaml
+│   ├── readme/                       # README 翻訳（zh-TW / zh-CN / ja）
+│   ├── test/TEST.md                  # テスト一覧
+│   └── changelog/CHANGELOG.md        # リリース記録
 ├── .gitignore
 ├── LICENSE
 └── README.md

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -112,15 +112,62 @@ flowchart LR
 | `exec.sh` | 进入运行中的容器 |
 | `stop.sh` | 停止并移除容器 |
 | `script/docker/setup.sh` | 自动检测系统参数并生成 `.env` |
-| `config/` | Shell 配置文件（bashrc、tmux、terminator、pip） |
-| `test/smoke/` | 给各 Docker repo 使用的共用测试 |
+| `script/docker/_lib.sh` | 共用 helper（`_load_env`、`_compose`、`_compose_project` 等） |
+| `script/docker/i18n.sh` | 共用语言检测（`_detect_lang`、`_LANG`） |
+| `config/` | Shell 配置文件（bashrc、tmux、terminator、pip）+ IMAGE_NAME 规则 |
+| `test/smoke/` | 共用 smoke 测试 + runtime assertion helpers（见下方） |
+| `test/unit/` | Template 自身测试（bats + kcov） |
+| `test/integration/` | Level-1 `init.sh` 集成测试 |
 | `.hadolint.yaml` | 共用 Hadolint 规则 |
 | `Makefile` | Repo 命令入口（`make build`、`make run`、`make stop` 等） |
 | `Makefile.ci` | Template CI 命令入口（`make test`、`make lint` 等） |
-| `init.sh` | 首次初始化 symlinks |
+| `init.sh` | 首次初始化 symlinks + 新 repo 骨架生成 |
 | `upgrade.sh` | Subtree 版本升级 |
 | `script/ci/ci.sh` | CI pipeline（本地 + 远端） |
+| `dockerfile/Dockerfile.example` | 新 repo 的多阶段 Dockerfile 模板 |
+| `dockerfile/Dockerfile.test-tools` | 预构建 lint/test 工具 image（shellcheck、hadolint、bats、bats-mock） |
 | `.github/workflows/` | 可重用 CI workflows（build + release） |
+
+### Dockerfile 分层（约定）
+
+下游 repo 遵循标准多阶段配置，定义于 `dockerfile/Dockerfile.example`。
+所有阶段共用 `ARG BASE_IMAGE` 指定的基础镜像。
+
+| 阶段 | 父阶段 | 用途 | 是否出货 |
+|------|--------|------|---------|
+| `sys` | `${BASE_IMAGE}` | 用户/用户组、sudo、时区、语系、APT mirror | 中间 |
+| `base` | `sys` | 开发工具与语言套件 | 中间 |
+| `devel` | `base` | 应用专属工具 + `entrypoint.sh` + PlotJuggler（env repos） | **是**（主要产物） |
+| `test` | `devel` | 短暂：ShellCheck + Hadolint + Bats smoke（均来自 `test-tools:local`） | 否（build 完即丢） |
+| `runtime-base`（可选） | `sys` | 最小 runtime 依赖（sudo、tini） | 中间 |
+| `runtime`（可选） | `runtime-base` | 精简 runtime 镜像（application repos 使用） | 启用时出货 |
+
+说明：
+- 只出货 developer image 的 repo（`env/*`）会跳过 `runtime-base` /
+  `runtime`——该 section 在 `Dockerfile.example` 保持注释状态。
+- `test` 总是从 `devel` 继承，所以 `test/smoke/<repo>_env.bats` 中的
+  runtime assertion 所看到的二进制与文件，就是用户 `docker run ...
+  <repo>:devel` 后会看到的内容。
+- `Dockerfile.test-tools` 另外构建一个 `test-tools:local` image（不在
+  上面的阶段链中），`test` 阶段通过 `COPY --from=test-tools:local`
+  把 bats / shellcheck / hadolint 二进制拉进来。
+
+### Smoke test helpers（供下游 repo 使用）
+
+`test/smoke/test_helper.bash`（每个 smoke spec 通过
+`load "${BATS_TEST_DIRNAME}/test_helper"` 加载）提供一组 runtime
+assertion helpers。下游 repo 应优先使用这些 helper 而非原生的
+`[ -f ... ]` / `command -v`，失败时会输出 decorated 诊断信息直指缺少
+的工件。
+
+| Helper | 用法 |
+|--------|------|
+| `assert_cmd_installed <cmd>` | `<cmd>` 不在 `PATH` 上时失败 |
+| `assert_cmd_runs <cmd> [flag]` | `<cmd> <flag>` 非 0 时失败（flag 默认 `--version`） |
+| `assert_file_exists <path>` | `<path>` 非 regular file 时失败 |
+| `assert_dir_exists <path>` | `<path>` 非目录时失败 |
+| `assert_file_owned_by <user> <path>` | `<path>` 所有者不是 `<user>` 时失败 |
+| `assert_pip_pkg <pkg>` | `pip show <pkg>` 非 0 时失败 |
 
 ### 各 repo 自行维护的文件（不共用）
 
@@ -230,37 +277,59 @@ template/
 │   │   ├── exec.sh
 │   │   ├── stop.sh
 │   │   ├── setup.sh                  # .env 生成器
+│   │   ├── _lib.sh                   # 共用 helper（_load_env、_compose、_compose_project）
+│   │   ├── i18n.sh                   # 共用语言检测（_detect_lang、_LANG）
 │   │   └── Makefile
 │   └── ci/
 │       └── ci.sh                     # CI pipeline（本地 + 远端）
 ├── dockerfile/
-│   ├── Dockerfile.test-tools         # 预构建测试工具 image
-│   └── Dockerfile.example            # 新 repo 的 Dockerfile 模板
+│   ├── Dockerfile.test-tools         # 预构建 lint/测试工具 image
+│   └── Dockerfile.example            # 新 repo 的 Dockerfile 模板（sys → base → devel → test → [runtime]）
 ├── config/                           # Shell/工具配置 + IMAGE_NAME 规则
 │   ├── image_name.conf               # 默认 IMAGE_NAME 检测规则
 │   ├── pip/
+│   │   ├── setup.sh
+│   │   └── requirements.txt
 │   └── shell/
 │       ├── bashrc
 │       ├── terminator/
+│       │   ├── setup.sh
+│       │   └── config
 │       └── tmux/
+│           ├── setup.sh
+│           └── tmux.conf
 ├── test/
-│   ├── smoke/                        # 给各 repo 使用的共用测试
-│   │   ├── test_helper.bash
+│   ├── smoke/                        # 共用 smoke 测试 + runtime assertion helpers
+│   │   ├── test_helper.bash          #  → assert_cmd_installed / _runs / file / dir / owned_by / pip_pkg
 │   │   ├── script_help.bats
 │   │   └── display_env.bats
-│   └── unit/                         # 模板自身测试
+│   ├── unit/                         # 模板自身测试（bats + kcov）
+│   │   ├── test_helper.bash
+│   │   ├── bashrc_spec.bats
+│   │   ├── ci_spec.bats              # ci.sh _install_deps
+│   │   ├── lib_spec.bats             # _lib.sh
+│   │   ├── pip_setup_spec.bats
+│   │   ├── setup_spec.bats
+│   │   ├── smoke_helper_spec.bats    # Runtime assertion helpers
+│   │   ├── template_spec.bats
+│   │   ├── terminator_config_spec.bats
+│   │   ├── terminator_setup_spec.bats
+│   │   ├── tmux_conf_spec.bats
+│   │   └── tmux_setup_spec.bats
+│   └── integration/
+│       └── init_new_repo_spec.bats   # Level-1 init.sh 集成测试
 ├── Makefile.ci                       # 模板 CI 入口（make test/lint/...）
 ├── compose.yaml                      # Docker CI 运行器
 ├── .hadolint.yaml                    # 共用 Hadolint 规则
+├── codecov.yml
 ├── .github/workflows/
 │   ├── self-test.yaml                # 模板 CI
 │   ├── build-worker.yaml             # 可重用构建 workflow
 │   └── release-worker.yaml           # 可重用发布 workflow
 ├── doc/
-│   ├── readme/                       # README 翻译
-│   ├── test/                         # TEST.md + 翻译
-│   └── changelog/                    # CHANGELOG.md + 翻译
-├── .codecov.yaml
+│   ├── readme/                       # README 翻译（zh-TW / zh-CN / ja）
+│   ├── test/TEST.md                  # 测试清单
+│   └── changelog/CHANGELOG.md        # 发布记录
 ├── .gitignore
 ├── LICENSE
 └── README.md

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -112,15 +112,62 @@ flowchart LR
 | `exec.sh` | 進入執行中的容器 |
 | `stop.sh` | 停止並移除容器 |
 | `script/docker/setup.sh` | 自動偵測系統參數並產生 `.env` |
-| `config/` | Shell 設定檔（bashrc、tmux、terminator、pip） |
-| `test/smoke/` | 給各 Docker repo 使用的共用測試 |
+| `script/docker/_lib.sh` | 共用 helper（`_load_env`、`_compose`、`_compose_project` 等） |
+| `script/docker/i18n.sh` | 共用語言偵測（`_detect_lang`、`_LANG`） |
+| `config/` | Shell 設定檔（bashrc、tmux、terminator、pip）+ IMAGE_NAME 規則 |
+| `test/smoke/` | 共用 smoke 測試 + runtime assertion helpers（見下方） |
+| `test/unit/` | Template 自身測試（bats + kcov） |
+| `test/integration/` | Level-1 `init.sh` 整合測試 |
 | `.hadolint.yaml` | 共用 Hadolint 規則 |
 | `Makefile` | Repo 指令入口（`make build`、`make run`、`make stop` 等） |
 | `Makefile.ci` | Template CI 指令入口（`make test`、`make lint` 等） |
-| `init.sh` | 首次初始化 symlinks |
+| `init.sh` | 首次初始化 symlinks + 新 repo 骨架產生 |
 | `upgrade.sh` | Subtree 版本升級 |
 | `script/ci/ci.sh` | CI pipeline（本地 + 遠端） |
+| `dockerfile/Dockerfile.example` | 新 repo 的多階段 Dockerfile 範本 |
+| `dockerfile/Dockerfile.test-tools` | 預建置 lint/test 工具 image（shellcheck、hadolint、bats、bats-mock） |
 | `.github/workflows/` | 可重用 CI workflows（build + release） |
+
+### Dockerfile 分層（慣例）
+
+下游 repo 遵循標準多階段配置，定義於 `dockerfile/Dockerfile.example`。
+所有階段共用 `ARG BASE_IMAGE` 指定的基礎映像。
+
+| 階段 | 父階段 | 用途 | 是否出貨 |
+|------|--------|------|---------|
+| `sys` | `${BASE_IMAGE}` | 使用者/群組、sudo、時區、語系、APT mirror | 中介 |
+| `base` | `sys` | 開發工具與語言套件 | 中介 |
+| `devel` | `base` | 應用專屬工具 + `entrypoint.sh` + PlotJuggler（env repos） | **是**（主要產物） |
+| `test` | `devel` | 短暫：ShellCheck + Hadolint + Bats smoke（均來自 `test-tools:local`） | 否（build 完即丟） |
+| `runtime-base`（選用） | `sys` | 最小 runtime 相依（sudo、tini） | 中介 |
+| `runtime`（選用） | `runtime-base` | 精簡 runtime 映像（application repos 使用） | 啟用時出貨 |
+
+說明：
+- 只出貨 developer image 的 repo（`env/*`）會跳過 `runtime-base` /
+  `runtime`——該 section 在 `Dockerfile.example` 維持註解狀態。
+- `test` 永遠從 `devel` 繼承，所以 `test/smoke/<repo>_env.bats` 裡的
+  runtime assertion 所看到的二進位與檔案，就是使用者 `docker run ...
+  <repo>:devel` 後會看到的內容。
+- `Dockerfile.test-tools` 另外建置一個 `test-tools:local` image（不在
+  上面的階段鏈中），`test` 階段透過 `COPY --from=test-tools:local`
+  把 bats / shellcheck / hadolint 二進位拉進來。
+
+### Smoke test helpers（供下游 repo 使用）
+
+`test/smoke/test_helper.bash`（每個 smoke spec 透過
+`load "${BATS_TEST_DIRNAME}/test_helper"` 載入）提供一組 runtime
+assertion helpers。下游 repo 應優先使用這些 helper 而非原生的
+`[ -f ... ]` / `command -v`，失敗時會輸出 decorated 診斷訊息直指缺少
+的工件。
+
+| Helper | 用法 |
+|--------|------|
+| `assert_cmd_installed <cmd>` | `<cmd>` 不在 `PATH` 上時失敗 |
+| `assert_cmd_runs <cmd> [flag]` | `<cmd> <flag>` 非 0 時失敗（flag 預設 `--version`） |
+| `assert_file_exists <path>` | `<path>` 非 regular file 時失敗 |
+| `assert_dir_exists <path>` | `<path>` 非目錄時失敗 |
+| `assert_file_owned_by <user> <path>` | `<path>` 擁有者不是 `<user>` 時失敗 |
+| `assert_pip_pkg <pkg>` | `pip show <pkg>` 非 0 時失敗 |
 
 ### 各 repo 自行維護的檔案（不共用）
 
@@ -230,37 +277,59 @@ template/
 │   │   ├── exec.sh
 │   │   ├── stop.sh
 │   │   ├── setup.sh                  # .env 產生器
+│   │   ├── _lib.sh                   # 共用 helper（_load_env、_compose、_compose_project）
+│   │   ├── i18n.sh                   # 共用語言偵測（_detect_lang、_LANG）
 │   │   └── Makefile
 │   └── ci/
 │       └── ci.sh                     # CI pipeline（本地 + 遠端）
 ├── dockerfile/
-│   ├── Dockerfile.test-tools         # 預建置測試工具 image
-│   └── Dockerfile.example            # 新 repo 的 Dockerfile 範本
+│   ├── Dockerfile.test-tools         # 預建置 lint/測試工具 image
+│   └── Dockerfile.example            # 新 repo 的 Dockerfile 範本（sys → base → devel → test → [runtime]）
 ├── config/                           # Shell/工具設定 + IMAGE_NAME 規則
 │   ├── image_name.conf               # 預設 IMAGE_NAME 偵測規則
 │   ├── pip/
+│   │   ├── setup.sh
+│   │   └── requirements.txt
 │   └── shell/
 │       ├── bashrc
 │       ├── terminator/
+│       │   ├── setup.sh
+│       │   └── config
 │       └── tmux/
+│           ├── setup.sh
+│           └── tmux.conf
 ├── test/
-│   ├── smoke/                        # 給各 repo 使用的共用測試
-│   │   ├── test_helper.bash
+│   ├── smoke/                        # 共用 smoke 測試 + runtime assertion helpers
+│   │   ├── test_helper.bash          #  → assert_cmd_installed / _runs / file / dir / owned_by / pip_pkg
 │   │   ├── script_help.bats
 │   │   └── display_env.bats
-│   └── unit/                         # 模板自身測試
+│   ├── unit/                         # 模板自身測試（bats + kcov）
+│   │   ├── test_helper.bash
+│   │   ├── bashrc_spec.bats
+│   │   ├── ci_spec.bats              # ci.sh _install_deps
+│   │   ├── lib_spec.bats             # _lib.sh
+│   │   ├── pip_setup_spec.bats
+│   │   ├── setup_spec.bats
+│   │   ├── smoke_helper_spec.bats    # Runtime assertion helpers
+│   │   ├── template_spec.bats
+│   │   ├── terminator_config_spec.bats
+│   │   ├── terminator_setup_spec.bats
+│   │   ├── tmux_conf_spec.bats
+│   │   └── tmux_setup_spec.bats
+│   └── integration/
+│       └── init_new_repo_spec.bats   # Level-1 init.sh 整合測試
 ├── Makefile.ci                       # 模板 CI 入口（make test/lint/...）
 ├── compose.yaml                      # Docker CI 執行器
 ├── .hadolint.yaml                    # 共用 Hadolint 規則
+├── codecov.yml
 ├── .github/workflows/
 │   ├── self-test.yaml                # 模板 CI
 │   ├── build-worker.yaml             # 可重用建置 workflow
 │   └── release-worker.yaml           # 可重用發布 workflow
 ├── doc/
-│   ├── readme/                       # README 翻譯
-│   ├── test/                         # TEST.md + 翻譯
-│   └── changelog/                    # CHANGELOG.md + 翻譯
-├── .codecov.yaml
+│   ├── readme/                       # README 翻譯（zh-TW / zh-CN / ja）
+│   ├── test/TEST.md                  # 測試清單
+│   └── changelog/CHANGELOG.md        # 發布記錄
 ├── .gitignore
 ├── LICENSE
 └── README.md

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **247 tests** total (226 unit + 21 integration).
+Template self-tests: **292 tests** total (271 unit + 21 integration).
 
 ## Test Files
 
@@ -24,7 +24,7 @@ Template self-tests: **247 tests** total (226 unit + 21 integration).
 | `_compose without DRY_RUN tries to invoke docker compose (sanity)` | Real-call branch |
 | `_compose_project pre-fills -p / -f / --env-file from PROJECT_NAME and FILE_PATH` | Project wrapper |
 
-### test/unit/setup_spec.bats (58)
+### test/unit/setup_spec.bats (61)
 
 | Test | Description |
 |------|-------------|
@@ -59,6 +59,9 @@ Template self-tests: **247 tests** total (226 unit + 21 integration).
 | `detect_ws_path strategy 1: docker_* without sibling falls through` | No sibling |
 | `detect_ws_path strategy 2: finds _ws component in path` | Path traversal |
 | `detect_ws_path strategy 3: falls back to parent directory` | Parent fallback |
+| `detect_ws_path fails with ERROR when base_path does not exist` | Explicit error on missing base_path |
+| `detect_ws_path normalizes base_path containing .. (strategy 1)` | Path normalization in strategy 1 |
+| `detect_ws_path normalizes base_path containing .. (strategy 3 fallback)` | Path normalization in strategy 3 |
 | `write_env creates .env with all required variables` | .env generation |
 | `write_env includes APT_MIRROR_UBUNTU` | APT mirror in .env |
 | `write_env includes APT_MIRROR_DEBIAN` | APT mirror in .env |
@@ -215,6 +218,74 @@ Template self-tests: **247 tests** total (226 unit + 21 integration).
 | `pip setup.sh runs pip install with requirements.txt` | pip install |
 | `pip setup.sh sets PIP_BREAK_SYSTEM_PACKAGES=1` | Break system packages |
 | `pip setup.sh fails when pip is not available` | Missing pip error |
+
+### test/unit/ci_spec.bats (8)
+
+| Test | Description |
+|------|-------------|
+| `_install_deps: skips apt-get and git when bats is already installed` | No-op fast path |
+| `_install_deps: dies with clear error when apt-get update fails` | Explicit `apt-get update` error |
+| `_install_deps: dies with clear error when apt-get install fails` | Explicit `apt-get install` error |
+| `_install_deps: dies with clear error when git clone bats-mock fails` | Explicit `git clone` error |
+| `_install_deps: happy path succeeds when bats absent and all deps install cleanly` | Full install path |
+| `_run_shellcheck: invokes shellcheck against every expected script` | Wired-file regression guard |
+| `_run_shellcheck: picks up every .sh file in script/docker/` | `find` covers new scripts |
+| `_run_shellcheck: exits non-zero when shellcheck fails on any script` | Strict-mode propagation |
+
+### test/unit/init_spec.bats (15)
+
+Unit coverage for `init.sh` helpers that previous rounds exercised only
+through the Level-1 integration test. Complements
+`test/integration/init_new_repo_spec.bats` by locking edge cases that
+are hard to trigger from a real `bash template/init.sh` invocation
+(network-down version detection, main.yaml `@ref` fallback,
+`_create_version_file` with no argument).
+
+| Test | Description |
+|------|-------------|
+| `_detect_template_version: parses newest vX.Y.Z tag from git ls-remote` | Happy path + head -1 |
+| `_detect_template_version: returns empty when git ls-remote fails` | Network-down fallback |
+| `_detect_template_version: returns empty when no v*.*.* tags exist` | Nothing to match |
+| `_detect_template_version: ignores non-semver tags (e.g. rc suffixes)` | Regex filters rc / pre-release |
+| `_create_version_file: writes given version to .template_version` | Happy path |
+| `_create_version_file: writes 'unknown' when no argument given` | Empty-string fallback |
+| `_create_version_file: writes 'unknown' when called with zero arguments` | No-arg fallback |
+| `_create_version_file: overwrites existing .template_version` | Re-init safety |
+| `_create_new_repo: main.yaml uses given ref in workflow @ref` | Ref threading |
+| `_create_new_repo: main.yaml falls back to @main when ref arg omitted` | Default ref |
+| `_create_new_repo: main.yaml falls back to @main when ref arg is empty` | Empty-string → `@main` |
+| `_create_new_repo: generates .env.example with IMAGE_NAME=<repo>` | Fallback image name |
+| `_create_symlinks: produces all five docker-script symlinks` | Symlink set |
+| `_create_symlinks: replaces a stale file at the symlink path` | Re-init over existing files |
+| `_create_symlinks: keeps custom .hadolint.yaml when it differs` | Custom-hadolint preservation |
+
+### test/unit/smoke_helper_spec.bats (19)
+
+Exercises the runtime assertion helpers shipped in
+`test/smoke/test_helper.bash` (used by downstream-repo smoke specs via
+`load "${BATS_TEST_DIRNAME}/test_helper"`).
+
+| Test | Description |
+|------|-------------|
+| `assert_cmd_installed passes when cmd is on PATH` | Happy path |
+| `assert_cmd_installed fails with descriptive message when cmd missing` | Missing cmd |
+| `assert_cmd_installed errors when cmd arg missing` | Required arg check |
+| `assert_cmd_runs passes when cmd exits 0` | Happy path |
+| `assert_cmd_runs uses custom version flag when given` | Custom flag |
+| `assert_cmd_runs fails when cmd exits non-zero` | Broken binary |
+| `assert_cmd_runs fails when cmd is not installed` | Missing cmd |
+| `assert_file_exists passes when file is a regular file` | Happy path |
+| `assert_file_exists fails when path is missing` | Missing path |
+| `assert_file_exists fails when path is a directory` | Type check |
+| `assert_dir_exists passes when path is a directory` | Happy path |
+| `assert_dir_exists fails when path is missing` | Missing path |
+| `assert_dir_exists fails when path is a file` | Type check |
+| `assert_file_owned_by passes when owner matches` | Happy path |
+| `assert_file_owned_by fails with owner diff when user mismatches` | Owner mismatch |
+| `assert_file_owned_by fails when path missing` | Missing path |
+| `assert_pip_pkg passes when pip show returns 0` | Package installed |
+| `assert_pip_pkg fails when pip show returns non-zero` | Package missing |
+| `assert_pip_pkg fails when pip is not installed` | pip itself missing |
 
 ### test/unit/terminator_config_spec.bats (10)
 

--- a/init.sh
+++ b/init.sh
@@ -8,7 +8,10 @@
 #   - Has Dockerfile → existing repo: create symlinks + .template_version
 #   - No Dockerfile → new repo: generate full project structure
 
-set -euo pipefail
+# Only set strict mode when running directly; when sourced, respect caller's settings
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+  set -euo pipefail
+fi
 
 TEMPLATE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly TEMPLATE_DIR
@@ -16,8 +19,6 @@ REPO_ROOT="$(cd -- "${TEMPLATE_DIR}/.." && pwd -P)"
 readonly REPO_ROOT
 TEMPLATE_REL="template"
 readonly TEMPLATE_REL
-
-cd "${REPO_ROOT}"
 
 _log() { printf "[init] %s\n" "$*"; }
 
@@ -49,14 +50,16 @@ _create_symlinks() {
   fi
 }
 
-_create_version_file() {
-  local ver=""
-  ver=$(git ls-remote --tags --sort=-v:refname \
-    git@github.com:ycpss91255-docker/template.git \
+_detect_template_version() {
+  git ls-remote --tags --sort=-v:refname \
+    git@github.com:ycpss91255-docker/template.git 2>/dev/null \
     | grep -oP 'refs/tags/v\d+\.\d+\.\d+$' \
     | head -1 \
-    | sed 's|refs/tags/||') || true
-  ver="${ver:-unknown}"
+    | sed 's|refs/tags/||' || true
+}
+
+_create_version_file() {
+  local ver="${1:-unknown}"
   echo "${ver}" > .template_version
   _log "Created .template_version (${ver})"
 }
@@ -68,6 +71,7 @@ _detect_repo_name() {
 }
 
 _create_new_repo() {
+  local ref="${1:-main}"
   local name=""
   name="$(_detect_repo_name)"
   _log "Creating new repo: ${name}"
@@ -120,13 +124,25 @@ ENTRY
   mkdir -p test/smoke
   cat > "test/smoke/${name}_env.bats" <<BATS
 #!/usr/bin/env bats
+#
+# Repo-specific runtime smoke tests. Exercise the \`devel\` image built
+# from this repo's Dockerfile, via the \`test\` stage. Use the shared
+# helpers in test_helper.bash (assert_cmd_installed, assert_file_exists,
+# assert_dir_exists, assert_file_owned_by, assert_pip_pkg, ...) to keep
+# assertions terse. Add one assertion per meaningful installation
+# artifact.
 
 setup() {
-    load "\${BATS_TEST_DIRNAME}/test_helper"
+  load "\${BATS_TEST_DIRNAME}/test_helper"
 }
 
-@test "entrypoint.sh exists and is executable" {
-    assert [ -x /entrypoint.sh ]
+@test "entrypoint.sh is installed and executable" {
+  assert_file_exists /entrypoint.sh
+  assert [ -x /entrypoint.sh ]
+}
+
+@test "bash is available on PATH" {
+  assert_cmd_installed bash
 }
 BATS
   _log "  Created test/smoke/${name}_env.bats"
@@ -137,8 +153,6 @@ BATS
 
   # .github/workflows/main.yaml
   mkdir -p .github/workflows
-  local ver=""
-  ver=$(cat .template_version 2>/dev/null || echo "v0.5.0")
   cat > .github/workflows/main.yaml <<YAML
 name: Main CI/CD
 
@@ -152,14 +166,14 @@ on:
 
 jobs:
   call-docker-build:
-    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@${ver}
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@${ref}
     with:
       image_name: ${name}
 
   call-release:
     needs: call-docker-build
     if: startsWith(github.ref, 'refs/tags/')
-    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@${ver}
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@${ref}
     with:
       archive_name_prefix: ${name}
 YAML
@@ -251,8 +265,9 @@ _error() { printf "[init] ERROR: %s\n" "$*" >&2; exit 1; }
 
 # ── Main ────────────────────────────────────────────────────────────────────
 
-if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
-  cat >&2 <<'EOF'
+main() {
+  if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
+    cat >&2 <<'EOF'
 Usage: ./template/init.sh [--gen-image-conf]
 
 Initialize a repo with template. Auto-detects:
@@ -267,22 +282,33 @@ Run from the repo root after:
   git subtree add --prefix=template \
       git@github.com:ycpss91255-docker/template.git <version> --squash
 EOF
-  exit 0
+    return 0
+  fi
+
+  cd "${REPO_ROOT}"
+
+  if [[ "${1:-}" == "--gen-image-conf" ]]; then
+    _gen_image_conf
+    return 0
+  fi
+
+  local template_version=""
+  template_version="$(_detect_template_version)"
+
+  if [[ -f Dockerfile ]]; then
+    _init_existing_repo
+  else
+    _create_new_repo "${template_version:-main}"
+    _create_symlinks
+  fi
+
+  _create_version_file "${template_version}"
+
+  _log ""
+  _log "Done!"
+}
+
+# Guard: only run main when executed directly, not when sourced (for testing)
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+  main "$@"
 fi
-
-if [[ "${1:-}" == "--gen-image-conf" ]]; then
-  _gen_image_conf
-  exit 0
-fi
-
-if [[ -f Dockerfile ]]; then
-  _init_existing_repo
-else
-  _create_new_repo
-  _create_symlinks
-fi
-
-_create_version_file
-
-_log ""
-_log "Done!"

--- a/script/ci/ci.sh
+++ b/script/ci/ci.sh
@@ -8,7 +8,10 @@
 #   ./ci.sh --coverage   # Run tests + coverage (via docker compose)
 #   ./ci.sh -h, --help   # Show this help
 
-set -euo pipefail
+# Only set strict mode when running directly; when sourced, respect caller's settings
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+  set -euo pipefail
+fi
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly SCRIPT_DIR
@@ -41,15 +44,24 @@ EOF
 
 # ── CI container setup ───────────────────────────────────────────────────────
 
+_die() { printf "[ci] ERROR: %s\n" "$*" >&2; exit 1; }
+
 _install_deps() {
-  if ! command -v bats >/dev/null 2>&1; then
-    apt-get update -qq
-    apt-get install -y --no-install-recommends \
+  command -v bats >/dev/null 2>&1 && return 0
+
+  apt-get update -qq \
+    || _die "apt-get update failed. Check network / apt mirror reachability."
+
+  apt-get install -y --no-install-recommends \
       bats bats-support bats-assert \
-      shellcheck git ca-certificates
-    git clone --depth 1 -b v1.2.5 \
-      https://github.com/jasonkarns/bats-mock /usr/lib/bats/bats-mock
-  fi
+      shellcheck git ca-certificates \
+    || _die "apt-get install failed for bats/shellcheck deps."
+
+  # bats-mock is distro-packaged on newer distros but missing on bookworm,
+  # so we always pin to upstream v1.2.5 for reproducibility.
+  git clone --depth 1 -b v1.2.5 \
+      https://github.com/jasonkarns/bats-mock /usr/lib/bats/bats-mock \
+    || _die "git clone bats-mock failed. Check network / GitHub access."
 }
 
 # ── ShellCheck ───────────────────────────────────────────────────────────────
@@ -156,4 +168,7 @@ main() {
   esac
 }
 
-main "$@"
+# Guard: only run main when executed directly, not when sourced (for testing)
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+  main "$@"
+fi

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -252,13 +252,25 @@ detect_ws_path() {
   local -n _outvar="${1:?"${FUNCNAME[0]}: missing outvar"}"; shift
   local _base_path="${1:?"${FUNCNAME[0]}: missing base_path"}"
 
+  # Normalize base_path to an absolute, symlink-resolved path.
+  # Strategies below use _base_path/.. — relative or .. segments would
+  # produce surprising results without this step.
+  if [[ ! -d "${_base_path}" ]]; then
+    printf "[setup] ERROR: detect_ws_path: base_path does not exist: %s\n" \
+      "${_base_path}" >&2
+    return 1
+  fi
+  _base_path="$(cd "${_base_path}" && pwd -P)"
+
   local _dirname=""
   _dirname="$(basename "${_base_path}")"
 
   # Strategy 1: docker_* directory → look for sibling *_ws
   if [[ "${_dirname}" == docker_* ]]; then
     local _name="${_dirname#docker_}"
-    local _sibling="${_base_path}/../${_name}_ws"
+    local _parent=""
+    _parent="$(dirname "${_base_path}")"
+    local _sibling="${_parent}/${_name}_ws"
     if [[ -d "${_sibling}" ]]; then
       _outvar="$(cd "${_sibling}" && pwd -P)"
       return 0
@@ -276,7 +288,7 @@ detect_ws_path() {
   done
 
   # Strategy 3: fall back to parent directory
-  _outvar="$(cd "${_base_path}/.." && pwd -P)"
+  _outvar="$(dirname "${_base_path}")"
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -397,6 +409,6 @@ main() {
 }
 
 # Guard: only run main when executed directly, not when sourced (for testing)
-if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
   main "$@"
 fi

--- a/test/integration/init_new_repo_spec.bats
+++ b/test/integration/init_new_repo_spec.bats
@@ -73,7 +73,9 @@ teardown() {
 @test "new repo: .github/workflows/main.yaml exists with reusable workflow ref" {
   bash template/init.sh
   assert [ -f "${REPO_DIR}/.github/workflows/main.yaml" ]
-  run grep -E 'build-worker\.yaml@v' "${REPO_DIR}/.github/workflows/main.yaml"
+  # Accept semver tag or "main" branch fallback (when offline / no tags)
+  run grep -E 'build-worker\.yaml@(v[0-9]+\.[0-9]+\.[0-9]+|main)' \
+    "${REPO_DIR}/.github/workflows/main.yaml"
   assert_success
 }
 

--- a/test/smoke/test_helper.bash
+++ b/test/smoke/test_helper.bash
@@ -1,4 +1,121 @@
 #!/usr/bin/env bash
+#
+# Shared bats test helper for smoke tests (copied into /smoke_test/ at the
+# Dockerfile `test` stage). Intended to be load-ed by per-repo smoke specs:
+#
+#   setup() {
+#     load "${BATS_TEST_DIRNAME}/test_helper"
+#   }
+#
+# The helpers below are thin wrappers around common runtime assertions
+# (binary on PATH, file/dir exists with expected ownership, python pkg
+# installed via pip). They keep per-repo smoke specs short and self-
+# documenting, e.g.:
+#
+#   @test "tmux is installed" { assert_cmd_installed tmux; }
+#   @test "tpm cloned"        { assert_dir_exists "${HOME}/.tmux/plugins/tpm"; }
+#   @test "rospy available"   { assert_pip_pkg rospkg; }
 
 bats_load_library "bats-support"
 bats_load_library "bats-assert"
+
+# ── Runtime assertion helpers ───────────────────────────────────────────────
+
+# Fail the test unless <cmd> is resolvable on PATH.
+#
+# Usage: assert_cmd_installed <cmd>
+assert_cmd_installed() {
+  local _cmd="${1:?assert_cmd_installed: missing cmd}"
+  if ! command -v "${_cmd}" >/dev/null 2>&1; then
+    batslib_print_kv_single 10 "cmd" "${_cmd}" \
+      | batslib_decorate "command not found on PATH" \
+      | fail
+  fi
+}
+
+# Fail the test unless <cmd> runs successfully with <version_flag>
+# (default `--version`). Useful for catching "installed but broken" cases
+# (missing shared libs, corrupt binary, etc.).
+#
+# Usage: assert_cmd_runs <cmd> [version_flag]
+assert_cmd_runs() {
+  local _cmd="${1:?assert_cmd_runs: missing cmd}"
+  local _flag="${2:---version}"
+  assert_cmd_installed "${_cmd}"
+  run "${_cmd}" "${_flag}"
+  # shellcheck disable=SC2154  # 'status' and 'output' are populated by `run`
+  if (( status != 0 )); then
+    batslib_print_kv_single_or_multi 10 \
+      "cmd"    "${_cmd} ${_flag}" \
+      "status" "${status}" \
+      "output" "${output}" \
+      | batslib_decorate "command ran but exited non-zero" \
+      | fail
+  fi
+}
+
+# Fail the test unless <path> exists and is a regular file.
+#
+# Usage: assert_file_exists <path>
+assert_file_exists() {
+  local _path="${1:?assert_file_exists: missing path}"
+  if [[ ! -f "${_path}" ]]; then
+    batslib_print_kv_single 10 "path" "${_path}" \
+      | batslib_decorate "file does not exist" \
+      | fail
+  fi
+}
+
+# Fail the test unless <path> exists and is a directory.
+#
+# Usage: assert_dir_exists <path>
+assert_dir_exists() {
+  local _path="${1:?assert_dir_exists: missing path}"
+  if [[ ! -d "${_path}" ]]; then
+    batslib_print_kv_single 10 "path" "${_path}" \
+      | batslib_decorate "directory does not exist" \
+      | fail
+  fi
+}
+
+# Fail the test unless <path>'s owning user matches <user>.
+#
+# Usage: assert_file_owned_by <user> <path>
+assert_file_owned_by() {
+  local _user="${1:?assert_file_owned_by: missing user}"
+  local _path="${2:?assert_file_owned_by: missing path}"
+  if [[ ! -e "${_path}" ]]; then
+    batslib_print_kv_single 10 "path" "${_path}" \
+      | batslib_decorate "path does not exist" \
+      | fail
+    return
+  fi
+  local _actual=""
+  _actual="$(stat -c '%U' "${_path}")"
+  if [[ "${_actual}" != "${_user}" ]]; then
+    batslib_print_kv_single_or_multi 10 \
+      "path"     "${_path}" \
+      "expected" "${_user}" \
+      "actual"   "${_actual}" \
+      | batslib_decorate "owner mismatch" \
+      | fail
+  fi
+}
+
+# Fail the test unless <pkg> is visible to `pip show`.
+#
+# Usage: assert_pip_pkg <pkg>
+assert_pip_pkg() {
+  local _pkg="${1:?assert_pip_pkg: missing pkg}"
+  assert_cmd_installed pip
+  run pip show "${_pkg}"
+  # shellcheck disable=SC2154
+  if (( status != 0 )); then
+    batslib_print_kv_single_or_multi 10 \
+      "pkg"    "${_pkg}" \
+      "status" "${status}" \
+      "output" "${output}" \
+      | batslib_decorate "pip package not installed" \
+      | fail
+  fi
+}

--- a/test/unit/ci_spec.bats
+++ b/test/unit/ci_spec.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+#
+# Unit tests for script/ci/ci.sh helper functions.
+# Only helpers that can be exercised without a full CI run are covered here.
+#
+# NOTE: these tests confine PATH to MOCK_DIR *after* sourcing ci.sh so that
+# (a) `command -v bats` inside _install_deps always misses (bats lives in
+#     /usr/bin in the CI container, which MOCK_DIR does not include), and
+# (b) apt-get / git resolve to our mocks instead of the real binaries.
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  create_mock_dir
+}
+
+teardown() {
+  cleanup_mock_dir
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _install_deps
+# ════════════════════════════════════════════════════════════════════
+
+@test "_install_deps: skips apt-get and git when bats is already installed" {
+  mock_cmd "bats" 'exit 0'
+  # These mocks must NOT be invoked; fail loudly if they are.
+  mock_cmd "apt-get" 'echo "apt-get should not be called"; exit 1'
+  mock_cmd "git" 'echo "git should not be called"; exit 1'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    _install_deps
+  '
+  assert_success
+  refute_output --partial "should not be called"
+}
+
+@test "_install_deps: dies with clear error when apt-get update fails" {
+  mock_cmd "apt-get" '
+    if [[ "$1" == "update" ]]; then exit 42; fi
+    exit 0'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    _install_deps
+  '
+  assert_failure
+  assert_output --partial "ERROR"
+  assert_output --partial "apt-get update failed"
+}
+
+@test "_install_deps: dies with clear error when apt-get install fails" {
+  mock_cmd "apt-get" '
+    case "$1" in
+      update)  exit 0 ;;
+      install) exit 100 ;;
+      *)       exit 0 ;;
+    esac'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    _install_deps
+  '
+  assert_failure
+  assert_output --partial "ERROR"
+  assert_output --partial "apt-get install failed"
+}
+
+@test "_install_deps: dies with clear error when git clone bats-mock fails" {
+  mock_cmd "apt-get" 'exit 0'
+  mock_cmd "git" '
+    if [[ "$1" == "clone" ]]; then exit 128; fi
+    exit 0'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    _install_deps
+  '
+  assert_failure
+  assert_output --partial "ERROR"
+  assert_output --partial "git clone bats-mock failed"
+}
+
+@test "_install_deps: happy path succeeds when bats absent and all deps install cleanly" {
+  mock_cmd "apt-get" 'exit 0'
+  mock_cmd "git" 'exit 0'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    _install_deps
+  '
+  assert_success
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _run_shellcheck
+#
+# Regression guard: if someone adds a new shell script under script/ or
+# config/ but forgets to wire it into _run_shellcheck, the list drifts
+# out of sync with reality. These tests pin the expected invocations so
+# that drift surfaces as a test failure.
+# ════════════════════════════════════════════════════════════════════
+
+@test "_run_shellcheck: invokes shellcheck against every expected script" {
+  # Log each invocation to a capture file so we can inspect the set.
+  local _log="${BATS_TEST_TMPDIR}/shellcheck.log"
+  mock_cmd "shellcheck" '
+    printf "%s\n" "$*" >> "'"${_log}"'"
+    exit 0'
+  # xargs needs a mock too — the real one would forward to the real
+  # shellcheck binary (which lives in MOCK_DIR), so this is just a
+  # belt-and-braces ensure PATH is honored.
+  run bash -c '
+    source /source/script/ci/ci.sh
+    _run_shellcheck
+  '
+  assert_success
+
+  assert [ -f "${_log}" ]
+  run cat "${_log}"
+  assert_output --partial "script/ci/ci.sh"
+  assert_output --partial "init.sh"
+  assert_output --partial "upgrade.sh"
+  assert_output --partial "config/pip/setup.sh"
+  assert_output --partial "config/shell/terminator/setup.sh"
+  assert_output --partial "config/shell/tmux/setup.sh"
+}
+
+@test "_run_shellcheck: picks up every .sh file in script/docker/" {
+  local _log="${BATS_TEST_TMPDIR}/shellcheck.log"
+  mock_cmd "shellcheck" '
+    printf "%s\n" "$*" >> "'"${_log}"'"
+    exit 0'
+  run bash -c '
+    source /source/script/ci/ci.sh
+    _run_shellcheck
+  '
+  assert_success
+
+  # Every .sh under script/docker/ (non-recursive) must appear.
+  for _f in /source/script/docker/*.sh; do
+    run grep -F "${_f}" "${_log}"
+    assert_success
+  done
+}
+
+@test "_run_shellcheck: exits non-zero when shellcheck fails on any script" {
+  # Simulate a lint violation on init.sh specifically.
+  mock_cmd "shellcheck" '
+    for _arg in "$@"; do
+      if [[ "${_arg}" == *"/init.sh" ]]; then
+        printf "SC0001: fake violation\n" >&2
+        exit 1
+      fi
+    done
+    exit 0'
+  # Enable -e to mirror real CI invocation (ci.sh sets it when run
+  # directly; when sourced, the caller owns strict mode).
+  run bash -c '
+    set -e
+    source /source/script/ci/ci.sh
+    _run_shellcheck
+  '
+  assert_failure
+}

--- a/test/unit/init_spec.bats
+++ b/test/unit/init_spec.bats
@@ -1,0 +1,230 @@
+#!/usr/bin/env bats
+#
+# Unit tests for init.sh helpers. Complements the Level-1 integration test
+# in test/integration/init_new_repo_spec.bats — which already covers
+# end-to-end init.sh runs — by exercising individual helpers against
+# edge cases that are hard to trigger from a real `bash template/init.sh`
+# invocation (e.g. network-down version detection, main.yaml @ref
+# fallback, _create_version_file with no argument).
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  create_mock_dir
+
+  # Mimic the integration-test layout so `init.sh` resolves TEMPLATE_DIR /
+  # REPO_ROOT to a writable temp tree instead of /source. Symlinking
+  # init.sh back to the real source keeps all edits in one place.
+  TMP_REPO="$(mktemp -d)"
+  mkdir -p "${TMP_REPO}/template/dockerfile" \
+           "${TMP_REPO}/template/config" \
+           "${TMP_REPO}/template/script/docker"
+  ln -s /source/init.sh "${TMP_REPO}/template/init.sh"
+
+  # Minimal Dockerfile.example stub for _create_new_repo's `cp` step.
+  cat > "${TMP_REPO}/template/dockerfile/Dockerfile.example" <<'EOF'
+FROM alpine
+EOF
+
+  # Stub scripts referenced by _create_symlinks — empty files are fine
+  # because symlinks only need a valid target path, not a valid payload.
+  for _f in build.sh run.sh exec.sh stop.sh Makefile; do
+    : > "${TMP_REPO}/template/script/docker/${_f}"
+  done
+  : > "${TMP_REPO}/template/.hadolint.yaml"
+
+  cd "${TMP_REPO}"
+}
+
+teardown() {
+  cleanup_mock_dir
+  rm -rf "${TMP_REPO}"
+}
+
+# Source init.sh within a `bash -c` so the test controls when functions
+# are loaded and can mutate PATH / cwd before invocation. `bash -c ... "$0"`
+# pattern via `run` is awkward — we wrap in a helper.
+_source_init() {
+  # shellcheck disable=SC1091
+  source "${TMP_REPO}/template/init.sh"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _detect_template_version
+# ════════════════════════════════════════════════════════════════════
+
+@test "_detect_template_version: parses newest vX.Y.Z tag from git ls-remote" {
+  # Mock emits refs in the order the real `--sort=-v:refname` would produce
+  # (newest-first). _detect_template_version trusts the sort and just
+  # takes `head -1`.
+  mock_cmd "git" '
+    if [[ "$1" == "ls-remote" ]]; then
+      cat <<REMOTE
+def456  refs/tags/v0.7.2
+ghi789  refs/tags/v0.7.1
+abc123  refs/tags/v0.7.0
+REMOTE
+      exit 0
+    fi
+    exit 0'
+  _source_init
+  local result
+  result="$(_detect_template_version)"
+  assert_equal "${result}" "v0.7.2"
+}
+
+@test "_detect_template_version: returns empty when git ls-remote fails" {
+  mock_cmd "git" 'exit 128'
+  _source_init
+  local result
+  result="$(_detect_template_version)"
+  assert_equal "${result}" ""
+}
+
+@test "_detect_template_version: returns empty when no v*.*.* tags exist" {
+  mock_cmd "git" '
+    if [[ "$1" == "ls-remote" ]]; then
+      cat <<REMOTE
+abc123  refs/heads/main
+def456  refs/tags/latest
+REMOTE
+      exit 0
+    fi
+    exit 0'
+  _source_init
+  local result
+  result="$(_detect_template_version)"
+  assert_equal "${result}" ""
+}
+
+@test "_detect_template_version: ignores non-semver tags (e.g. rc suffixes)" {
+  # --sort=-v:refname would rank v0.8.0-rc2 > v0.7.2-rc1 > v0.7.0, but
+  # the regex strips the rc variants, leaving v0.7.0 as the only valid
+  # vX.Y.Z entry.
+  mock_cmd "git" '
+    if [[ "$1" == "ls-remote" ]]; then
+      cat <<REMOTE
+ghi789  refs/tags/v0.8.0-rc2
+def456  refs/tags/v0.7.2-rc1
+abc123  refs/tags/v0.7.0
+REMOTE
+      exit 0
+    fi
+    exit 0'
+  _source_init
+  local result
+  result="$(_detect_template_version)"
+  assert_equal "${result}" "v0.7.0"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _create_version_file
+# ════════════════════════════════════════════════════════════════════
+
+@test "_create_version_file: writes given version to .template_version" {
+  _source_init
+  _create_version_file "v1.2.3"
+  assert [ -f "${TMP_REPO}/.template_version" ]
+  run cat "${TMP_REPO}/.template_version"
+  assert_output "v1.2.3"
+}
+
+@test "_create_version_file: writes 'unknown' when no argument given" {
+  _source_init
+  _create_version_file ""
+  run cat "${TMP_REPO}/.template_version"
+  assert_output "unknown"
+}
+
+@test "_create_version_file: writes 'unknown' when called with zero arguments" {
+  _source_init
+  _create_version_file
+  run cat "${TMP_REPO}/.template_version"
+  assert_output "unknown"
+}
+
+@test "_create_version_file: overwrites existing .template_version" {
+  echo "v0.1.0" > "${TMP_REPO}/.template_version"
+  _source_init
+  _create_version_file "v2.0.0"
+  run cat "${TMP_REPO}/.template_version"
+  assert_output "v2.0.0"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _create_new_repo: ref threading into main.yaml
+# ════════════════════════════════════════════════════════════════════
+
+@test "_create_new_repo: main.yaml uses given ref in workflow @ref" {
+  _source_init
+  _create_new_repo "v9.9.9"
+  assert [ -f "${TMP_REPO}/.github/workflows/main.yaml" ]
+  run grep -E 'build-worker\.yaml@v9\.9\.9' \
+    "${TMP_REPO}/.github/workflows/main.yaml"
+  assert_success
+  run grep -E 'release-worker\.yaml@v9\.9\.9' \
+    "${TMP_REPO}/.github/workflows/main.yaml"
+  assert_success
+}
+
+@test "_create_new_repo: main.yaml falls back to @main when ref arg omitted" {
+  _source_init
+  _create_new_repo
+  run grep -E 'build-worker\.yaml@main' \
+    "${TMP_REPO}/.github/workflows/main.yaml"
+  assert_success
+  run grep -E 'release-worker\.yaml@main' \
+    "${TMP_REPO}/.github/workflows/main.yaml"
+  assert_success
+}
+
+@test "_create_new_repo: main.yaml falls back to @main when ref arg is empty" {
+  _source_init
+  _create_new_repo ""
+  run grep -E 'build-worker\.yaml@main' \
+    "${TMP_REPO}/.github/workflows/main.yaml"
+  assert_success
+}
+
+@test "_create_new_repo: generates .env.example with IMAGE_NAME=<repo>" {
+  _source_init
+  _create_new_repo "main"
+  run cat "${TMP_REPO}/.env.example"
+  assert_output --partial "IMAGE_NAME="
+  # TMP_REPO's basename is random; the entry should reference it.
+  local _expected
+  _expected="$(basename "${TMP_REPO}")"
+  assert_output "IMAGE_NAME=${_expected}"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _create_symlinks
+# ════════════════════════════════════════════════════════════════════
+
+@test "_create_symlinks: produces all five docker-script symlinks" {
+  _source_init
+  _create_symlinks
+  for _f in build.sh run.sh exec.sh stop.sh Makefile; do
+    assert [ -L "${TMP_REPO}/${_f}" ]
+    run readlink "${TMP_REPO}/${_f}"
+    assert_output "template/script/docker/${_f}"
+  done
+}
+
+@test "_create_symlinks: replaces a stale file at the symlink path" {
+  # Pretend an earlier run left a regular file where the symlink should go
+  echo "stale" > "${TMP_REPO}/build.sh"
+  _source_init
+  _create_symlinks
+  assert [ -L "${TMP_REPO}/build.sh" ]
+}
+
+@test "_create_symlinks: keeps custom .hadolint.yaml when it differs" {
+  echo "# repo-specific rules" > "${TMP_REPO}/.hadolint.yaml"
+  # Template's stub is empty — force a difference
+  _source_init
+  run _create_symlinks
+  assert_success
+  assert_output --partial "Keeping custom .hadolint.yaml"
+  # Custom file should still be a regular file, not a symlink
+  assert [ ! -L "${TMP_REPO}/.hadolint.yaml" ]
+}

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -323,6 +323,38 @@ EOF
   assert_equal "${_result}" "${TEMP_DIR}"
 }
 
+@test "detect_ws_path fails with ERROR when base_path does not exist" {
+  local _missing="${TEMP_DIR}/does_not_exist"
+  run bash -c "
+    source /source/script/docker/setup.sh
+    detect_ws_path _result '${_missing}'
+  "
+  assert_failure
+  assert_output --partial "ERROR"
+  assert_output --partial "${_missing}"
+}
+
+@test "detect_ws_path normalizes base_path containing .. (strategy 1)" {
+  # Ensure /foo/docker_myapp/../docker_myapp still resolves sibling myapp_ws
+  local _ws_dir="${TEMP_DIR}/myapp_ws"
+  local _proj_dir="${TEMP_DIR}/docker_myapp"
+  local _messy="${_proj_dir}/../docker_myapp"
+  mkdir -p "${_ws_dir}" "${_proj_dir}"
+  local _result
+  detect_ws_path _result "${_messy}"
+  assert_equal "${_result}" "${_ws_dir}"
+}
+
+@test "detect_ws_path normalizes base_path containing .. (strategy 3 fallback)" {
+  local _plain="${TEMP_DIR}/plain"
+  mkdir -p "${_plain}"
+  local _messy="${_plain}/../plain"
+  local _result
+  detect_ws_path _result "${_messy}"
+  # Expect normalized absolute parent of ${_plain}
+  assert_equal "${_result}" "${TEMP_DIR}"
+}
+
 # ════════════════════════════════════════════════════════════════════
 # write_env
 # ════════════════════════════════════════════════════════════════════

--- a/test/unit/smoke_helper_spec.bats
+++ b/test/unit/smoke_helper_spec.bats
@@ -1,0 +1,178 @@
+#!/usr/bin/env bats
+#
+# Unit tests for test/smoke/test_helper.bash runtime assertion helpers.
+# These helpers are intended to be load-ed by per-repo smoke specs inside
+# the Docker `test` stage; here we exercise them in isolation under the
+# template's own CI.
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  load "/source/test/smoke/test_helper"
+
+  create_mock_dir
+  TEMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  cleanup_mock_dir
+  rm -rf "${TEMP_DIR}"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# assert_cmd_installed
+# ════════════════════════════════════════════════════════════════════
+
+@test "assert_cmd_installed passes when cmd is on PATH" {
+  mock_cmd "fakecmd" 'exit 0'
+  run assert_cmd_installed fakecmd
+  assert_success
+}
+
+@test "assert_cmd_installed fails with descriptive message when cmd missing" {
+  run assert_cmd_installed no_such_cmd_xyzzy
+  assert_failure
+  assert_output --partial "command not found on PATH"
+  assert_output --partial "no_such_cmd_xyzzy"
+}
+
+@test "assert_cmd_installed errors when cmd arg missing" {
+  run assert_cmd_installed
+  assert_failure
+  assert_output --partial "missing cmd"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# assert_cmd_runs
+# ════════════════════════════════════════════════════════════════════
+
+@test "assert_cmd_runs passes when cmd exits 0" {
+  mock_cmd "fakecmd" 'echo "v1.2.3"; exit 0'
+  run assert_cmd_runs fakecmd
+  assert_success
+}
+
+@test "assert_cmd_runs uses custom version flag when given" {
+  mock_cmd "fakecmd" '
+    if [[ "$1" == "-V" ]]; then exit 0; fi
+    exit 99'
+  run assert_cmd_runs fakecmd -V
+  assert_success
+}
+
+@test "assert_cmd_runs fails when cmd exits non-zero" {
+  mock_cmd "fakecmd" 'echo "boom" >&2; exit 7'
+  run assert_cmd_runs fakecmd
+  assert_failure
+  assert_output --partial "exited non-zero"
+  assert_output --partial "status"
+}
+
+@test "assert_cmd_runs fails when cmd is not installed" {
+  run assert_cmd_runs no_such_cmd_xyzzy
+  assert_failure
+  assert_output --partial "command not found on PATH"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# assert_file_exists
+# ════════════════════════════════════════════════════════════════════
+
+@test "assert_file_exists passes when file is a regular file" {
+  local _file="${TEMP_DIR}/present.txt"
+  : > "${_file}"
+  run assert_file_exists "${_file}"
+  assert_success
+}
+
+@test "assert_file_exists fails when path is missing" {
+  run assert_file_exists "${TEMP_DIR}/missing.txt"
+  assert_failure
+  assert_output --partial "file does not exist"
+}
+
+@test "assert_file_exists fails when path is a directory" {
+  run assert_file_exists "${TEMP_DIR}"
+  assert_failure
+  assert_output --partial "file does not exist"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# assert_dir_exists
+# ════════════════════════════════════════════════════════════════════
+
+@test "assert_dir_exists passes when path is a directory" {
+  run assert_dir_exists "${TEMP_DIR}"
+  assert_success
+}
+
+@test "assert_dir_exists fails when path is missing" {
+  run assert_dir_exists "${TEMP_DIR}/nodir"
+  assert_failure
+  assert_output --partial "directory does not exist"
+}
+
+@test "assert_dir_exists fails when path is a file" {
+  local _file="${TEMP_DIR}/a_file"
+  : > "${_file}"
+  run assert_dir_exists "${_file}"
+  assert_failure
+  assert_output --partial "directory does not exist"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# assert_file_owned_by
+# ════════════════════════════════════════════════════════════════════
+
+@test "assert_file_owned_by passes when owner matches" {
+  local _file="${TEMP_DIR}/owned.txt"
+  : > "${_file}"
+  local _user
+  _user="$(stat -c '%U' "${_file}")"
+  run assert_file_owned_by "${_user}" "${_file}"
+  assert_success
+}
+
+@test "assert_file_owned_by fails with owner diff when user mismatches" {
+  local _file="${TEMP_DIR}/owned.txt"
+  : > "${_file}"
+  run assert_file_owned_by definitely_not_a_real_user "${_file}"
+  assert_failure
+  assert_output --partial "owner mismatch"
+  assert_output --partial "expected"
+  assert_output --partial "actual"
+}
+
+@test "assert_file_owned_by fails when path missing" {
+  run assert_file_owned_by root "${TEMP_DIR}/missing"
+  assert_failure
+  assert_output --partial "path does not exist"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# assert_pip_pkg
+# ════════════════════════════════════════════════════════════════════
+
+@test "assert_pip_pkg passes when pip show returns 0" {
+  mock_cmd "pip" '
+    if [[ "$1" == "show" ]]; then exit 0; fi
+    exit 0'
+  run assert_pip_pkg somepkg
+  assert_success
+}
+
+@test "assert_pip_pkg fails when pip show returns non-zero" {
+  mock_cmd "pip" '
+    if [[ "$1" == "show" ]]; then exit 1; fi
+    exit 0'
+  run assert_pip_pkg missingpkg
+  assert_failure
+  assert_output --partial "pip package not installed"
+  assert_output --partial "missingpkg"
+}
+
+@test "assert_pip_pkg fails when pip is not installed" {
+  run assert_pip_pkg any
+  assert_failure
+  assert_output --partial "command not found on PATH"
+  assert_output --partial "pip"
+}


### PR DESCRIPTION
## Summary

- Ships reusable runtime assertion helpers for downstream-repo smoke specs (`assert_cmd_installed`, `assert_cmd_runs`, `assert_file_exists`, `assert_dir_exists`, `assert_file_owned_by`, `assert_pip_pkg`) with decorated failure diagnostics.
- Fixes latent bugs surfaced by a full audit: `init.sh` hard-coded `v0.5.0` workflow fallback, `setup.sh detect_ws_path` path-normalization, `setup.sh` inconsistent `BASH_SOURCE` guard, `ci.sh _install_deps` silent-failure paths.
- Closes test-coverage gaps on previously-untested branches — network-down version detection, `main.yaml @ref` fallback, `detect_ws_path` `..`-normalization, `_install_deps` error messaging, `_run_shellcheck` wired-file regression guard.

## Changes

### Added
- `test/smoke/test_helper.bash`: 6 runtime assert helpers for downstream smoke specs.
- `init.sh` new-repo skeleton now demos two sample smoke assertions using the helpers.
- Tests: `test/unit/init_spec.bats` (15) · `test/unit/ci_spec.bats` (8) · `test/unit/smoke_helper_spec.bats` (19) · +3 `detect_ws_path` cases in `setup_spec.bats`.

### Fixed
- `init.sh`: version detection unified; workflow refs fall back to `@main` (valid git ref) instead of hard-coded `v0.5.0`.
- `setup.sh detect_ws_path`: normalize `base_path` before composing sibling/parent paths; explicit ERROR on missing `base_path`.
- `setup.sh`: `${0:-}` consistency in `BASH_SOURCE == $0` guard.
- `ci.sh _install_deps`: explicit error messages for `apt-get update` / `install` / `git clone bats-mock` failures.

### Changed (testability)
- `ci.sh` and `init.sh`: wrap top-level flow in `main()` + `BASH_SOURCE == $0` guard + strict-mode gating (matches `setup.sh`). Behaviour when invoked directly is unchanged.

### Docs
- `TEST.md`: 247 → 292 tests, new sections for `ci_spec`, `init_spec`, `smoke_helper_spec`.
- `README` (en / zh-TW / zh-CN / ja): Directory tree refreshed; new **Dockerfile stages** section + **Smoke test helpers** section.
- `CHANGELOG.md` `[Unreleased]` Added / Fixed / Changed blocks.

## Test plan

- [x] `make -f Makefile.ci test` → 292/292 passing, 0 failure
- [x] ShellCheck + Hadolint (via CI `test` stage) green
- [x] Google Style self-review on all touched files
- [x] CI self-test workflow passed on push