### PR TITLE
feat(build): add [build] network key + fresh-clone portability integration test

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **`[build] network` setup.conf key**: overrides Docker's build-time
+  network mode. Empty (default) = Docker decides (bridge + NAT). Set
+  to `host` when the host's bridge NAT is unusable: stripped embedded
+  kernels (e.g. Jetson L4T missing `iptable_raw`), hosts with
+  `"iptables": false` in daemon.json, or firewall-locked CI runners.
+  `setup.sh` writes `BUILD_NETWORK=<value>` to `.env` and emits
+  `build.network: <value>` under each service in `compose.yaml`;
+  `build.sh` forwards `--network <value>` to the auxiliary
+  `docker build` invocation for `test-tools`. `setup_tui.sh` gains a
+  matching `[build] Build network` menu item and
+  `_validate_build_network` validator (accepts empty / `host` /
+  `bridge` / `none` / `default`).
+- **Integration test** `fresh_clone_portability_spec.bats` covers the
+  fresh-clone-on-a-different-machine path end-to-end (real `build.sh`
+  + `setup.sh`, no mocks): both the stale-absolute-path auto-migrate
+  and the portable `${WS_PATH}` round-trip.
+
+### Changed
+- **`_dump_conf_section` hides empty-valued keys** in the
+  `_print_config_summary` output. Lines like `shm_size =` (using the
+  template default) are noise in the config dump; they're now
+  filtered. Sections whose every key is empty collapse to nothing and
+  the section header is skipped too (via the existing
+  `[[ -z ${_content} ]]` check in the caller).
+
 ## [v0.9.5] - 2026-04-23
 
 ### Changed

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **531 tests** total (498 unit + 33 integration).
+Template self-tests: **543 tests** total (508 unit + 35 integration).
 
 ## Test Files
 
-### test/unit/lib_spec.bats (25)
+### test/unit/lib_spec.bats (26)
 
 | Test | Description |
 |------|-------------|
@@ -34,7 +34,7 @@ Template self-tests: **531 tests** total (498 unit + 33 integration).
 | `_print_config_summary hides sections that are empty in setup.conf` | Empty-section skip |
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
 
-### test/unit/setup_spec.bats (95)
+### test/unit/setup_spec.bats (97)
 
 Covers core detection (user/hardware/docker/GPU/GUI), the INI parser
 (`_parse_ini_section`), setup.conf section merging (`_load_setup_conf`
@@ -61,7 +61,7 @@ writeback (first-time bootstrap / user-edit respect / opt-out).
 | `[build]` apt_mirror (empty fallback, override) | 2 |
 | Workspace writeback (first-time, respect user edit, opt-out) | 3 |
 
-### test/unit/tui_spec.bats (59)
+### test/unit/tui_spec.bats (70)
 
 Pure-logic unit tests for the TUI support libraries (`_tui_conf.sh`).
 No dialog/whiptail invocations here — strictly validators, mount-string
@@ -76,7 +76,7 @@ parsers, and setup.conf round-trip.
 | `_load_setup_conf_full` + `_write_setup_conf` (section order, kv, comment preservation, untouched keys, round-trip) | 5 |
 | `_upsert_conf_value` (updates existing, leaves other sections untouched) | 2 |
 
-### test/unit/tui_backend_spec.bats (11)
+### test/unit/tui_backend_spec.bats (23)
 
 Backend detection and wrapper-level arg forwarding. Uses a stub
 `dialog` / `whiptail` binary installed on PATH that logs argv and echoes
@@ -92,7 +92,7 @@ a canned response; exercised with `TUI_STUB_RESPONSE` / `TUI_STUB_EXIT`.
 | `_tui_checklist` (passes `--separate-output`) | 1 |
 | `_tui_msgbox` / `_tui_yesno` (correct flags, propagates exit code) | 2 |
 
-### test/unit/build_sh_spec.bats (23)
+### test/unit/build_sh_spec.bats (25)
 
 Unit tests for `build.sh` argument handling and control flow. Uses a
 sandbox tree mirroring the expected layout (build.sh + `template/` subtree
@@ -123,7 +123,7 @@ routing, `--instance`, already-running guard, Wayland xhost path,
 `--lang` / `--instance` argument validation, fallback `_detect_lang`
 branches.
 
-### test/unit/compose_gen_spec.bats (31)
+### test/unit/compose_gen_spec.bats (35)
 
 Covers `generate_compose_yaml` conditional output: AUTO-GENERATED
 header, baseline workspace volume, network/ipc/privileged env-var
@@ -444,3 +444,18 @@ which has access to a Docker daemon on the host runner.
 | `new repo: .gitignore contains .env (derived artifact)` | gitignore .env |
 | `new repo: compose.yaml has AUTO-GENERATED header (produced by setup.sh)` | setup.sh generated compose.yaml |
 | `new repo: per-repo setup.conf not created by default` | template default usage |
+
+### test/integration/fresh_clone_portability_spec.bats (2)
+
+End-to-end verification for the fresh-clone-on-a-different-machine scenario:
+the consumer repo's `setup.conf` has already been committed by another
+contributor and carries either a stale absolute `mount_1` path (the Jetson
+bug) or the portable `${WS_PATH}` form. Runs the real `build.sh` +
+`setup.sh` (no mocks) and asserts the auto-migration / per-machine detection
+pipeline lands a valid `.env` + `compose.yaml`. **Level 1** (no Docker
+invocation — `build.sh --dry-run`).
+
+| Test | Description |
+|------|-------------|
+| `fresh clone with stale absolute mount_1: build.sh auto-migrates + generates local .env` | Stale-path auto-migrate |
+| `fresh clone with portable ${WS_PATH} mount_1: no warning, .env gets local path` | Happy path round-trip |

--- a/script/docker/_lib.sh
+++ b/script/docker/_lib.sh
@@ -82,11 +82,16 @@ _compute_project_name() {
 _dump_conf_section() {
   local _file="$1" _sec="$2"
   [[ -f "${_file}" ]] || return 0
+  # Filter out empty values (`key =` / `key = `). An empty value means
+  # "use the Docker / template default" and is noise in the summary.
+  # Populated keys print as-is; cleared list slots (arg_N = / mount_N =)
+  # are also hidden so they don't show up as blank rows.
   awk -v sec="[${_sec}]" '
     $0 == sec { in_sec=1; next }
     /^\[/ && in_sec { in_sec=0 }
     in_sec && /^[[:space:]]*#/ { next }
     in_sec && /^[[:space:]]*$/ { next }
+    in_sec && /^[[:space:]]*[^#=]+=[[:space:]]*$/ { next }
     in_sec { print }
   ' "${_file}"
 }

--- a/script/docker/_tui_conf.sh
+++ b/script/docker/_tui_conf.sh
@@ -155,6 +155,21 @@ _validate_target_arch() {
   esac
 }
 
+# _validate_build_network <value>
+#
+# Accepts empty (Docker default = bridge) or one of the network modes
+# that docker build / docker compose build accept via their --network
+# flag. `host` is the common workaround for environments where bridge
+# NAT is broken (stripped embedded kernels, iptables:false).
+_validate_build_network() {
+  local _v="${1-}"
+  [[ -z "${_v}" ]] && return 0
+  case "${_v}" in
+    host|bridge|none|default) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # ════════════════════════════════════════════════════════════════════
 # Mount-string parsers
 # ════════════════════════════════════════════════════════════════════

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -221,6 +221,12 @@ main() {
   if [[ -n "${TARGET_ARCH:-}" ]]; then
     _tools_args+=(--build-arg "TARGETARCH=${TARGET_ARCH}")
   fi
+  # Forward [build] network when set. Empty = docker default (bridge).
+  # Needed on hosts whose bridge NAT is unusable (Jetson L4T without
+  # iptable_raw, daemon.json with iptables: false, firewall-locked CI).
+  if [[ -n "${BUILD_NETWORK:-}" ]]; then
+    _tools_args+=(--network "${BUILD_NETWORK}")
+  fi
   if [[ -f "${_tools_dockerfile}" ]]; then
     if [[ "${DRY_RUN}" == true ]]; then
       printf '[dry-run] docker build'

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -567,6 +567,7 @@ generate_compose_yaml() {
   local _cgroup_rule_str="${19:-}"
   local _user_build_args_str="${20:-}"
   local _target_arch="${21:-}"
+  local _build_network="${22:-}"
 
   # TARGETARCH line emitter: only when target_arch is set. Empty =
   # omit the line entirely so BuildKit auto-fills TARGETARCH from the
@@ -575,6 +576,15 @@ generate_compose_yaml() {
     [[ -z "${_target_arch}" ]] && return 0
     # shellcheck disable=SC2016  # literal ${} consumed by compose, not bash
     printf '        TARGETARCH: ${TARGET_ARCH}\n'
+  }
+
+  # build.network emitter: only when build_network is set. Empty =
+  # omit the line so Docker uses its default (bridge). Non-empty =
+  # force the build to use that network (typically "host" for
+  # environments where bridge NAT doesn't work).
+  _emit_build_network_line() {
+    [[ -z "${_build_network}" ]] && return 0
+    printf '      network: %s\n' "${_build_network}"
   }
 
   # Convert space-separated caps to YAML array form [a, b, c]
@@ -604,6 +614,9 @@ services:
       context: .
       dockerfile: Dockerfile
       target: devel
+YAML
+    _emit_build_network_line
+    cat <<YAML
       args:
         APT_MIRROR_UBUNTU: \${APT_MIRROR_UBUNTU:-archive.ubuntu.com}
         APT_MIRROR_DEBIAN: \${APT_MIRROR_DEBIAN:-deb.debian.org}
@@ -765,6 +778,9 @@ YAML
       context: .
       dockerfile: Dockerfile
       target: test
+YAML
+    _emit_build_network_line
+    cat <<YAML
       args:
         APT_MIRROR_UBUNTU: \${APT_MIRROR_UBUNTU:-archive.ubuntu.com}
         APT_MIRROR_DEBIAN: \${APT_MIRROR_DEBIAN:-deb.debian.org}
@@ -838,7 +854,8 @@ write_env() {
   local _conf_hash="${1}"; shift
   local _network_name="${1:-}"; shift || true
   local _user_build_args="${1:-}"; shift || true
-  local _target_arch="${1:-}"
+  local _target_arch="${1:-}"; shift || true
+  local _build_network="${1:-}"
 
   local _comment=""
   _comment="$(_msg env_comment)"
@@ -905,6 +922,16 @@ EOF
     {
       printf '\n# ── TARGETARCH override (from [build] target_arch) ──\n'
       printf 'TARGET_ARCH=%q\n' "${_target_arch}"
+    } >> "${_env_file}"
+  fi
+
+  # BUILD_NETWORK override: only emit when the user set [build] network.
+  # Empty stays unset so build.sh skips the `--network` flag and docker
+  # compose build inherits its default.
+  if [[ -n "${_build_network:-}" ]]; then
+    {
+      printf '\n# ── BUILD_NETWORK override (from [build] network) ──\n'
+      printf 'BUILD_NETWORK=%q\n' "${_build_network}"
     } >> "${_env_file}"
   fi
 }
@@ -1077,6 +1104,14 @@ main() {
   # Non-empty = pin the value for cross-build or explicit control.
   local target_arch=""
   _get_conf_value _build_k _build_v "target_arch" "" target_arch
+
+  # Build-time network override: scalar `[build] network`. Empty =
+  # docker default (bridge). Non-empty = passed as `build.network` in
+  # compose.yaml and `--network <value>` to the auxiliary test-tools
+  # docker build. Typical value: `host`, for hosts whose docker bridge
+  # NAT is unusable (stripped embedded kernels, iptables:false).
+  local build_network=""
+  _get_conf_value _build_k _build_v "network" "" build_network
 
   local gpu_mode="" gpu_count="" gpu_caps=""
   local gui_mode=""
@@ -1269,7 +1304,8 @@ main() {
     "${gui_detected}" "${conf_hash}" \
     "${network_name}" \
     "${_user_build_args_str}" \
-    "${target_arch}"
+    "${target_arch}" \
+    "${build_network}"
 
   generate_compose_yaml "${_base_path}/compose.yaml" "${image_name}" \
     "${gui_enabled_eff}" "${gpu_enabled_eff}" \
@@ -1281,7 +1317,8 @@ main() {
     "${_cap_add_str}" "${_cap_drop_str}" "${_sec_opt_str}" \
     "${_cgroup_rule_str}" \
     "${_user_build_args_str}" \
-    "${target_arch}"
+    "${target_arch}" \
+    "${build_network}"
 
   printf "[setup] %s\n" "$(_msg env_done)"
   printf "[setup] USER=%s (%s:%s)  GPU=%s/%s  GUI=%s/%s  IMAGE=%s  WS=%s\n" \

--- a/script/docker/setup_tui.sh
+++ b/script/docker/setup_tui.sh
@@ -94,8 +94,12 @@ declare -gA _TUI_MSG_EN=(
   [build.target_arch.label]="TARGETARCH override"
   [build.target_arch.prompt]=$'Docker TARGETARCH override\n  - Empty = let BuildKit auto-fill from host / --platform (default)\n  - amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64\n  - Applies to the main image + the test-tools image\n  - Pin when you need cross-builds or explicit control'
   [build.target_arch.auto]="(auto)"
+  [build.network.label]="Build network"
+  [build.network.prompt]=$'Docker build-time network (only the build stage; runtime is separate)\n  - Empty = Docker default (bridge + NAT)\n  - host = use the host network stack. Required when the host\'s bridge\n          NAT is unusable: stripped embedded kernels (e.g. Jetson L4T\n          missing iptable_raw), hosts with iptables: false, or firewall-\n          locked CI runners.\n  - bridge / none / default = explicit variants (rarely needed)'
+  [build.network.default]="(default: bridge)"
   [build.args.label]="Extra build args"
   [err.invalid_target_arch]="Invalid TARGETARCH. Use empty or amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64."
+  [err.invalid_build_network]="Invalid build network. Use empty or host / bridge / none / default."
   [network.title]="Network"
   [network.mode.prompt]="Network mode"
   [network.mode.host]="host (share host network stack)"
@@ -238,8 +242,12 @@ declare -gA _TUI_MSG_ZH_TW=(
   [build.target_arch.label]="TARGETARCH 覆寫"
   [build.target_arch.prompt]=$'Docker TARGETARCH 覆寫\n  - 留空 = 交給 BuildKit 依 host / --platform 自動填（預設）\n  - amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64\n  - 同時套用主 image 與 test-tools image\n  - 需要跨架構編譯或明確指定時才填'
   [build.target_arch.auto]="（自動）"
+  [build.network.label]="Build 網路"
+  [build.network.prompt]=$'Docker build 階段使用的網路（不影響 runtime 容器的網路）\n  - 留空 = Docker 預設（bridge + NAT）\n  - host = 改用 host 網路 stack。當主機的 bridge NAT 無法用時需要：\n          例如 kernel 缺 iptable_raw（Jetson L4T）、\n          daemon.json 有 iptables: false、或 CI runner 防火牆限制。\n  - bridge / none / default = 其他明確選項（很少用到）'
+  [build.network.default]="（預設：bridge）"
   [build.args.label]="額外 build args"
   [err.invalid_target_arch]="TARGETARCH 無效，請填空值或 amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64。"
+  [err.invalid_build_network]="Build 網路無效，請填空值或 host / bridge / none / default。"
   [network.title]="Network"
   [network.mode.prompt]="網路模式"
   [network.mode.host]="host（共用主機網路堆疊）"
@@ -380,8 +388,12 @@ declare -gA _TUI_MSG_ZH_CN=(
   [build.target_arch.label]="TARGETARCH 覆盖"
   [build.target_arch.prompt]=$'Docker TARGETARCH 覆盖\n  - 留空 = 交给 BuildKit 依 host / --platform 自动填（默认）\n  - amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64\n  - 同时应用于主 image 与 test-tools image\n  - 需要跨架构构建或明确指定时才填'
   [build.target_arch.auto]="（自动）"
+  [build.network.label]="Build 网络"
+  [build.network.prompt]=$'Docker build 阶段使用的网络（不影响 runtime 容器的网络）\n  - 留空 = Docker 默认（bridge + NAT）\n  - host = 改用 host 网络 stack。当主机的 bridge NAT 无法用时需要：\n          例如 kernel 缺 iptable_raw（Jetson L4T）、\n          daemon.json 有 iptables: false、或 CI runner 防火墙限制。\n  - bridge / none / default = 其他明确选项（很少用到）'
+  [build.network.default]="（默认：bridge）"
   [build.args.label]="额外 build args"
   [err.invalid_target_arch]="TARGETARCH 无效，请填空值或 amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64。"
+  [err.invalid_build_network]="Build 网络无效，请填空值或 host / bridge / none / default。"
   [network.title]="Network"
   [network.mode.prompt]="网络模式"
   [network.mode.host]="host（共用主机网络栈）"
@@ -517,8 +529,12 @@ declare -gA _TUI_MSG_JA=(
   [build.target_arch.label]="TARGETARCH 上書き"
   [build.target_arch.prompt]=$'Docker TARGETARCH 上書き\n  - 空 = BuildKit が host / --platform から自動補完（デフォルト）\n  - amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64\n  - メイン image と test-tools image の両方に適用\n  - クロスビルドや明示指定が必要なときのみ設定'
   [build.target_arch.auto]="（自動）"
+  [build.network.label]="Build ネットワーク"
+  [build.network.prompt]=$'Docker build 時のネットワーク（runtime コンテナは別管理）\n  - 空 = Docker デフォルト（bridge + NAT）\n  - host = ホストのネットワークスタックを利用。ホストの bridge NAT が\n          使えない場合に必要：kernel が iptable_raw 欠落（Jetson L4T）、\n          daemon.json に iptables: false、CI runner のファイアウォール制限など。\n  - bridge / none / default = 明示指定（めったに使用しない）'
+  [build.network.default]="（デフォルト：bridge）"
   [build.args.label]="追加 build args"
   [err.invalid_target_arch]="TARGETARCH が不正です。空、または amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64 を指定してください。"
+  [err.invalid_build_network]="Build ネットワークが不正です。空、または host / bridge / none / default を指定してください。"
   [network.title]="Network"
   [network.mode.prompt]="ネットワークモード"
   [network.mode.host]="host（ホストネットワークスタックを共有）"
@@ -965,12 +981,18 @@ _swap_image_rule() {
 
 _edit_section_build() {
   while true; do
-    local _arch_cur _arch_display _args_cnt
+    local _arch_cur _arch_display _net_cur _net_display _args_cnt
     _arch_cur="$(_override_get "build.target_arch" "")"
     if [[ -n "${_arch_cur}" ]]; then
       _arch_display="${_arch_cur}"
     else
       _arch_display="$(_tui_msg build.target_arch.auto)"
+    fi
+    _net_cur="$(_override_get "build.network" "")"
+    if [[ -n "${_net_cur}" ]]; then
+      _net_display="${_net_cur}"
+    else
+      _net_display="$(_tui_msg build.network.default)"
     fi
     # Count populated arg_N slots for the menu-item badge. Pulls from
     # the pending override state (_TUI_CURRENT is the effective view
@@ -986,6 +1008,7 @@ _edit_section_build() {
     local _choice
     _choice="$(_tui_menu "$(_tui_msg build.title)" "$(_tui_msg build.menu)" \
       target_arch "$(_tui_msg build.target_arch.label) = ${_arch_display}" \
+      network     "$(_tui_msg build.network.label) = ${_net_display}" \
       args        "$(_tui_msg build.args.label) (${_args_cnt})" \
       __back      "$(_tui_msg build.back)")" || return 0
 
@@ -1003,6 +1026,16 @@ _edit_section_build() {
         # setup.sh's `[[ -n $target_arch ]]` check handles the empty
         # case by omitting TARGETARCH from .env + compose.yaml.
         _override_set "build.target_arch" "${_new}"
+        ;;
+      network)
+        local _new_net
+        _new_net="$(_tui_inputbox "$(_tui_msg build.title)" \
+          "$(_tui_msg build.network.prompt)" "${_net_cur}")" || continue
+        if ! _validate_build_network "${_new_net}"; then
+          _tui_msgbox "$(_tui_msg build.title)" "$(_tui_msg err.invalid_build_network)"
+          continue
+        fi
+        _override_set "build.network" "${_new_net}"
         ;;
       args)
         _edit_list_section build arg_ \

--- a/setup.conf
+++ b/setup.conf
@@ -71,8 +71,24 @@ rule_3 = @basename
 # When empty, no --build-arg is passed and no TARGETARCH line appears
 # in compose.yaml's build.args, so BuildKit's auto-detection stays
 # intact. Validated via the TUI as `amd64|arm64|<empty>`.
+#
+# network: Docker build-time network mode. Only the user's own
+# Dockerfile RUN stages (apk/apt/curl/git clone) care — runtime is
+# controlled separately via [network] mode.
+#   <empty>         → Docker default (bridge + NAT via iptables)
+#   host            → build uses the host's network stack. Necessary
+#                     on environments where Docker's default bridge
+#                     NAT is unusable: stripped embedded kernels (e.g.
+#                     Jetson L4T missing iptable_raw), firewall-locked
+#                     CI runners, or hosts with `iptables: false` in
+#                     daemon.json.
+# When non-empty, setup.sh writes BUILD_NETWORK to .env and emits
+# `build.network: <value>` under each service in compose.yaml;
+# build.sh forwards `--network <value>` to the auxiliary `docker build`
+# call for test-tools.
 [build]
 target_arch =
+network =
 arg_1 = APT_MIRROR_UBUNTU=tw.archive.ubuntu.com
 arg_2 = APT_MIRROR_DEBIAN=mirror.twds.com.tw
 arg_3 = TZ=Asia/Taipei

--- a/test/integration/fresh_clone_portability_spec.bats
+++ b/test/integration/fresh_clone_portability_spec.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+#
+# Integration test: fresh clone of a consumer repo whose committed
+# setup.conf was written by a different contributor and still carries
+# that contributor's absolute host workspace path in mount_1.
+#
+# This is the exact scenario that surfaced on the NVIDIA Jetson:
+#
+#   1. Contributor A runs `./build.sh` locally, setup.sh bootstraps and
+#      writes mount_1 = /home/A/repo:/home/${USER_NAME}/work into
+#      setup.conf. Committed to git.
+#   2. Contributor B clones on a machine where /home/A/... doesn't
+#      exist. `.env` and `compose.yaml` are gitignored so a fresh
+#      clone has setup.conf (with A's path) + no derived artifacts.
+#   3. Running `./build.sh` used to silently resolve WS_PATH to A's
+#      path (compose.yaml then failed or bind-mounted an empty dir).
+#
+# The fixes from v0.9.4 (mount_1 portability / auto-migrate) and
+# v0.9.5 (build.sh drift auto-regen) combine to handle this flow
+# end-to-end. This test exercises that composition against the real
+# build.sh + setup.sh — unit tests cover each layer individually.
+#
+# Level-1 (file generation only) — docker is not invoked.
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/../unit/test_helper"
+
+  REPO_NAME="myapp_test"
+  TMP_ROOT="$(mktemp -d)"
+  REPO_DIR="${TMP_ROOT}/${REPO_NAME}"
+  mkdir -p "${REPO_DIR}/template"
+  cp -a /source/. "${REPO_DIR}/template/"
+
+  # Make the repo look like a committed consumer repo: Dockerfile is
+  # present (so init.sh's existing-repo path fires), build.sh is
+  # symlinked exactly as init.sh would have produced it.
+  touch "${REPO_DIR}/Dockerfile"
+  ln -s template/script/docker/build.sh "${REPO_DIR}/build.sh"
+
+  cd "${REPO_DIR}"
+}
+
+teardown() {
+  rm -rf "${TMP_ROOT}"
+}
+
+# _seed_stale_setup_conf <host_path>
+#
+# Drop in a setup.conf that mirrors what another contributor would
+# have committed: all the template defaults with mount_1 pointing at
+# an absolute host path that does NOT exist on the current machine.
+_seed_stale_setup_conf() {
+  local _host="$1"
+  cp "${REPO_DIR}/template/setup.conf" "${REPO_DIR}/setup.conf"
+  # shellcheck disable=SC2016  # ${USER_NAME} is a literal in setup.conf
+  sed -i "s|^mount_1 =.*|mount_1 = ${_host}:/home/\${USER_NAME}/work|" \
+    "${REPO_DIR}/setup.conf"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# Scenario: contributor B clones; setup.conf has A's absolute path;
+# no .env / compose.yaml exist yet.
+# ════════════════════════════════════════════════════════════════════
+
+@test "fresh clone with stale absolute mount_1: build.sh auto-migrates + generates local .env" {
+  _seed_stale_setup_conf "/nonexistent/contributor-a/repo"
+
+  # Sanity: fresh-clone preconditions.
+  assert [ -f "${REPO_DIR}/setup.conf" ]
+  assert [ ! -f "${REPO_DIR}/.env" ]
+  assert [ ! -f "${REPO_DIR}/compose.yaml" ]
+
+  # --dry-run so build.sh stops before invoking docker (the docker
+  # binary may be absent in the test image), but setup.sh still runs
+  # end-to-end and produces .env + compose.yaml.
+  run bash "${REPO_DIR}/build.sh" --dry-run
+  assert_success
+  # The bootstrap banner fires because compose.yaml / .env are missing.
+  assert_output --partial "First run"
+  # setup.sh warns about the stale absolute path.
+  assert_output --partial "WARNING"
+  assert_output --partial "/nonexistent/contributor-a/repo"
+
+  # mount_1 auto-migrated to the portable ${WS_PATH} form.
+  run grep '^mount_1' "${REPO_DIR}/setup.conf"
+  assert_output --partial 'mount_1 = ${WS_PATH}:/home/${USER_NAME}/work'
+
+  # .env carries THIS machine's WS_PATH, not contributor A's path.
+  assert [ -f "${REPO_DIR}/.env" ]
+  run grep '^WS_PATH=' "${REPO_DIR}/.env"
+  assert_success
+  refute_output --partial "WS_PATH=/nonexistent/contributor-a/repo"
+
+  # compose.yaml regenerated.
+  assert [ -f "${REPO_DIR}/compose.yaml" ]
+}
+
+@test "fresh clone with portable \${WS_PATH} mount_1: no warning, .env gets local path" {
+  # Same shape as above but with a repo whose committed setup.conf
+  # already uses the portable form (the happy case after v0.9.4+).
+  cp "${REPO_DIR}/template/setup.conf" "${REPO_DIR}/setup.conf"
+  # shellcheck disable=SC2016  # literal ${WS_PATH} / ${USER_NAME} intentional
+  sed -i 's|^mount_1 =.*|mount_1 = ${WS_PATH}:/home/${USER_NAME}/work|' \
+    "${REPO_DIR}/setup.conf"
+
+  run bash "${REPO_DIR}/build.sh" --dry-run
+  assert_success
+  # No stale-path warning.
+  refute_output --partial "WARNING"
+
+  # mount_1 stays as the portable form.
+  run grep '^mount_1' "${REPO_DIR}/setup.conf"
+  assert_output --partial 'mount_1 = ${WS_PATH}:/home/${USER_NAME}/work'
+
+  # .env populated with this machine's WS_PATH (non-empty, absolute).
+  run grep '^WS_PATH=' "${REPO_DIR}/.env"
+  assert_output --regexp '^WS_PATH=/[^[:space:]]+'
+}

--- a/test/unit/build_sh_spec.bats
+++ b/test/unit/build_sh_spec.bats
@@ -296,6 +296,39 @@ EOS
   refute_output --partial "TARGETARCH"
 }
 
+@test "build.sh passes --network <value> to docker build when BUILD_NETWORK set in .env" {
+  # Seed .env with BUILD_NETWORK. [build] network controls the docker
+  # build network mode for the auxiliary test-tools image. Required on
+  # hosts where Docker's bridge NAT can't reach the outside (e.g.
+  # Jetson L4T without iptable_raw kernel module).
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+    echo "BUILD_NETWORK=host"
+  } > "${SANDBOX}/.env"
+  : > "${SANDBOX}/setup.conf"
+  : > "${SANDBOX}/compose.yaml"
+  run bash "${SANDBOX}/build.sh" --dry-run
+  assert_success
+  assert_output --partial "--network host"
+}
+
+@test "build.sh omits --network when BUILD_NETWORK absent from .env" {
+  # No BUILD_NETWORK line → docker build uses its default network
+  # (bridge). build.sh must not pass any --network flag.
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+  : > "${SANDBOX}/setup.conf"
+  : > "${SANDBOX}/compose.yaml"
+  run bash "${SANDBOX}/build.sh" --dry-run
+  assert_success
+  refute_output --partial "--network"
+}
+
 @test "build.sh --lang zh-TW prints Chinese usage text" {
   run bash "${SANDBOX}/build.sh" --lang zh-TW --help
   assert_success

--- a/test/unit/compose_gen_spec.bats
+++ b/test/unit/compose_gen_spec.bats
@@ -292,6 +292,28 @@ teardown() {
   assert_failure
 }
 
+@test "generate_compose_yaml emits build.network line in both services when build_network set" {
+  local _extras=()
+  # Pos #22 is build_network (new).
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras \
+    "" "" "" "" "" "" "host" "host" \
+    "" "" "" "" "" "" "host"
+  # Must appear under both devel + test service build blocks.
+  run grep -cE '^      network: host$' "${COMPOSE_OUT}"
+  assert_success
+  assert_output "2"
+}
+
+@test "generate_compose_yaml omits build.network line when build_network empty" {
+  local _extras=()
+  # Default = empty → no network key under build.
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras
+  run grep -E '^      network:' "${COMPOSE_OUT}"
+  assert_failure
+}
+
 @test "generate_compose_yaml does NOT emit /dev:/dev by default (not in baseline)" {
   local _extras=()
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \

--- a/test/unit/lib_spec.bats
+++ b/test/unit/lib_spec.bats
@@ -240,6 +240,32 @@ EOF
   assert_output ""
 }
 
+@test "_dump_conf_section hides keys with empty values (using default)" {
+  # Empty `key =` means "use the Docker / template default"; surfacing
+  # it in the summary is noise. Populated keys in the same section
+  # still print.
+  local _f="${BATS_TEST_TMPDIR}/setup.conf"
+  cat > "${_f}" <<'EOF'
+[build]
+target_arch =
+network =
+arg_1 = TZ=Asia/Taipei
+[resources]
+shm_size =
+EOF
+  run bash -c "source ${LIB}; _dump_conf_section '${_f}' build"
+  assert_success
+  assert_output --partial "arg_1 = TZ=Asia/Taipei"
+  refute_output --partial "target_arch ="
+  refute_output --partial "network ="
+
+  # Section with only empty keys → empty output → caller skips the
+  # whole section header via the [[ -z ${_content} ]] check.
+  run bash -c "source ${LIB}; _dump_conf_section '${_f}' resources"
+  assert_success
+  assert_output ""
+}
+
 @test "_print_config_summary prints files, identity, all populated sections, resolved" {
   local _fp="${BATS_TEST_TMPDIR}"
   _write_sample_conf "${_fp}/setup.conf"

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -1000,6 +1000,30 @@ EOF
   assert_output "0"
 }
 
+@test "[build] network = host writes BUILD_NETWORK to .env" {
+  cp /source/setup.conf "${TEMP_DIR}/setup.conf"
+  _upsert_conf_value "${TEMP_DIR}/setup.conf" build network host
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep '^BUILD_NETWORK=' '${TEMP_DIR}/.env'
+  "
+  assert_success
+  assert_output --partial "BUILD_NETWORK=host"
+}
+
+@test "[build] network empty omits BUILD_NETWORK from .env" {
+  cp /source/setup.conf "${TEMP_DIR}/setup.conf"
+  _upsert_conf_value "${TEMP_DIR}/setup.conf" build network ""
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -c '^BUILD_NETWORK=' '${TEMP_DIR}/.env'
+  "
+  assert_failure
+  assert_output "0"
+}
+
 # ════════════════════════════════════════════════════════════════════
 # _get_conf_list_sorted skips empty values
 # ════════════════════════════════════════════════════════════════════

--- a/test/unit/tui_spec.bats
+++ b/test/unit/tui_spec.bats
@@ -224,6 +224,32 @@ teardown() {
 }
 
 # ════════════════════════════════════════════════════════════════════
+# _validate_build_network
+# ════════════════════════════════════════════════════════════════════
+
+@test "_validate_build_network accepts empty (docker default)" {
+  _validate_build_network ""
+}
+
+@test "_validate_build_network accepts docker-known network modes" {
+  _validate_build_network host
+  _validate_build_network bridge
+  _validate_build_network none
+  _validate_build_network default
+}
+
+@test "_validate_build_network rejects unknown values" {
+  run _validate_build_network "HOST"   # case-sensitive
+  [ "${status}" -ne 0 ]
+  run _validate_build_network "container:foo"  # network aliases not supported
+  [ "${status}" -ne 0 ]
+  run _validate_build_network "my-custom-net"
+  [ "${status}" -ne 0 ]
+  run _validate_build_network "foo"
+  [ "${status}" -ne 0 ]
+}
+
+# ════════════════════════════════════════════════════════════════════
 # _warn_if_lang_rejected — TUI msgbox when --lang fell back to "en"
 # ════════════════════════════════════════════════════════════════════
 #


### PR DESCRIPTION
## Summary

Two related changes aimed at making the template robust across hostile build environments (Jetson L4T, corporate firewalls, hosts with `iptables: false`):

1. **`[build] network` setup.conf key** — lets the user force the docker build-time network mode (typically `host`) when the host's bridge NAT doesn't work.
2. **`fresh_clone_portability_spec.bats`** — end-to-end integration test covering the exact scenario that broke on the Jetson (fresh clone of a repo whose committed `setup.conf` was written by another contributor).

Drive-by: `_dump_conf_section` now filters empty-valued keys so the config summary doesn't include noise like `shm_size =` (keys that mean "use the default").

## Motivation

On the NVIDIA Jetson `./build.sh` kept failing with `apk add` DNS errors even after all v0.9.x fixes landed. Root cause: the Jetson's L4T kernel is missing `iptable_raw` so Docker can't manage iptables; `iptables: false` in `daemon.json` is the mandatory workaround, which in turn breaks bridge NAT, which breaks DNS for the auxiliary `docker build` of `test-tools`. The only fix that works on that machine is `docker build --network=host`.

This PR makes that opt-in, per-repo, via the same `setup.conf` flow as other settings. Users on a broken kernel write:

```ini
[build]
network = host
```

Everything downstream (`.env`, `compose.yaml`, `build.sh`'s docker invocations) picks it up.

## Changes

### `setup.conf` + threading
- `setup.conf`: new `[build] network =` scalar with doc block explaining when to set it.
- `setup.sh`: reads the key → passes through `write_env` (writes `BUILD_NETWORK=<value>` to `.env` only when non-empty) and `generate_compose_yaml` (emits `network: <value>` under `build:` in both `devel` and `test` services).
- `build.sh`: when `BUILD_NETWORK` is set in env, adds `--network <value>` to the auxiliary `docker build test-tools:local` invocation.

### TUI
- `setup_tui.sh`: new `[build] Build network` menu entry + 4-language prompt + default-display fallback.
- `_tui_conf.sh`: new `_validate_build_network` (accepts empty / `host` / `bridge` / `none` / `default`).

### `_dump_conf_section` filter (drive-by)
- Keys with empty values (`target_arch =`, `network =`, `shm_size =`, …) no longer appear in `_print_config_summary`. They mean "use the default" and were just noise.
- Sections whose every key is empty collapse to nothing (existing `[[ -z ${_content} ]] && continue` in the caller does the skip).

### Integration test
- New `test/integration/fresh_clone_portability_spec.bats` simulates:
  - fresh clone with a **stale absolute** `mount_1` → `build.sh --dry-run` auto-migrates to `${WS_PATH}` form, WS_PATH in `.env` is local, WARNING surfaces
  - fresh clone with the **portable `${WS_PATH}`** form → no warning, per-machine detection works

## Tests (+12, 531 → 543)

| Spec | Delta |
|------|-------|
| `setup_spec.bats` | +2 (BUILD_NETWORK write / omit) |
| `compose_gen_spec.bats` | +2 (build.network emit / omit) |
| `build_sh_spec.bats` | +2 (--network forward / omit) |
| `tui_spec.bats` | +3 (`_validate_build_network`) |
| `lib_spec.bats` | +1 (`_dump_conf_section` empty-value filter) |
| `fresh_clone_portability_spec.bats` | +2 (new integration file) |

## Test plan

- [x] `make -f Makefile.ci test` — 543/543 green
- [x] `make -f Makefile.ci lint` — shellcheck clean
- [ ] CI `test` passes
- [ ] After merge: tag v0.9.6, upgrade ros1_bridge, verify on the Jetson by setting `[build] network = host` in its `setup.conf` and `./build.sh` succeeding without manual `--network=host`