### PR TITLE
feat(upgrade/init): default template remote to HTTPS; SSH via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ mkdir <repo_name> && cd <repo_name>
 git init
 git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=template \
-    git@github.com:ycpss91255-docker/template.git main --squash
+    https://github.com/ycpss91255-docker/template.git main --squash
 ./template/init.sh
 
 # Upgrade to latest
@@ -268,7 +268,7 @@ git commit --allow-empty -m "chore: initial commit"
 
 # 2. Add subtree
 git subtree add --prefix=template \
-    git@github.com:ycpss91255-docker/template.git main --squash
+    https://github.com/ycpss91255-docker/template.git main --squash
 
 # 3. Initialize symlinks (one command; runs setup.sh under the hood)
 ./template/init.sh

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **`upgrade.sh` / `init.sh` default to HTTPS** for the template remote
+  (`https://github.com/ycpss91255-docker/template.git`). Fresh clones /
+  CI runners / first-time contributors no longer need an SSH key to
+  `./template/upgrade.sh`. Override with `TEMPLATE_REMOTE=git@...` env
+  var for private forks or SSH-agent setups. 4-language READMEs and
+  `init.sh` docstring updated accordingly.
+
 ## [v0.9.0] - 2026-04-23
 
 ### Added (Wave 1 + Wave 2 — 2026-04-22)

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -35,7 +35,7 @@ mkdir <repo_name> && cd <repo_name>
 git init
 git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=template \
-    git@github.com:ycpss91255-docker/template.git main --squash
+    https://github.com/ycpss91255-docker/template.git main --squash
 ./template/init.sh
 
 # 最新版にアップグレード
@@ -278,7 +278,7 @@ git commit --allow-empty -m "chore: initial commit"
 
 # 2. subtree 追加
 git subtree add --prefix=template \
-    git@github.com:ycpss91255-docker/template.git main --squash
+    https://github.com/ycpss91255-docker/template.git main --squash
 
 # 3. symlink 初期化（ワンコマンド）
 ./template/init.sh

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -35,7 +35,7 @@ mkdir <repo_name> && cd <repo_name>
 git init
 git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=template \
-    git@github.com:ycpss91255-docker/template.git main --squash
+    https://github.com/ycpss91255-docker/template.git main --squash
 ./template/init.sh
 
 # 升级到最新版
@@ -267,7 +267,7 @@ git commit --allow-empty -m "chore: initial commit"
 
 # 2. 添加 subtree
 git subtree add --prefix=template \
-    git@github.com:ycpss91255-docker/template.git main --squash
+    https://github.com/ycpss91255-docker/template.git main --squash
 
 # 3. 初始化 symlinks（一个命令搞定）
 ./template/init.sh

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -35,7 +35,7 @@ mkdir <repo_name> && cd <repo_name>
 git init
 git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=template \
-    git@github.com:ycpss91255-docker/template.git main --squash
+    https://github.com/ycpss91255-docker/template.git main --squash
 ./template/init.sh
 
 # 升級到最新版
@@ -267,7 +267,7 @@ git commit --allow-empty -m "chore: initial commit"
 
 # 2. 加入 subtree
 git subtree add --prefix=template \
-    git@github.com:ycpss91255-docker/template.git main --squash
+    https://github.com/ycpss91255-docker/template.git main --squash
 
 # 3. 初始化 symlinks（一個指令搞定）
 ./template/init.sh

--- a/init.sh
+++ b/init.sh
@@ -7,8 +7,10 @@
 #   git init
 #   git commit --allow-empty -m "chore: initial commit"
 #   git subtree add --prefix=template \
-#       git@github.com:ycpss91255-docker/template.git main --squash
+#       https://github.com/ycpss91255-docker/template.git main --squash
 #   ./template/init.sh
+#
+# (Substitute `git@github.com:...` for SSH if you have a key configured.)
 #
 # Auto-detects:
 #   - Has Dockerfile → existing repo: create symlinks
@@ -104,9 +106,12 @@ _detect_template_version() {
     tr -d '[:space:]' < "${version_file}"
     return 0
   fi
-  # Fallback: query remote tags (for fresh subtree add before VERSION existed)
+  # Fallback: query remote tags (for fresh subtree add before VERSION existed).
+  # HTTPS by default so fresh clones / CI runners without an SSH key still
+  # work. Override via TEMPLATE_REMOTE env var (e.g. SSH for private forks).
+  local _remote="${TEMPLATE_REMOTE:-https://github.com/ycpss91255-docker/template.git}"
   git ls-remote --tags --sort=-v:refname \
-    git@github.com:ycpss91255-docker/template.git 2>/dev/null \
+    "${_remote}" 2>/dev/null \
     | grep -oP 'refs/tags/v\d+\.\d+\.\d+$' \
     | head -1 \
     | sed 's|refs/tags/||' || true
@@ -327,7 +332,7 @@ Options:
 
 Run from the repo root after:
   git subtree add --prefix=template \
-      git@github.com:ycpss91255-docker/template.git <version> --squash
+      https://github.com/ycpss91255-docker/template.git <version> --squash
 EOF
     return 0
   fi

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -12,7 +12,11 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly SCRIPT_DIR
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd -P)"
 readonly REPO_ROOT
-TEMPLATE_REMOTE="git@github.com:ycpss91255-docker/template.git"
+# Default to HTTPS so users without an SSH key (fresh clone, CI runner,
+# first-time contributor) can `./template/upgrade.sh` out of the box.
+# Export TEMPLATE_REMOTE=git@github.com:... to opt into SSH (needed for
+# private forks, or when the user prefers agent-based auth).
+TEMPLATE_REMOTE="${TEMPLATE_REMOTE:-https://github.com/ycpss91255-docker/template.git}"
 readonly TEMPLATE_REMOTE
 VERSION_FILE="${REPO_ROOT}/template/VERSION"
 readonly VERSION_FILE


### PR DESCRIPTION
## Summary

Fresh clones, CI runners, and first-time contributors no longer need an SSH key to run `./template/upgrade.sh` or `./template/init.sh`.

- `upgrade.sh`: `TEMPLATE_REMOTE="${TEMPLATE_REMOTE:-https://...}"` with env-var override preserved for SSH opt-in
- `init.sh` `_detect_template_version`: same pattern on the `ls-remote` fallback
- 4-lang README + docstrings updated to HTTPS URLs (SSH mentioned as alternative)

## Test plan

- [x] `make test` — 524/524 green
- [x] Manual: `./template/upgrade.sh --check` from a fresh clone (HTTPS) works without SSH key

## Opt into SSH

```bash
TEMPLATE_REMOTE="git@github.com:ycpss91255-docker/template.git" ./template/upgrade.sh
```