### PR TITLE
fix(setup): make mount_1 workspace path portable across machines

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`[volumes] mount_1` portability**: `setup.sh` used to bake the
+  absolute host workspace path into `setup.conf` on first-time
+  bootstrap. Committing that file broke fresh clones on any other
+  machine whose filesystem layout differed — `_load_env` resolved
+  `WS_PATH` to a directory that doesn't exist and docker tried to
+  mount it. `setup.sh` now writes `mount_1` in the portable
+  `${WS_PATH}:/home/${USER_NAME}/work` form so docker-compose resolves
+  `${WS_PATH}` per-machine from `.env`. When a stale absolute path
+  (baked from another machine, absent locally) is encountered,
+  `setup.sh` warns and auto-migrates `mount_1` back to the portable
+  form. Users who intentionally pin an existing absolute path still
+  get that value honored.
+
 ## [v0.9.3] - 2026-04-23
 
 ### BREAKING

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **527 tests** total (494 unit + 33 integration).
+Template self-tests: **529 tests** total (496 unit + 33 integration).
 
 ## Test Files
 
@@ -34,7 +34,7 @@ Template self-tests: **527 tests** total (494 unit + 33 integration).
 | `_print_config_summary hides sections that are empty in setup.conf` | Empty-section skip |
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
 
-### test/unit/setup_spec.bats (85)
+### test/unit/setup_spec.bats (95)
 
 Covers core detection (user/hardware/docker/GPU/GUI), the INI parser
 (`_parse_ini_section`), setup.conf section merging (`_load_setup_conf`

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -1090,20 +1090,35 @@ main() {
 
   # ── WS_PATH + workspace mount ──
   #
-  # First-time bootstrap (no <repo>/setup.conf):
-  #   detect ws_path → copy template/setup.conf → upsert [volumes] mount_1.
-  # Subsequent runs:
-  #   <repo>/setup.conf is the source of truth. If mount_1 is set, extract
-  #   its host side as WS_PATH. If mount_1 is intentionally empty (user
-  #   opted out), fall back to best-effort detection for WS_PATH but
-  #   leave setup.conf alone.
+  # mount_1 can be:
+  #   - `${WS_PATH}:/home/${USER_NAME}/work` — portable form (default
+  #     since v0.9.4). docker-compose resolves ${WS_PATH} from .env on
+  #     each machine. setup.sh re-runs detect_ws_path locally.
+  #   - absolute host path — user pinned a specific directory. Honored
+  #     as long as the path exists on this machine.
+  #   - stale absolute path (baked from another machine, path absent
+  #     locally) — warn, auto-migrate mount_1 back to the portable
+  #     ${WS_PATH} form, and re-detect locally.
+  #   - empty — user opted out; skip the mount but still detect WS_PATH
+  #     so .env remains populated.
+  #
+  # First-time bootstrap (no <repo>/setup.conf) copies the template and
+  # writes mount_1 in the portable form.
   local _repo_conf="${_base_path}/setup.conf"
   local _mount_1=""
   _get_conf_value _vol_k _vol_v "mount_1" "" _mount_1
 
+  # SC2016: literal ${WS_PATH} / ${USER_NAME} are intentional — this
+  # string is written into setup.conf and expanded by docker-compose
+  # (via .env) at container start time, not by shell here.
+  # shellcheck disable=SC2016
+  local _ws_portable_form='${WS_PATH}:/home/${USER_NAME}/work'
+
   if [[ ! -f "${_repo_conf}" ]]; then
-    # First-time bootstrap: create per-repo setup.conf from template, then
-    # write the detected workspace into mount_1.
+    # First-time bootstrap: create per-repo setup.conf from template.
+    # Write mount_1 as the portable ${WS_PATH} form so the committed
+    # file stays machine-agnostic; .env carries the detected absolute
+    # path for docker-compose to expand.
     if [[ -z "${ws_path}" ]] || [[ ! -d "${ws_path}" ]]; then
       detect_ws_path ws_path "${_base_path}"
     fi
@@ -1113,14 +1128,48 @@ main() {
     if [[ -f "${_tpl_conf}" ]]; then
       cp "${_tpl_conf}" "${_repo_conf}"
       _upsert_conf_value "${_repo_conf}" "volumes" "mount_1" \
-        "${ws_path}:/home/\${USER_NAME}/work"
+        "${_ws_portable_form}"
       # Reload [volumes] so extra_volumes picks up the new mount_1.
       _vol_k=(); _vol_v=()
       _load_setup_conf "${_base_path}" "volumes" _vol_k _vol_v
       _get_conf_value _vol_k _vol_v "mount_1" "" _mount_1
     fi
   elif [[ -n "${_mount_1}" ]]; then
-    _mount_host_path "${_mount_1}" ws_path
+    local _mount_1_host=""
+    _mount_host_path "${_mount_1}" _mount_1_host
+    # SC2016: literal ${WS_PATH} / $WS_PATH substrings are intentional
+    # — we are matching the variable reference stored in setup.conf,
+    # not expanding it.
+    # shellcheck disable=SC2016
+    if [[ "${_mount_1_host}" == *'${WS_PATH}'* ]] \
+        || [[ "${_mount_1_host}" == *'$WS_PATH'* ]]; then
+      # Portable form — detect ws_path locally; mount_1 stays untouched.
+      ws_path=""
+      detect_ws_path ws_path "${_base_path}"
+      [[ -d "${ws_path}" ]] && ws_path="$(cd "${ws_path}" && pwd -P)"
+    elif [[ -d "${_mount_1_host}" ]]; then
+      # User pinned an absolute path that exists locally — honor it.
+      ws_path="${_mount_1_host}"
+    else
+      # Absolute path that doesn't exist on this machine — almost always
+      # a stale bake from another contributor's clone. Warn loudly so
+      # the user understands the rewrite, then migrate mount_1 back to
+      # the portable form.
+      printf "[setup] WARNING: [volumes] mount_1 host path '%s' does not exist on this machine.\n" \
+        "${_mount_1_host}" >&2
+      printf "[setup]          This is usually a stale absolute path committed from\n" >&2
+      printf "[setup]          a different machine. Rewriting mount_1 to the portable\n" >&2
+      printf "[setup]          '\${WS_PATH}:/home/\${USER_NAME}/work' form and re-detecting\n" >&2
+      printf "[setup]          WS_PATH locally. Commit the updated setup.conf to share.\n" >&2
+      ws_path=""
+      detect_ws_path ws_path "${_base_path}"
+      [[ -d "${ws_path}" ]] && ws_path="$(cd "${ws_path}" && pwd -P)"
+      _upsert_conf_value "${_repo_conf}" "volumes" "mount_1" \
+        "${_ws_portable_form}"
+      _vol_k=(); _vol_v=()
+      _load_setup_conf "${_base_path}" "volumes" _vol_k _vol_v
+      _get_conf_value _vol_k _vol_v "mount_1" "" _mount_1
+    fi
   else
     # setup.conf exists but user cleared mount_1: best-effort detection
     # for WS_PATH only; do not touch setup.conf.

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -1013,10 +1013,13 @@ EOF
 # Workspace writeback (first-time / user edit / opt-out)
 # ════════════════════════════════════════════════════════════════════
 
-@test "workspace first-time: creates <repo>/setup.conf + writes mount_1" {
+@test "workspace first-time: writes \${WS_PATH} variable form (portable)" {
+  # Regression (v0.9.4): writeback used to bake the absolute host path
+  # into setup.conf. Committing that file broke other machines whose
+  # filesystem layout differed. Now we write the \${WS_PATH} variable
+  # form so docker-compose resolves it per-machine from .env.
   local _repo="${TEMP_DIR}/repo"
   mkdir -p "${_repo}"
-  # Fresh: no setup.conf in repo
   run bash -c "
     source /source/script/docker/setup.sh
     main --base-path '${_repo}' 2>&1
@@ -1024,19 +1027,18 @@ EOF
   assert_success
   assert [ -f "${_repo}/setup.conf" ]
   run grep '^mount_1' "${_repo}/setup.conf"
-  [[ "${output}" == *"/home/\${USER_NAME}/work"* ]]
+  assert_output --partial '${WS_PATH}:/home/${USER_NAME}/work'
 }
 
-@test "workspace second-run: respects user-edited mount_1" {
+@test "workspace second-run: \${WS_PATH} form re-detects per machine" {
+  # Round-trip: first-time writes \${WS_PATH} form → second run reads
+  # setup.conf, sees the variable reference, and re-runs detect_ws_path
+  # so WS_PATH in .env reflects THIS machine (not the one that first
+  # committed the file).
   local _repo="${TEMP_DIR}/repo"
   mkdir -p "${_repo}"
-  # First run creates setup.conf with detected mount_1
   bash -c "source /source/script/docker/setup.sh; main --base-path '${_repo}'" \
     >/dev/null 2>&1
-  # User edits mount_1 to a custom path
-  sed -i 's|^mount_1.*|mount_1 = /custom/ws:/home/${USER_NAME}/work|' \
-    "${_repo}/setup.conf"
-  # Second run should read the user value, not re-detect
   run bash -c "
     source /source/script/docker/setup.sh
     main --base-path '${_repo}' 2>&1
@@ -1044,8 +1046,60 @@ EOF
     grep '^mount_1' '${_repo}/setup.conf'
   "
   assert_success
-  assert_output --partial "WS_PATH=/custom/ws"
-  assert_output --partial "mount_1 = /custom/ws:"
+  # WS_PATH is a non-empty absolute path — exact value depends on the
+  # sandbox, but it must not be the literal variable string.
+  refute_output --partial 'WS_PATH=${WS_PATH}'
+  assert_output --regexp 'WS_PATH=/[^[:space:]]+'
+  # mount_1 stays as the portable variable form.
+  assert_output --partial 'mount_1 = ${WS_PATH}:/home/${USER_NAME}/work'
+}
+
+@test "workspace second-run: respects user-pinned absolute path that exists" {
+  local _repo="${TEMP_DIR}/repo"
+  local _pin="${TEMP_DIR}/custom_ws"
+  mkdir -p "${_repo}" "${_pin}"
+  bash -c "source /source/script/docker/setup.sh; main --base-path '${_repo}'" \
+    >/dev/null 2>&1
+  # User pins mount_1 to an existing local path.
+  sed -i "s|^mount_1.*|mount_1 = ${_pin}:/home/\${USER_NAME}/work|" \
+    "${_repo}/setup.conf"
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main --base-path '${_repo}' 2>&1
+    grep '^WS_PATH=' '${_repo}/.env'
+    grep '^mount_1' '${_repo}/setup.conf'
+  "
+  assert_success
+  assert_output --partial "WS_PATH=${_pin}"
+  assert_output --partial "mount_1 = ${_pin}:"
+}
+
+@test "workspace second-run: stale absolute path (nonexistent) warns + auto-migrates to \${WS_PATH}" {
+  # Regression (v0.9.4): a repo cloned from github with mount_1 baked
+  # as another machine's absolute path (e.g. /home/alice/work/ws) must
+  # not try to mount that directory on /home/bob. setup.sh detects the
+  # stale host path (absolute, non-existent), warns, and rewrites
+  # mount_1 to the portable \${WS_PATH} form.
+  local _repo="${TEMP_DIR}/repo"
+  mkdir -p "${_repo}"
+  bash -c "source /source/script/docker/setup.sh; main --base-path '${_repo}'" \
+    >/dev/null 2>&1
+  # Plant a stale absolute path that does not exist on this machine.
+  sed -i 's|^mount_1.*|mount_1 = /nonexistent/stale/ws:/home/${USER_NAME}/work|' \
+    "${_repo}/setup.conf"
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main --base-path '${_repo}' 2>&1
+    grep '^mount_1' '${_repo}/setup.conf'
+    grep '^WS_PATH=' '${_repo}/.env'
+  "
+  assert_success
+  assert_output --partial "WARNING"
+  assert_output --partial "/nonexistent/stale/ws"
+  # mount_1 is rewritten back to the portable form.
+  assert_output --partial 'mount_1 = ${WS_PATH}:/home/${USER_NAME}/work'
+  # WS_PATH in .env is a local path, not the stale literal.
+  refute_output --partial "WS_PATH=/nonexistent/stale/ws"
 }
 
 @test "workspace opt-out: cleared mount_1 means no workspace mount in compose" {


### PR DESCRIPTION
## Summary

Fix user-reported bug: a fresh clone of `ros1_bridge` on an NVIDIA Jetson tried to mount a workspace under `/home/yunchien/Desktop/...` because that absolute path had been committed into `setup.conf` from a different contributor's clone.

## Root cause

`setup.sh` first-time bootstrap wrote the detected workspace as an **absolute host path** into `<repo>/setup.conf`:

```
mount_1 = /home/alice/work/ros1_bridge:/home/${USER_NAME}/work
```

Committing that file broke every other contributor's clone — on machine B, `/home/alice/...` doesn't exist.

## Fix

- First-time bootstrap now writes the **portable** form
  `${WS_PATH}:/home/${USER_NAME}/work`. docker-compose resolves `${WS_PATH}` from per-machine `.env`.
- Reading mount_1:
  - `${WS_PATH}` form → re-run `detect_ws_path` locally.
  - absolute, **exists** locally → honor (user pinned intentionally).
  - absolute, **doesn't exist** locally → WARN + auto-migrate back to the portable form, re-detect.
  - empty → opt-out (unchanged).

## Tests (+2, 527 → 529)

- First-time now asserts the `${WS_PATH}` form
- `${WS_PATH}` round-trip: value reference is preserved in setup.conf, WS_PATH in .env reflects local machine
- **NEW**: user-pinned absolute path that exists is honored (test pre-creates the dir — the old `/custom/ws` form would trip the new auto-migration)
- **NEW**: stale absolute path warns + auto-migrates back to the portable form

## Test plan

- [x] `make -f Makefile.ci test` — 529/529 green
- [x] `make -f Makefile.ci lint` — shellcheck clean
- [ ] CI `test` check passes
- [ ] After merge: tag v0.9.4 + fix ros1_bridge's committed setup.conf