### PR TITLE
fix: silence Bats BW01/BW02 warnings

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `test/smoke/test_helper.bash`: `assert_cmd_installed` now returns `1`
+  after calling `fail`, so callers can short-circuit via `|| return 1`
+  instead of silently falling through. `assert_cmd_runs` and
+  `assert_pip_pkg` now short-circuit when the target command is missing,
+  so they no longer execute `run <missing-cmd>` and emit a spurious
+  Bats BW01 warning.
+- `test/unit/lib_spec.bats`, `test/unit/pip_setup_spec.bats`,
+  `test/unit/setup_spec.bats`: replace `run <cmd>` / `assert_failure`
+  pairs with `run -127 <cmd>` on the five tests whose command is
+  expected to exit 127 (`_load_env` missing arg, `_compose` on empty
+  PATH, `pip setup.sh` without pip, `setup.sh main --base-path` /
+  `--lang` missing value). Silences Bats BW01. Files that use `run -N`
+  flags now declare `bats_require_minimum_version 1.5.0` to silence
+  BW02.
+
 ## [v0.8.1] - 2026-04-15
 
 ### Fixed

--- a/test/smoke/test_helper.bash
+++ b/test/smoke/test_helper.bash
@@ -30,6 +30,7 @@ assert_cmd_installed() {
     batslib_print_kv_single 10 "cmd" "${_cmd}" \
       | batslib_decorate "command not found on PATH" \
       | fail
+    return 1
   fi
 }
 
@@ -41,7 +42,7 @@ assert_cmd_installed() {
 assert_cmd_runs() {
   local _cmd="${1:?assert_cmd_runs: missing cmd}"
   local _flag="${2:---version}"
-  assert_cmd_installed "${_cmd}"
+  assert_cmd_installed "${_cmd}" || return 1
   run "${_cmd}" "${_flag}"
   # shellcheck disable=SC2154  # 'status' and 'output' are populated by `run`
   if (( status != 0 )); then
@@ -107,7 +108,7 @@ assert_file_owned_by() {
 # Usage: assert_pip_pkg <pkg>
 assert_pip_pkg() {
   local _pkg="${1:?assert_pip_pkg: missing pkg}"
-  assert_cmd_installed pip
+  assert_cmd_installed pip || return 1
   run pip show "${_pkg}"
   # shellcheck disable=SC2154
   if (( status != 0 )); then

--- a/test/unit/lib_spec.bats
+++ b/test/unit/lib_spec.bats
@@ -5,6 +5,8 @@
 # These tests source _lib.sh in a fresh subshell and call each helper so
 # the bash branches actually run (kcov can then attribute coverage).
 
+bats_require_minimum_version 1.5.0
+
 setup() {
   load "${BATS_TEST_DIRNAME}/test_helper"
   LIB="/source/script/docker/_lib.sh"
@@ -72,8 +74,7 @@ EOF
 }
 
 @test "_load_env errors when no path is given" {
-  run bash -c "source ${LIB}; _load_env"
-  assert_failure
+  run -127 bash -c "source ${LIB}; _load_env"
 }
 
 # ── _compute_project_name ───────────────────────────────────────────────────
@@ -125,10 +126,9 @@ EOF
   # When DRY_RUN is unset/false, _compose calls real docker compose; on a
   # CI runner without docker the command exits non-zero, but we just want
   # to confirm the false branch executes (kcov coverage).
-  run bash -c "source ${LIB}; PATH=/nonexistent _compose version"
-  # Either docker compose ran (rc 0) or PATH lookup failed (rc 127);
-  # both are fine. We assert the script *attempted* the call by checking
-  # we did not see the dry-run prefix in output.
+  run -127 bash -c "source ${LIB}; PATH=/nonexistent _compose version"
+  # PATH=/nonexistent forces `docker compose` lookup to fail with rc 127,
+  # confirming the non-dry-run branch was taken (reached the real invocation).
   refute_output --partial "[dry-run]"
 }
 

--- a/test/unit/pip_setup_spec.bats
+++ b/test/unit/pip_setup_spec.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
   load "${BATS_TEST_DIRNAME}/test_helper"
   create_mock_dir
@@ -39,6 +41,5 @@ exit 0'
 
 @test "pip setup.sh fails when pip is not available" {
   mock_cmd "pip" 'exit 127'
-  run bash "${FAKE_SCRIPT_DIR}/setup.sh"
-  assert_failure
+  run -127 bash "${FAKE_SCRIPT_DIR}/setup.sh"
 }

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
   load "${BATS_TEST_DIRNAME}/test_helper"
 
@@ -540,8 +542,7 @@ EOF
 }
 
 @test "main returns error when --base-path value is missing" {
-  run bash -c "source /source/script/docker/setup.sh; main --base-path"
-  assert_failure
+  run -127 bash -c "source /source/script/docker/setup.sh; main --base-path"
 }
 
 @test "main sets APT_MIRROR defaults in fresh .env" {
@@ -664,6 +665,5 @@ EOF
 }
 
 @test "main --lang requires a value" {
-  run bash -c "source /source/script/docker/setup.sh; main --lang"
-  assert_failure
+  run -127 bash -c "source /source/script/docker/setup.sh; main --lang"
 }


### PR DESCRIPTION
## Summary
- Fix 5 intentional rc=127 unit tests to use `run -127 <cmd>` (was `run <cmd>` + `assert_failure`), and declare `bats_require_minimum_version 1.5.0` on affected files to avoid BW02.
- Fix real bug in `test/smoke/test_helper.bash`: `assert_cmd_installed` `| fail` in pipeline swallowed the non-zero rc, so `assert_cmd_runs` / `assert_pip_pkg` fell through and executed `run <missing-cmd>`, triggering BW01 and producing confusing double-fail output. Now `assert_cmd_installed` returns `1` after `fail`, and callers short-circuit via `|| return 1`.

## Result
`make -f Makefile.ci test`: 292 tests pass, 0 warnings (previously 7 BW01).

Closes #70.

## Test plan
- [x] `make -f Makefile.ci test` — 292 ok, no warnings, ShellCheck + Hadolint green
- [x] Tests that exercise "cmd missing" branches still fail with the same diagnostic text (`"command not found on PATH"`) — `assert_output --partial` assertions unchanged