### PR TITLE
fix(bootstrap): cover compose.yaml + non-interactive bootstrap + defensive guard

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`build.sh` / `run.sh` bootstrap**: fresh clones (where `compose.yaml`
+  is gitignored since v0.9.0) now bootstrap correctly. Two regressions
+  fixed:
+  1. Bootstrap condition now also checks `compose.yaml`; previously a
+     clone with `.env` + `setup.conf` present but `compose.yaml` absent
+     skipped to the drift-check path and died in `_load_env` with a
+     cryptic "No such file" error.
+  2. Bootstrap path no longer dispatches through `_run_interactive`,
+     which on a TTY launches `setup_tui.sh`. A user who pressed
+     Esc / Ctrl+C in the TUI previously ended up with no `.env`.
+     Bootstrap now calls `setup.sh` directly; TUI stays reserved for
+     the explicit `--setup` flag.
+- **`build.sh` / `run.sh` defensive guard**: if `setup.sh` returns
+  without producing `.env` (cancelled TUI, setup crash, …), surface a
+  clear error pointing at `--setup` instead of failing deep in
+  `_load_env`.
+
 ## [v0.9.1] - 2026-04-23
 
 ### Changed

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **524 tests** total (491 unit + 33 integration).
+Template self-tests: **530 tests** total (497 unit + 33 integration).
 
 ## Test Files
 
@@ -92,7 +92,7 @@ a canned response; exercised with `TUI_STUB_RESPONSE` / `TUI_STUB_EXIT`.
 | `_tui_checklist` (passes `--separate-output`) | 1 |
 | `_tui_msgbox` / `_tui_yesno` (correct flags, propagates exit code) | 2 |
 
-### test/unit/build_sh_spec.bats (18)
+### test/unit/build_sh_spec.bats (22)
 
 Unit tests for `build.sh` argument handling and control flow. Uses a
 sandbox tree mirroring the expected layout (build.sh + `template/` subtree
@@ -101,21 +101,27 @@ so the stub captures argv; `build.sh` is symlinked (not copied) so kcov
 attributes coverage to the real source file.
 
 Covers: `--help` (en/zh/zh-CN/ja), `--setup`/`-s`, auto-bootstrap on
-missing `.env`, drift-check path when `.env` present, `--no-cache`,
-`--clean-tools`, positional `TARGET`, `--lang` argument validation,
-fallback `_detect_lang` branches (zh_TW/zh_CN/ja), and real (non-dry-run)
+missing `.env` / `setup.conf` / `compose.yaml`, drift-check path when
+all three are present, bootstrap staying non-interactive (setup.sh
+direct, not `setup_tui.sh`), defensive guard when setup produces no
+`.env`, TARGETARCH build-arg forwarding, `--no-cache`, `--clean-tools`,
+positional `TARGET`, `--lang` argument validation, fallback
+`_detect_lang` branches (zh_TW/zh_CN/ja), and real (non-dry-run)
 docker build invocation.
 
-### test/unit/run_sh_spec.bats (16)
+### test/unit/run_sh_spec.bats (23)
 
 Unit tests for `run.sh`. Mirrors the build_sh_spec.bats harness;
 `docker ps` reads from a controllable stub file so tests can simulate
 "container already running" scenarios.
 
-Covers: `--help` (en/zh/zh-CN/ja), `--setup`/`-s`, bootstrap / drift
-check, `--detach`, devel vs non-devel TARGET routing, `--instance`,
-already-running guard, Wayland xhost path, `--lang` / `--instance`
-argument validation, fallback `_detect_lang` branches.
+Covers: `--help` (en/zh/zh-CN/ja), `--setup`/`-s`, bootstrap on
+missing `.env` / `setup.conf` / `compose.yaml`, drift-check path,
+bootstrap staying non-interactive (setup.sh, not TUI), defensive guard
+when setup produces no `.env`, `--detach`, devel vs non-devel TARGET
+routing, `--instance`, already-running guard, Wayland xhost path,
+`--lang` / `--instance` argument validation, fallback `_detect_lang`
+branches.
 
 ### test/unit/compose_gen_spec.bats (31)
 

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -161,20 +161,36 @@ main() {
   }
 
   # Decide whether to run setup.sh / setup_tui.sh:
-  #   - --setup flag          → always run interactive-or-setup
-  #   - missing .env          → auto-bootstrap (first-time / fresh CI clone)
-  #   - otherwise             → check for drift and warn (but continue)
+  #   - --setup flag                         → interactive (TUI on TTY, else setup.sh)
+  #   - missing .env / setup.conf / compose.yaml → non-interactive bootstrap
+  #   - otherwise                            → drift-check only
+  #
+  # Bootstrap MUST stay non-interactive: compose.yaml is gitignored
+  # since v0.9.0, so every fresh clone hits the bootstrap path. If we
+  # dispatched through _run_interactive, a TTY user who cancelled the
+  # TUI (Esc / Ctrl+C) would end up with no .env and the next step
+  # would die inside _load_env with a cryptic "No such file" error.
+  # Direct setup.sh guarantees .env + compose.yaml are generated.
   if [[ "${RUN_SETUP}" == true ]]; then
     _run_interactive
-  elif [[ ! -f "${FILE_PATH}/.env" ]] || [[ ! -f "${FILE_PATH}/setup.conf" ]]; then
-    # Missing .env OR setup.conf → bootstrap. Covers fresh clones and
-    # the "I rm'd setup.conf to reset to defaults" reset workflow.
+  elif [[ ! -f "${FILE_PATH}/.env" ]] \
+      || [[ ! -f "${FILE_PATH}/setup.conf" ]] \
+      || [[ ! -f "${FILE_PATH}/compose.yaml" ]]; then
     printf "[build] INFO: First run — bootstrapping...\n"
-    _run_interactive
+    "${_setup}" --base-path "${FILE_PATH}" --lang "${_LANG}"
   else
     # shellcheck disable=SC1090
     source "${_setup}"
     _check_setup_drift "${FILE_PATH}" || true
+  fi
+
+  # Defensive: setup above should always produce .env. If it didn't
+  # (user cancelled an interactive TUI, setup.sh crashed, ...), surface
+  # a useful error instead of letting _load_env fail on a missing file.
+  if [[ ! -f "${FILE_PATH}/.env" ]]; then
+    printf "[build] ERROR: setup did not produce .env.\n" >&2
+    printf "[build] Re-run with './build.sh --setup' to open the editor.\n" >&2
+    exit 1
   fi
 
   # Load .env for project name

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -165,20 +165,32 @@ main() {
   }
 
   # Decide whether to run setup.sh / setup_tui.sh:
-  #   - --setup flag          → always run interactive-or-setup
-  #   - missing .env          → auto-bootstrap (first-time / fresh CI clone)
-  #   - otherwise             → check for drift and warn (but continue)
+  #   - --setup flag                         → interactive (TUI on TTY, else setup.sh)
+  #   - missing .env / setup.conf / compose.yaml → non-interactive bootstrap
+  #   - otherwise                            → drift-check only
+  #
+  # Bootstrap stays non-interactive (see build.sh for the full rationale):
+  # compose.yaml is gitignored since v0.9.0, every fresh clone lands here,
+  # and dispatching through the TUI would leave cancelled sessions
+  # without a .env.
   if [[ "${RUN_SETUP}" == true ]]; then
     _run_interactive
-  elif [[ ! -f "${FILE_PATH}/.env" ]] || [[ ! -f "${FILE_PATH}/setup.conf" ]]; then
-    # Missing .env OR setup.conf → bootstrap. Covers fresh clones and
-    # the "I rm'd setup.conf to reset to defaults" reset workflow.
+  elif [[ ! -f "${FILE_PATH}/.env" ]] \
+      || [[ ! -f "${FILE_PATH}/setup.conf" ]] \
+      || [[ ! -f "${FILE_PATH}/compose.yaml" ]]; then
     printf "[run] INFO: First run — bootstrapping...\n"
-    _run_interactive
+    "${_setup}" --base-path "${FILE_PATH}" --lang "${_LANG}"
   else
     # shellcheck disable=SC1090
     source "${_setup}"
     _check_setup_drift "${FILE_PATH}" || true
+  fi
+
+  # Defensive: bootstrap must leave .env in place. See build.sh.
+  if [[ ! -f "${FILE_PATH}/.env" ]]; then
+    printf "[run] ERROR: setup did not produce .env.\n" >&2
+    printf "[run] Re-run with './run.sh --setup' to open the editor.\n" >&2
+    exit 1
   fi
 
   # Load .env, derive PROJECT_NAME (sets/exports INSTANCE_SUFFIX too).

--- a/test/unit/build_sh_spec.bats
+++ b/test/unit/build_sh_spec.bats
@@ -109,15 +109,16 @@ teardown() {
   assert [ -f "${SANDBOX}/.env" ]
 }
 
-@test "build.sh skips setup.sh when .env AND setup.conf exist (drift-check path)" {
-  # Pre-create .env AND setup.conf → build.sh must NOT execute setup.sh,
-  # only source it for drift detection.
+@test "build.sh skips setup.sh when .env AND setup.conf AND compose.yaml exist (drift-check path)" {
+  # Pre-create all three derived files → build.sh must NOT execute
+  # setup.sh, only source it for drift detection.
   {
     echo "USER_NAME=tester"
     echo "IMAGE_NAME=mockimg"
     echo "DOCKER_HUB_USER=mockuser"
   } > "${SANDBOX}/.env"
   : > "${SANDBOX}/setup.conf"
+  : > "${SANDBOX}/compose.yaml"
   run bash "${SANDBOX}/build.sh" --dry-run
   assert_success
   refute_output --partial "First run"
@@ -139,6 +140,66 @@ teardown() {
   assert_success
   assert_output --partial "First run"
   assert [ -f "${MOCK_SETUP_LOG}" ]
+}
+
+@test "build.sh bootstraps setup.sh when compose.yaml is missing (fresh clone)" {
+  # Regression (v0.9.2): v0.9.0 started gitignoring compose.yaml, so
+  # a fresh clone has .env.example absent + setup.conf tracked +
+  # compose.yaml missing. Prior bootstrap check only looked at .env /
+  # setup.conf and skipped to the drift path, which then blew up in
+  # _load_env because .env also wasn't there. Missing compose.yaml
+  # must now trigger the bootstrap path on its own.
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+  : > "${SANDBOX}/setup.conf"
+  rm -f "${SANDBOX}/compose.yaml"
+  run bash "${SANDBOX}/build.sh" --dry-run
+  assert_success
+  assert_output --partial "First run"
+  assert [ -f "${MOCK_SETUP_LOG}" ]
+  assert [ -f "${SANDBOX}/compose.yaml" ]
+}
+
+@test "build.sh bootstrap calls setup.sh directly, not setup_tui.sh" {
+  # Regression (v0.9.2): bootstrap used to dispatch through
+  # _run_interactive, which on a TTY launches setup_tui.sh. A user who
+  # pressed Esc / Ctrl+C in the TUI ended up with no .env and the next
+  # build step blew up. Bootstrap must always go through setup.sh
+  # non-interactively; TUI is reserved for explicit --setup.
+  cat > "${SANDBOX}/setup_tui.sh" <<'EOS'
+#!/usr/bin/env bash
+echo "TUI_INVOKED" >> "${MOCK_SETUP_LOG}.tui"
+exit 0
+EOS
+  chmod +x "${SANDBOX}/setup_tui.sh"
+  run bash "${SANDBOX}/build.sh" --dry-run
+  assert_success
+  assert [ -f "${MOCK_SETUP_LOG}" ]
+  assert [ ! -f "${MOCK_SETUP_LOG}.tui" ]
+}
+
+@test "build.sh fails with clear error if setup.sh produced no .env" {
+  # Defensive guard: if bootstrap runs but setup.sh exits without
+  # writing .env (user cancelled a TUI, setup.sh crashed, etc.), the
+  # next step would fail deep in _load_env with a cryptic path error.
+  # Surface a helpful message instead.
+  cat > "${SANDBOX}/template/script/docker/setup.sh" <<'EOS'
+#!/usr/bin/env bash
+# Mock that exits cleanly but produces nothing.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  exit 0
+else
+  _check_setup_drift() { :; }
+fi
+EOS
+  chmod +x "${SANDBOX}/template/script/docker/setup.sh"
+  run bash "${SANDBOX}/build.sh" --dry-run
+  assert_failure
+  assert_output --partial ".env"
+  assert_output --partial "--setup"
 }
 
 @test "build.sh --no-cache is forwarded to docker build and compose" {
@@ -169,6 +230,7 @@ teardown() {
     echo "TARGET_ARCH=arm64"
   } > "${SANDBOX}/.env"
   : > "${SANDBOX}/setup.conf"
+  : > "${SANDBOX}/compose.yaml"
   run bash "${SANDBOX}/build.sh" --dry-run
   assert_success
   assert_output --partial "--build-arg TARGETARCH=arm64"
@@ -183,6 +245,7 @@ teardown() {
     echo "DOCKER_HUB_USER=mockuser"
   } > "${SANDBOX}/.env"
   : > "${SANDBOX}/setup.conf"
+  : > "${SANDBOX}/compose.yaml"
   run bash "${SANDBOX}/build.sh" --dry-run
   assert_success
   refute_output --partial "TARGETARCH"

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -109,13 +109,14 @@ teardown() {
   assert [ -f "${SANDBOX}/.env" ]
 }
 
-@test "run.sh skips setup.sh when .env AND setup.conf exist (drift-check path)" {
+@test "run.sh skips setup.sh when .env AND setup.conf AND compose.yaml exist (drift-check path)" {
   {
     echo "USER_NAME=tester"
     echo "IMAGE_NAME=mockimg"
     echo "DOCKER_HUB_USER=mockuser"
   } > "${SANDBOX}/.env"
   : > "${SANDBOX}/setup.conf"
+  : > "${SANDBOX}/compose.yaml"
   run bash "${SANDBOX}/run.sh" --dry-run
   assert_success
   refute_output --partial "First run"
@@ -133,6 +134,56 @@ teardown() {
   assert_success
   assert_output --partial "First run"
   assert [ -f "${MOCK_SETUP_LOG}" ]
+}
+
+@test "run.sh bootstraps setup.sh when compose.yaml is missing (fresh clone)" {
+  # Regression (v0.9.2): compose.yaml is gitignored since v0.9.0, so
+  # a fresh clone lands here with .env / setup.conf present but no
+  # compose.yaml. That case must also bootstrap.
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+  : > "${SANDBOX}/setup.conf"
+  rm -f "${SANDBOX}/compose.yaml"
+  run bash "${SANDBOX}/run.sh" --dry-run
+  assert_success
+  assert_output --partial "First run"
+  assert [ -f "${MOCK_SETUP_LOG}" ]
+  assert [ -f "${SANDBOX}/compose.yaml" ]
+}
+
+@test "run.sh bootstrap calls setup.sh directly, not setup_tui.sh" {
+  # Regression (v0.9.2): bootstrap used to launch setup_tui.sh on a
+  # TTY; user cancelling left the repo with no .env. Bootstrap must
+  # always be non-interactive.
+  cat > "${SANDBOX}/setup_tui.sh" <<'EOS'
+#!/usr/bin/env bash
+echo "TUI_INVOKED" >> "${MOCK_SETUP_LOG}.tui"
+exit 0
+EOS
+  chmod +x "${SANDBOX}/setup_tui.sh"
+  run bash "${SANDBOX}/run.sh" --dry-run
+  assert_success
+  assert [ -f "${MOCK_SETUP_LOG}" ]
+  assert [ ! -f "${MOCK_SETUP_LOG}.tui" ]
+}
+
+@test "run.sh fails with clear error if setup.sh produced no .env" {
+  cat > "${SANDBOX}/template/script/docker/setup.sh" <<'EOS'
+#!/usr/bin/env bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  exit 0
+else
+  _check_setup_drift() { :; }
+fi
+EOS
+  chmod +x "${SANDBOX}/template/script/docker/setup.sh"
+  run bash "${SANDBOX}/run.sh" --dry-run
+  assert_failure
+  assert_output --partial ".env"
+  assert_output --partial "--setup"
 }
 
 @test "run.sh --detach routes to 'compose up -d'" {


### PR DESCRIPTION
## Summary

Fresh clones since v0.9.0 (which gitignored `compose.yaml`) hit a
bootstrap bug on another machine:

```
.../template/script/docker/_lib.sh: line 48: .../.env: No such file or directory
```

Two stacked regressions in `build.sh` / `run.sh`:

1. **Bootstrap check omits `compose.yaml`.** `.env` + `setup.conf` can
   be present (e.g. user ran `setup.sh` once, `.gitignore` kept
   `compose.yaml` out of the working tree) and the code falls through
   to the drift path, which dies in `_load_env`.
2. **Bootstrap path dispatches through `_run_interactive`**, which on
   a TTY launches `setup_tui.sh`. A user pressing Esc / Ctrl+C leaves
   the repo without a `.env` and the next `_load_env` blows up the
   same way.

## Fix

- Bootstrap condition in both `build.sh` and `run.sh` now also checks
  `compose.yaml`.
- Bootstrap path calls `setup.sh` directly (non-interactive). TUI
  stays reserved for the explicit `--setup` flag.
- Defensive post-bootstrap guard prints a clear message pointing at
  `--setup` when `setup.sh` returns without producing `.env`.

## Tests (+6, total 524 → 530)

Regression tests in `build_sh_spec.bats` / `run_sh_spec.bats`:
- bootstrap triggers when `compose.yaml` is missing (even if `.env` +
  `setup.conf` exist)
- bootstrap calls `setup.sh` directly, not `setup_tui.sh` — an
  executable TUI stub in the sandbox confirms it is never invoked
- clear error when `setup.sh` leaves no `.env`

Existing drift-check tests updated to pre-create `compose.yaml` too.

## Test plan

- [x] `make -f Makefile.ci test` — 530/530 green
- [x] `make -f Makefile.ci lint` — shellcheck clean
- [ ] CI: `test` check passes
- [ ] Manual: fresh clone of a downstream repo → `./build.sh` works
      without `--setup`