### PR TITLE
fix(build/run): auto-regenerate .env + compose.yaml on drift

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **`build.sh` / `run.sh` auto-regenerate on drift**. `_check_setup_drift`
+  now returns non-zero when `setup.conf` / GPU / GUI / USER_UID drifted
+  from `.env`; the drift branch in `build.sh` / `run.sh` re-runs
+  `setup.sh` automatically instead of printing a WARNING and continuing
+  with stale `.env`. `.env` + `compose.yaml` are derived artifacts with
+  no user-owned data to preserve, so re-running is always safe. Fixes
+  the footgun where `git pull` + `./build.sh` silently used the
+  previous machine's `WS_PATH`. Users who preferred the warn-only
+  behaviour can still edit `.env` freely — drift is only re-triggered
+  by changes to `setup.conf` or detected hardware, not by editing
+  `.env` directly.
+
 ## [v0.9.4] - 2026-04-23
 
 ### Fixed

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **529 tests** total (496 unit + 33 integration).
+Template self-tests: **531 tests** total (498 unit + 33 integration).
 
 ## Test Files
 
@@ -92,7 +92,7 @@ a canned response; exercised with `TUI_STUB_RESPONSE` / `TUI_STUB_EXIT`.
 | `_tui_checklist` (passes `--separate-output`) | 1 |
 | `_tui_msgbox` / `_tui_yesno` (correct flags, propagates exit code) | 2 |
 
-### test/unit/build_sh_spec.bats (22)
+### test/unit/build_sh_spec.bats (23)
 
 Unit tests for `build.sh` argument handling and control flow. Uses a
 sandbox tree mirroring the expected layout (build.sh + `template/` subtree
@@ -109,7 +109,7 @@ positional `TARGET`, `--lang` argument validation, fallback
 `_detect_lang` branches (zh_TW/zh_CN/ja), and real (non-dry-run)
 docker build invocation.
 
-### test/unit/run_sh_spec.bats (23)
+### test/unit/run_sh_spec.bats (24)
 
 Unit tests for `run.sh`. Mirrors the build_sh_spec.bats harness;
 `docker ps` reads from a controllable stub file so tests can simulate

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -181,7 +181,16 @@ main() {
   else
     # shellcheck disable=SC1090
     source "${_setup}"
-    _check_setup_drift "${FILE_PATH}" || true
+    # Drift-check path. When setup.conf / GPU / GUI / USER_UID changed
+    # since .env was last generated (e.g. after `git pull` or a manual
+    # edit) we regenerate .env + compose.yaml automatically — they are
+    # derived artifacts with no user-owned data to preserve, so
+    # re-running setup.sh is always safe and saves the user from having
+    # to remember `./build.sh --setup`.
+    if ! _check_setup_drift "${FILE_PATH}"; then
+      printf "[build] regenerating .env / compose.yaml (setup.conf drifted)\n"
+      "${_setup}" --base-path "${FILE_PATH}" --lang "${_LANG}"
+    fi
   fi
 
   # Defensive: setup above should always produce .env. If it didn't

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -183,7 +183,11 @@ main() {
   else
     # shellcheck disable=SC1090
     source "${_setup}"
-    _check_setup_drift "${FILE_PATH}" || true
+    # Drift → auto-regen (see build.sh for the full rationale).
+    if ! _check_setup_drift "${FILE_PATH}"; then
+      printf "[run] regenerating .env / compose.yaml (setup.conf drifted)\n"
+      "${_setup}" --base-path "${FILE_PATH}" --lang "${_LANG}"
+    fi
   fi
 
   # Defensive: bootstrap must leave .env in place. See build.sh.

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -913,8 +913,9 @@ EOF
 # _check_setup_drift <base_path>
 #
 # Compares current system state + setup.conf hash against .env's SETUP_*
-# metadata. Prints [WARNING] lines to stderr when drift detected. Always
-# returns 0 (non-blocking). Caller is build.sh/run.sh before build/run.
+# metadata. Prints drift descriptions to stderr when drift detected and
+# returns 1 so the caller (build.sh / run.sh) can auto-regenerate the
+# derived artifacts. Returns 0 (silent) when in sync.
 #
 # Requires .env to exist (caller checks first).
 # ════════════════════════════════════════════════════════════════════
@@ -949,12 +950,13 @@ _check_setup_drift() {
 
   if (( ${#_drift[@]} > 0 )); then
     local _d
-    printf "[setup] WARNING: drift detected since last setup.sh run:\n" >&2
+    printf "[setup] drift detected since last setup.sh run:\n" >&2
     for _d in "${_drift[@]}"; do
       printf "[setup]   - %s\n" "${_d}" >&2
     done
-    printf "[setup] Run with --setup to regenerate .env / compose.yaml.\n" >&2
+    return 1
   fi
+  return 0
 }
 
 # ════════════════════════════════════════════════════════════════════

--- a/test/unit/build_sh_spec.bats
+++ b/test/unit/build_sh_spec.bats
@@ -109,6 +109,51 @@ teardown() {
   assert [ -f "${SANDBOX}/.env" ]
 }
 
+@test "build.sh auto-regens .env / compose.yaml when drift detected" {
+  # Regression (v0.9.5): drift used to be warn-only, leaving the stale
+  # .env in place. Users had to remember `./build.sh --setup` after
+  # every git pull / setup.conf edit. Now the drift branch regens
+  # automatically since .env / compose.yaml are derived artifacts.
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+  : > "${SANDBOX}/setup.conf"
+  : > "${SANDBOX}/compose.yaml"
+  # Patch the mock so that its sourced form reports drift.
+  cat > "${SANDBOX}/template/script/docker/setup.sh" <<'EOS'
+#!/usr/bin/env bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  _base=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --base-path) _base="$2"; shift 2 ;;
+      --lang)      shift 2 ;;
+      *)           shift ;;
+    esac
+  done
+  printf 'setup.sh invoked --base-path %s\n' "${_base}" >> "${MOCK_SETUP_LOG}"
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${_base}/.env"
+  echo "# mock compose" > "${_base}/compose.yaml"
+else
+  _check_setup_drift() { return 1; }
+fi
+EOS
+  chmod +x "${SANDBOX}/template/script/docker/setup.sh"
+  run bash "${SANDBOX}/build.sh" --dry-run
+  assert_success
+  assert_output --partial "regenerating"
+  assert [ -f "${MOCK_SETUP_LOG}" ]
+  run cat "${MOCK_SETUP_LOG}"
+  assert_output --partial "setup.sh invoked --base-path ${SANDBOX}"
+}
+
 @test "build.sh skips setup.sh when .env AND setup.conf AND compose.yaml exist (drift-check path)" {
   # Pre-create all three derived files → build.sh must NOT execute
   # setup.sh, only source it for drift detection.

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -109,6 +109,45 @@ teardown() {
   assert [ -f "${SANDBOX}/.env" ]
 }
 
+@test "run.sh auto-regens .env / compose.yaml when drift detected" {
+  # Regression (v0.9.5): mirror of the build.sh drift auto-regen test.
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+  : > "${SANDBOX}/setup.conf"
+  : > "${SANDBOX}/compose.yaml"
+  cat > "${SANDBOX}/template/script/docker/setup.sh" <<'EOS'
+#!/usr/bin/env bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  _base=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --base-path) _base="$2"; shift 2 ;;
+      --lang)      shift 2 ;;
+      *)           shift ;;
+    esac
+  done
+  printf 'setup.sh invoked --base-path %s\n' "${_base}" >> "${MOCK_SETUP_LOG}"
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${_base}/.env"
+  echo "# mock compose" > "${_base}/compose.yaml"
+else
+  _check_setup_drift() { return 1; }
+fi
+EOS
+  chmod +x "${SANDBOX}/template/script/docker/setup.sh"
+  run bash "${SANDBOX}/run.sh" --dry-run
+  assert_success
+  assert_output --partial "regenerating"
+  assert [ -f "${MOCK_SETUP_LOG}" ]
+}
+
 @test "run.sh skips setup.sh when .env AND setup.conf AND compose.yaml exist (drift-check path)" {
   {
     echo "USER_NAME=tester"

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -698,7 +698,7 @@ EOF
   refute_output --partial "WARNING"
 }
 
-@test "_check_setup_drift warns when conf hash changes" {
+@test "_check_setup_drift returns non-zero when conf hash changes" {
   local _h_old=""
   _compute_conf_hash "${TEMP_DIR}" _h_old
   write_env "${TEMP_DIR}/.env" \
@@ -718,11 +718,13 @@ mode = off
 EOF
 
   run _check_setup_drift "${TEMP_DIR}"
-  assert_output --partial "WARNING"
+  # Non-zero exit lets build.sh/run.sh trigger auto-regen (v0.9.5+).
+  assert_failure
+  assert_output --partial "drift detected"
   assert_output --partial "setup.conf modified"
 }
 
-@test "_check_setup_drift warns when GPU detection changes" {
+@test "_check_setup_drift returns non-zero when GPU detection changes" {
   local _h=""
   _compute_conf_hash "${TEMP_DIR}" _h
   # Store with GPU=false
@@ -738,6 +740,7 @@ EOF
   detect_gpu() { local -n _o=$1; _o="true"; }
 
   run _check_setup_drift "${TEMP_DIR}"
+  assert_failure
   assert_output --partial "GPU detection changed"
 }
 


### PR DESCRIPTION
## Summary

Drift between `setup.conf` and `.env` / `compose.yaml` used to only print a WARNING and continue. Users who didn't read the stderr line ended up with stale `.env` (e.g. after `git pull` brought in a new `setup.conf`). This was exactly what happened on the NVIDIA Jetson: `git pull` updated `mount_1` to the portable `${WS_PATH}` form, `./build.sh` warned about drift, but kept the previous machine's `WS_PATH=/home/yunchien/...` in `.env`.

Fix: make the drift branch self-healing.

## Changes

- `_check_setup_drift` (setup.sh): returns `1` when drift detected (was always `0`). Silent on success.
- `build.sh` / `run.sh`: drift branch checks the return code — on drift, re-runs `setup.sh` directly to regen `.env` + `compose.yaml`. Prints `[build] regenerating ...` so the user sees what happened.
- `.env` + `compose.yaml` are derived artifacts (all user config is in `setup.conf`), so regen is always safe.

## Tests (+2, 529 → 531)

- `_check_setup_drift warns when ...` → renamed to `returns non-zero when ...`, assert `failure` + drift description.
- **NEW** `build.sh auto-regens .env / compose.yaml when drift detected` — mock `_check_setup_drift` to return 1, assert setup.sh is invoked + regen log line printed.
- **NEW** mirror test in `run_sh_spec.bats`.

## Test plan

- [x] `make -f Makefile.ci test` — 531/531 green
- [x] `make -f Makefile.ci lint` — shellcheck clean
- [ ] CI `test` passes
- [ ] After merge: tag v0.9.5, upgrade ros1_bridge (Jetson user's `git pull && ./build.sh` should then silently auto-regen `.env`)