### PR TITLE
fix: drop AI-attribution trailer from upgrade.sh commit message

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `upgrade.sh`: drop the auto-appended `Co-Authored-By: Claude ...`
+  trailer from the `chore: update template references` commit message.
+  AI-attribution lines are visual noise for reviewers and the project
+  convention is to omit them everywhere (PR body, commit message, code).
+
 ## [v0.8.0] - 2026-04-15
 
 ### Added

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -108,8 +108,6 @@ chore: update template references to ${target_ver}
 
 - .template_version: ${local_ver} → ${target_ver}
 - main.yaml: workflow @tag updated to ${target_ver}
-
-Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
 COMMIT
 )" || _log "No additional changes to commit"
 


### PR DESCRIPTION
## Summary

- \`upgrade.sh\` auto-appended a \`Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>\` trailer into every \`chore: update template references\` commit produced by downstream-repo upgrades.
- Project convention is to omit AI-attribution lines from PR bodies, commit messages, and code — they are visual noise for reviewers and carry no useful information.
- This patch removes the trailer from the \`git commit\` heredoc in \`upgrade.sh\`. No behaviour change beyond the commit message.

## Test plan

- [x] \`shellcheck -x upgrade.sh\` clean
- [x] \`make -f Makefile.ci test\` → 292/292 passing
- [x] No test referenced the trailer (grepped \`test/\` and \`doc/\`)