### PR TITLE
feat(cli): full i18n for build.sh / run.sh / exec.sh / stop.sh

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Full i18n coverage for `build.sh` / `run.sh` / `exec.sh` / `stop.sh`**.
+  Previously only `usage()` (help text) honoured `--lang` / `SETUP_LANG`;
+  runtime log lines (`First run — bootstrapping`, `regenerating .env /
+  compose.yaml`, `ERROR: setup did not produce .env`, `Container is
+  already running`, `is not running`, `No instances found`, ...) were
+  hardcoded English regardless of language. Each script now ships a
+  local `_msg()` translation table covering `en` / `zh-TW` / `zh-CN` /
+  `ja`, matching the existing `setup.sh` pattern. English remains the
+  default when no flag / env var is set, so existing tooling and CI
+  output are unchanged.
+
+### Added
+- **`test/unit/exec_sh_spec.bats`** (18 tests) and
+  **`test/unit/stop_sh_spec.bats`** (17 tests): new unit specs
+  covering argument parsing, the container-running precheck hints in
+  `exec.sh`, the `--all` / `--instance` branches in `stop.sh`, all
+  four languages of usage text, runtime log-line i18n, and the
+  fallback `_detect_lang` branches (`LANG=zh_TW.UTF-8` etc. when
+  `template/` is absent).
+- Log-line i18n regression tests in `test/unit/build_sh_spec.bats`
+  (+7) and `test/unit/run_sh_spec.bats` (+6) assert that `--lang
+  <code>` actually translates the runtime logs (bootstrap, drift-regen,
+  err_no_env, already-running), not just `--help`.
+
 ## [v0.9.6] - 2026-04-23
 
 ### Added

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **543 tests** total (508 unit + 35 integration).
+Template self-tests: **590 tests** total (555 unit + 35 integration).
 
 ## Test Files
 
@@ -92,7 +92,7 @@ a canned response; exercised with `TUI_STUB_RESPONSE` / `TUI_STUB_EXIT`.
 | `_tui_checklist` (passes `--separate-output`) | 1 |
 | `_tui_msgbox` / `_tui_yesno` (correct flags, propagates exit code) | 2 |
 
-### test/unit/build_sh_spec.bats (25)
+### test/unit/build_sh_spec.bats (32)
 
 Unit tests for `build.sh` argument handling and control flow. Uses a
 sandbox tree mirroring the expected layout (build.sh + `template/` subtree
@@ -106,10 +106,12 @@ all three are present, bootstrap staying non-interactive (setup.sh
 direct, not `setup_tui.sh`), defensive guard when setup produces no
 `.env`, TARGETARCH build-arg forwarding, `--no-cache`, `--clean-tools`,
 positional `TARGET`, `--lang` argument validation, fallback
-`_detect_lang` branches (zh_TW/zh_CN/ja), and real (non-dry-run)
-docker build invocation.
+`_detect_lang` branches (zh_TW/zh_CN/ja), real (non-dry-run) docker
+build invocation, and **runtime log-line i18n** (bootstrap /
+drift-regen / err_no_env messages translate in all four languages via
+the local `_msg()` table; English remains the default).
 
-### test/unit/run_sh_spec.bats (24)
+### test/unit/run_sh_spec.bats (30)
 
 Unit tests for `run.sh`. Mirrors the build_sh_spec.bats harness;
 `docker ps` reads from a controllable stub file so tests can simulate
@@ -121,7 +123,38 @@ bootstrap staying non-interactive (setup.sh, not TUI), defensive guard
 when setup produces no `.env`, `--detach`, devel vs non-devel TARGET
 routing, `--instance`, already-running guard, Wayland xhost path,
 `--lang` / `--instance` argument validation, fallback `_detect_lang`
-branches.
+branches, and **runtime log-line i18n** (bootstrap + already-running
+error translate in all four languages via the local `_msg()` table).
+
+### test/unit/exec_sh_spec.bats (18)
+
+Unit tests for `exec.sh` argument parsing, the container-running
+precheck, and i18n. Sandbox tree mirrors build_sh_spec.bats;
+`docker ps` reads from a controllable stub file so tests can toggle
+"container running" state without a real docker daemon. `.env` is
+pre-seeded so `_load_env` / `_compute_project_name` succeed without a
+bootstrap step.
+
+Covers: `--help` (en/zh/zh-CN/ja), `--lang` / `--target` / `--instance`
+value validation, English-default not-running error, Chinese /
+Simplified Chinese / Japanese not-running error text, instance-specific
+vs default start hints, `--dry-run` bypassing the guard, compose exec
+routing when container is running, and fallback `_detect_lang`
+branches when `template/` is absent.
+
+### test/unit/stop_sh_spec.bats (16)
+
+Unit tests for `stop.sh` argument parsing, the `--all` multi-instance
+teardown, and i18n. `docker ps -a` output is PATH-shimmed via
+`${DOCKER_PS_A_FILE}` so tests can seed the project list for the `--all`
+branch.
+
+Covers: `--help` (en/zh/zh-CN/ja), `--lang` / `--instance` value
+validation, default teardown via `docker compose down`, named-instance
+suffix in project name, `--all` no-instances English message,
+Chinese / Simplified Chinese / Japanese translations of the
+no-instances message, `--all` multi-project teardown loop, and
+fallback `_detect_lang` branches.
 
 ### test/unit/compose_gen_spec.bats (35)
 

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -23,6 +23,28 @@ else
   _LANG="${SETUP_LANG:-$(_detect_lang)}"
 fi
 
+_msg() {
+  local _key="${1:?}"
+  case "${_LANG}:${_key}" in
+    zh-TW:bootstrap_info)  echo "[build] 資訊：首次執行 — 初始化中..." ;;
+    zh-CN:bootstrap_info)  echo "[build] 信息：首次运行 — 初始化中..." ;;
+    ja:bootstrap_info)     echo "[build] 情報: 初回実行 — ブートストラップ中..." ;;
+    *:bootstrap_info)      echo "[build] INFO: First run — bootstrapping..." ;;
+    zh-TW:drift_regen)     echo "[build] 重新產生 .env / compose.yaml（setup.conf 已變更）" ;;
+    zh-CN:drift_regen)     echo "[build] 重新生成 .env / compose.yaml（setup.conf 已变更）" ;;
+    ja:drift_regen)        echo "[build] .env / compose.yaml を再生成中（setup.conf が変更されました）" ;;
+    *:drift_regen)         echo "[build] regenerating .env / compose.yaml (setup.conf drifted)" ;;
+    zh-TW:err_no_env)      echo "[build] 錯誤：setup 未產生 .env。" ;;
+    zh-CN:err_no_env)      echo "[build] 错误：setup 未生成 .env。" ;;
+    ja:err_no_env)         echo "[build] エラー: setup が .env を生成しませんでした。" ;;
+    *:err_no_env)          echo "[build] ERROR: setup did not produce .env." ;;
+    zh-TW:err_rerun_setup) echo "[build] 請改以 './build.sh --setup' 重新執行以開啟編輯器。" ;;
+    zh-CN:err_rerun_setup) echo "[build] 请改以 './build.sh --setup' 重新运行以打开编辑器。" ;;
+    ja:err_rerun_setup)    echo "[build] './build.sh --setup' で再実行してエディタを開いてください。" ;;
+    *:err_rerun_setup)     echo "[build] Re-run with './build.sh --setup' to open the editor." ;;
+  esac
+}
+
 usage() {
   case "${_LANG}" in
     zh-TW)
@@ -176,7 +198,7 @@ main() {
   elif [[ ! -f "${FILE_PATH}/.env" ]] \
       || [[ ! -f "${FILE_PATH}/setup.conf" ]] \
       || [[ ! -f "${FILE_PATH}/compose.yaml" ]]; then
-    printf "[build] INFO: First run — bootstrapping...\n"
+    printf "%s\n" "$(_msg bootstrap_info)"
     "${_setup}" --base-path "${FILE_PATH}" --lang "${_LANG}"
   else
     # shellcheck disable=SC1090
@@ -188,7 +210,7 @@ main() {
     # re-running setup.sh is always safe and saves the user from having
     # to remember `./build.sh --setup`.
     if ! _check_setup_drift "${FILE_PATH}"; then
-      printf "[build] regenerating .env / compose.yaml (setup.conf drifted)\n"
+      printf "%s\n" "$(_msg drift_regen)"
       "${_setup}" --base-path "${FILE_PATH}" --lang "${_LANG}"
     fi
   fi
@@ -197,8 +219,8 @@ main() {
   # (user cancelled an interactive TUI, setup.sh crashed, ...), surface
   # a useful error instead of letting _load_env fail on a missing file.
   if [[ ! -f "${FILE_PATH}/.env" ]]; then
-    printf "[build] ERROR: setup did not produce .env.\n" >&2
-    printf "[build] Re-run with './build.sh --setup' to open the editor.\n" >&2
+    printf "%s\n" "$(_msg err_no_env)" >&2
+    printf "%s\n" "$(_msg err_rerun_setup)" >&2
     exit 1
   fi
 

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -21,6 +21,24 @@ else
   _LANG="${SETUP_LANG:-$(_detect_lang)}"
 fi
 
+_msg() {
+  local _key="${1:?}"
+  case "${_LANG}:${_key}" in
+    zh-TW:err_not_running)     echo "[exec] 錯誤：容器 '%s' 未在執行中。" ;;
+    zh-CN:err_not_running)     echo "[exec] 错误：容器 '%s' 未在运行中。" ;;
+    ja:err_not_running)        echo "[exec] エラー: コンテナ '%s' は実行されていません。" ;;
+    *:err_not_running)         echo "[exec] ERROR: Container '%s' is not running." ;;
+    zh-TW:hint_start_instance) echo "[exec] 請先以 './run.sh --instance %s' 啟動。" ;;
+    zh-CN:hint_start_instance) echo "[exec] 请先以 './run.sh --instance %s' 启动。" ;;
+    ja:hint_start_instance)    echo "[exec] まず './run.sh --instance %s' で起動してください。" ;;
+    *:hint_start_instance)     echo "[exec] Start it first with './run.sh --instance %s'." ;;
+    zh-TW:hint_start_default)  echo "[exec] 請先以 './run.sh' 啟動（或使用 './run.sh --instance NAME' 啟動並行實例）。" ;;
+    zh-CN:hint_start_default)  echo "[exec] 请先以 './run.sh' 启动（或使用 './run.sh --instance NAME' 启动并行实例）。" ;;
+    ja:hint_start_default)     echo "[exec] まず './run.sh' で起動してください（または './run.sh --instance NAME' で並列インスタンスを起動）。" ;;
+    *:hint_start_default)      echo "[exec] Start it first with './run.sh' (or use './run.sh --instance NAME' for a parallel one)." ;;
+  esac
+}
+
 usage() {
   case "${_LANG}" in
     zh-TW)
@@ -160,13 +178,13 @@ main() {
   local _container_name="${IMAGE_NAME}${INSTANCE_SUFFIX}"
   if [[ "${DRY_RUN}" != true ]] \
       && ! docker ps --format '{{.Names}}' | grep -qx "${_container_name}"; then
-    printf "[exec] ERROR: Container '%s' is not running.\n" \
-      "${_container_name}" >&2
+    # shellcheck disable=SC2059
+    printf "$(_msg err_not_running)\n" "${_container_name}" >&2
     if [[ -n "${INSTANCE}" ]]; then
-      printf "[exec] Start it first with './run.sh --instance %s'.\n" \
-        "${INSTANCE}" >&2
+      # shellcheck disable=SC2059
+      printf "$(_msg hint_start_instance)\n" "${INSTANCE}" >&2
     else
-      printf "[exec] Start it first with './run.sh' (or use './run.sh --instance NAME' for a parallel one).\n" >&2
+      printf "%s\n" "$(_msg hint_start_default)" >&2
     fi
     exit 1
   fi

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -21,6 +21,40 @@ else
   _LANG="${SETUP_LANG:-$(_detect_lang)}"
 fi
 
+_msg() {
+  local _key="${1:?}"
+  case "${_LANG}:${_key}" in
+    zh-TW:bootstrap_info)     echo "[run] 資訊：首次執行 — 初始化中..." ;;
+    zh-CN:bootstrap_info)     echo "[run] 信息：首次运行 — 初始化中..." ;;
+    ja:bootstrap_info)        echo "[run] 情報: 初回実行 — ブートストラップ中..." ;;
+    *:bootstrap_info)         echo "[run] INFO: First run — bootstrapping..." ;;
+    zh-TW:drift_regen)        echo "[run] 重新產生 .env / compose.yaml（setup.conf 已變更）" ;;
+    zh-CN:drift_regen)        echo "[run] 重新生成 .env / compose.yaml（setup.conf 已变更）" ;;
+    ja:drift_regen)           echo "[run] .env / compose.yaml を再生成中（setup.conf が変更されました）" ;;
+    *:drift_regen)            echo "[run] regenerating .env / compose.yaml (setup.conf drifted)" ;;
+    zh-TW:err_no_env)         echo "[run] 錯誤：setup 未產生 .env。" ;;
+    zh-CN:err_no_env)         echo "[run] 错误：setup 未生成 .env。" ;;
+    ja:err_no_env)            echo "[run] エラー: setup が .env を生成しませんでした。" ;;
+    *:err_no_env)             echo "[run] ERROR: setup did not produce .env." ;;
+    zh-TW:err_rerun_setup)    echo "[run] 請改以 './run.sh --setup' 重新執行以開啟編輯器。" ;;
+    zh-CN:err_rerun_setup)    echo "[run] 请改以 './run.sh --setup' 重新运行以打开编辑器。" ;;
+    ja:err_rerun_setup)       echo "[run] './run.sh --setup' で再実行してエディタを開いてください。" ;;
+    *:err_rerun_setup)        echo "[run] Re-run with './run.sh --setup' to open the editor." ;;
+    zh-TW:err_already_running) echo "[run] 錯誤：容器 '%s' 已在執行中。" ;;
+    zh-CN:err_already_running) echo "[run] 错误：容器 '%s' 已在运行中。" ;;
+    ja:err_already_running)   echo "[run] エラー: コンテナ '%s' はすでに実行中です。" ;;
+    *:err_already_running)    echo "[run] ERROR: Container '%s' is already running." ;;
+    zh-TW:err_stop_hint)      echo "[run] 請以 './stop.sh%s' 停止" ;;
+    zh-CN:err_stop_hint)      echo "[run] 请以 './stop.sh%s' 停止" ;;
+    ja:err_stop_hint)         echo "[run] './stop.sh%s' で停止してください" ;;
+    *:err_stop_hint)          echo "[run] Either stop it with './stop.sh%s'" ;;
+    zh-TW:err_parallel_hint)  echo "[run] 或使用 './run.sh --instance NAME' 啟動並行實例。" ;;
+    zh-CN:err_parallel_hint)  echo "[run] 或使用 './run.sh --instance NAME' 启动并行实例。" ;;
+    ja:err_parallel_hint)     echo "[run] または './run.sh --instance NAME' で並列インスタンスを起動してください。" ;;
+    *:err_parallel_hint)      echo "[run] or start a parallel instance with './run.sh --instance NAME'." ;;
+  esac
+}
+
 usage() {
   case "${_LANG}" in
     zh-TW)
@@ -178,22 +212,22 @@ main() {
   elif [[ ! -f "${FILE_PATH}/.env" ]] \
       || [[ ! -f "${FILE_PATH}/setup.conf" ]] \
       || [[ ! -f "${FILE_PATH}/compose.yaml" ]]; then
-    printf "[run] INFO: First run — bootstrapping...\n"
+    printf "%s\n" "$(_msg bootstrap_info)"
     "${_setup}" --base-path "${FILE_PATH}" --lang "${_LANG}"
   else
     # shellcheck disable=SC1090
     source "${_setup}"
     # Drift → auto-regen (see build.sh for the full rationale).
     if ! _check_setup_drift "${FILE_PATH}"; then
-      printf "[run] regenerating .env / compose.yaml (setup.conf drifted)\n"
+      printf "%s\n" "$(_msg drift_regen)"
       "${_setup}" --base-path "${FILE_PATH}" --lang "${_LANG}"
     fi
   fi
 
   # Defensive: bootstrap must leave .env in place. See build.sh.
   if [[ ! -f "${FILE_PATH}/.env" ]]; then
-    printf "[run] ERROR: setup did not produce .env.\n" >&2
-    printf "[run] Re-run with './run.sh --setup' to open the editor.\n" >&2
+    printf "%s\n" "$(_msg err_no_env)" >&2
+    printf "%s\n" "$(_msg err_rerun_setup)" >&2
     exit 1
   fi
 
@@ -222,11 +256,12 @@ main() {
   if [[ "${DETACH}" != true && "${TARGET}" == "devel" \
       && "${DRY_RUN}" != true ]]; then
     if docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
-      printf "[run] ERROR: Container '%s' is already running.\n" \
-        "${CONTAINER_NAME}" >&2
-      printf "[run] Either stop it with './stop.sh%s'\n" \
+      # shellcheck disable=SC2059
+      printf "$(_msg err_already_running)\n" "${CONTAINER_NAME}" >&2
+      # shellcheck disable=SC2059
+      printf "$(_msg err_stop_hint)\n" \
         "$([[ -n "${INSTANCE}" ]] && printf ' --instance %s' "${INSTANCE}")" >&2
-      printf "[run] or start a parallel instance with './run.sh --instance NAME'.\n" >&2
+      printf "%s\n" "$(_msg err_parallel_hint)" >&2
       exit 1
     fi
   fi

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -21,6 +21,16 @@ else
   _LANG="${SETUP_LANG:-$(_detect_lang)}"
 fi
 
+_msg() {
+  local _key="${1:?}"
+  case "${_LANG}:${_key}" in
+    zh-TW:no_instances) echo "[stop] 未找到 %s 的執行中實例" ;;
+    zh-CN:no_instances) echo "[stop] 未找到 %s 的运行中实例" ;;
+    ja:no_instances)    echo "[stop] %s のインスタンスが見つかりません" ;;
+    *:no_instances)     echo "[stop] No instances found for %s" ;;
+  esac
+}
+
 usage() {
   case "${_LANG}" in
     zh-TW)
@@ -143,7 +153,8 @@ main() {
         | sort -u | grep -E "^${_prefix}(\$|-)" || true
     )
     if [[ ${#_projects[@]} -eq 0 ]]; then
-      printf "[stop] No instances found for %s\n" "${IMAGE_NAME}" >&2
+      # shellcheck disable=SC2059
+      printf "$(_msg no_instances)\n" "${IMAGE_NAME}" >&2
       exit 0
     fi
     local _proj _suffix

--- a/test/unit/build_sh_spec.bats
+++ b/test/unit/build_sh_spec.bats
@@ -399,3 +399,98 @@ EOS
   assert_output --partial "docker build"
   assert_output --partial "-t test-tools:local"
 }
+
+# ── i18n log lines (bootstrap / drift / err_no_env) ────────────────────────
+# These exercise _msg() for every language on every log line that build.sh
+# emits directly. Usage-text coverage lives above; these assert that the
+# *runtime* messages (not just --help) translate end-to-end.
+
+@test "build.sh --lang zh-TW prints Chinese bootstrap log" {
+  run bash "${SANDBOX}/build.sh" --lang zh-TW --dry-run
+  assert_success
+  assert_output --partial "首次執行"
+}
+
+@test "build.sh --lang zh-CN prints Simplified Chinese bootstrap log" {
+  run bash "${SANDBOX}/build.sh" --lang zh-CN --dry-run
+  assert_success
+  assert_output --partial "首次运行"
+}
+
+@test "build.sh --lang ja prints Japanese bootstrap log" {
+  run bash "${SANDBOX}/build.sh" --lang ja --dry-run
+  assert_success
+  assert_output --partial "初回実行"
+}
+
+@test "build.sh default bootstrap log is English" {
+  run bash "${SANDBOX}/build.sh" --dry-run
+  assert_success
+  assert_output --partial "First run"
+}
+
+@test "build.sh --lang zh-TW prints Chinese drift-regen log" {
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+  : > "${SANDBOX}/setup.conf"
+  : > "${SANDBOX}/compose.yaml"
+  cat > "${SANDBOX}/template/script/docker/setup.sh" <<'EOS'
+#!/usr/bin/env bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  _base=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --base-path) _base="$2"; shift 2 ;;
+      --lang)      shift 2 ;;
+      *)           shift ;;
+    esac
+  done
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${_base}/.env"
+  echo "# mock compose" > "${_base}/compose.yaml"
+else
+  _check_setup_drift() { return 1; }
+fi
+EOS
+  chmod +x "${SANDBOX}/template/script/docker/setup.sh"
+  run bash "${SANDBOX}/build.sh" --lang zh-TW --dry-run
+  assert_success
+  assert_output --partial "重新產生"
+}
+
+@test "build.sh --lang zh-TW prints Chinese err_no_env on failed bootstrap" {
+  cat > "${SANDBOX}/template/script/docker/setup.sh" <<'EOS'
+#!/usr/bin/env bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  exit 0
+else
+  _check_setup_drift() { :; }
+fi
+EOS
+  chmod +x "${SANDBOX}/template/script/docker/setup.sh"
+  run bash "${SANDBOX}/build.sh" --lang zh-TW --dry-run
+  assert_failure
+  assert_output --partial "錯誤"
+}
+
+@test "build.sh --lang ja prints Japanese err_no_env on failed bootstrap" {
+  cat > "${SANDBOX}/template/script/docker/setup.sh" <<'EOS'
+#!/usr/bin/env bash
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  exit 0
+else
+  _check_setup_drift() { :; }
+fi
+EOS
+  chmod +x "${SANDBOX}/template/script/docker/setup.sh"
+  run bash "${SANDBOX}/build.sh" --lang ja --dry-run
+  assert_failure
+  assert_output --partial "エラー"
+}

--- a/test/unit/exec_sh_spec.bats
+++ b/test/unit/exec_sh_spec.bats
@@ -1,0 +1,179 @@
+#!/usr/bin/env bats
+#
+# Unit tests for script/docker/exec.sh argument handling, i18n log lines,
+# and the "container not running" guard. Mirrors the sandbox/mock strategy
+# from build_sh_spec.bats / run_sh_spec.bats: a sandbox tree with symlinked
+# exec.sh, real _lib.sh / i18n.sh, and a PATH-shimmed `docker` stub whose
+# `docker ps` output is controlled by ${DOCKER_PS_FILE} so individual tests
+# can toggle "container running" state.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+
+  # shellcheck disable=SC2154
+  TEMP_DIR="$(mktemp -d)"
+  export TEMP_DIR
+
+  SANDBOX="${TEMP_DIR}/repo"
+  mkdir -p "${SANDBOX}/template/script/docker"
+
+  cp /source/script/docker/_lib.sh  "${SANDBOX}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh  "${SANDBOX}/template/script/docker/i18n.sh"
+  ln -s /source/script/docker/exec.sh "${SANDBOX}/exec.sh"
+
+  # Seed .env so _load_env / _compute_project_name succeed without bootstrap.
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+
+  BIN_DIR="${TEMP_DIR}/bin"
+  mkdir -p "${BIN_DIR}"
+
+  DOCKER_PS_FILE="${TEMP_DIR}/docker_ps.out"
+  export DOCKER_PS_FILE
+  : > "${DOCKER_PS_FILE}"
+
+  cat > "${BIN_DIR}/docker" <<'EOS'
+#!/usr/bin/env bash
+if [[ "$1" == "ps" ]]; then
+  cat "${DOCKER_PS_FILE}"
+  exit 0
+fi
+printf 'docker'
+printf ' %q' "$@"
+printf '\n'
+EOS
+  chmod +x "${BIN_DIR}/docker"
+
+  export PATH="${BIN_DIR}:${PATH}"
+}
+
+teardown() {
+  rm -rf "${TEMP_DIR}"
+}
+
+@test "exec.sh --help exits 0 and shows usage" {
+  run bash "${SANDBOX}/exec.sh" --help
+  assert_success
+  assert_output --partial "exec.sh"
+}
+
+@test "exec.sh --lang zh-TW prints Chinese usage text" {
+  run bash "${SANDBOX}/exec.sh" --lang zh-TW --help
+  assert_success
+  assert_output --partial "用法"
+}
+
+@test "exec.sh --lang zh-CN prints Simplified Chinese usage text" {
+  run bash "${SANDBOX}/exec.sh" --lang zh-CN --help
+  assert_success
+  assert_output --partial "用法"
+}
+
+@test "exec.sh --lang ja prints Japanese usage text" {
+  run bash "${SANDBOX}/exec.sh" --lang ja --help
+  assert_success
+  assert_output --partial "使用法"
+}
+
+@test "exec.sh --lang requires a value" {
+  run bash "${SANDBOX}/exec.sh" --lang
+  assert_failure
+}
+
+@test "exec.sh --target requires a value" {
+  run bash "${SANDBOX}/exec.sh" --target
+  assert_failure
+}
+
+@test "exec.sh --instance requires a value" {
+  run bash "${SANDBOX}/exec.sh" --instance
+  assert_failure
+}
+
+@test "exec.sh fails when container not running (default English)" {
+  run bash "${SANDBOX}/exec.sh"
+  assert_failure
+  assert_output --partial "is not running"
+}
+
+@test "exec.sh --lang zh-TW prints Chinese not-running error" {
+  run bash "${SANDBOX}/exec.sh" --lang zh-TW
+  assert_failure
+  assert_output --partial "未在執行中"
+}
+
+@test "exec.sh --lang zh-CN prints Simplified Chinese not-running error" {
+  run bash "${SANDBOX}/exec.sh" --lang zh-CN
+  assert_failure
+  assert_output --partial "未在运行中"
+}
+
+@test "exec.sh --lang ja prints Japanese not-running error" {
+  run bash "${SANDBOX}/exec.sh" --lang ja
+  assert_failure
+  assert_output --partial "実行されていません"
+}
+
+@test "exec.sh prints instance-specific start hint with --instance" {
+  run bash "${SANDBOX}/exec.sh" --instance foo
+  assert_failure
+  assert_output --partial "./run.sh --instance foo"
+}
+
+@test "exec.sh --lang zh-TW instance-specific hint translates" {
+  run bash "${SANDBOX}/exec.sh" --lang zh-TW --instance foo
+  assert_failure
+  assert_output --partial "請先以"
+  assert_output --partial "./run.sh --instance foo"
+}
+
+@test "exec.sh --dry-run bypasses container-running check" {
+  # No container running, but --dry-run should short-circuit the guard
+  # and fall through to _compose_project exec (which the docker stub logs).
+  run bash "${SANDBOX}/exec.sh" --dry-run
+  assert_success
+}
+
+@test "exec.sh runs docker compose exec when container is running" {
+  echo "mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run
+  assert_success
+  assert_output --partial "exec"
+}
+
+# ── Fallback _detect_lang (no template/ tree) ──────────────────────────────
+
+@test "exec.sh fallback _detect_lang maps zh_TW.UTF-8 to zh-TW" {
+  local _tmp
+  _tmp="$(mktemp -d)"
+  ln -s /source/script/docker/exec.sh "${_tmp}/exec.sh"
+  LANG=zh_TW.UTF-8 run bash "${_tmp}/exec.sh" -h
+  assert_success
+  assert_output --partial "用法"
+  rm -rf "${_tmp}"
+}
+
+@test "exec.sh fallback _detect_lang maps zh_CN.UTF-8 to zh-CN" {
+  local _tmp
+  _tmp="$(mktemp -d)"
+  ln -s /source/script/docker/exec.sh "${_tmp}/exec.sh"
+  LANG=zh_CN.UTF-8 run bash "${_tmp}/exec.sh" -h
+  assert_success
+  assert_output --partial "用法"
+  rm -rf "${_tmp}"
+}
+
+@test "exec.sh fallback _detect_lang maps ja_JP.UTF-8 to ja" {
+  local _tmp
+  _tmp="$(mktemp -d)"
+  ln -s /source/script/docker/exec.sh "${_tmp}/exec.sh"
+  LANG=ja_JP.UTF-8 run bash "${_tmp}/exec.sh" -h
+  assert_success
+  assert_output --partial "使用法"
+  rm -rf "${_tmp}"
+}

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -330,3 +330,55 @@ EOS
   assert_output --partial "使用法"
   rm -rf "${_tmp}"
 }
+
+# ── i18n log lines (bootstrap / drift / err_no_env / already-running) ──────
+# Exercises _msg() across all four languages on the log lines run.sh emits
+# itself. Usage-text coverage is above.
+
+@test "run.sh --lang zh-TW prints Chinese bootstrap log" {
+  run bash "${SANDBOX}/run.sh" --lang zh-TW --dry-run
+  assert_success
+  assert_output --partial "首次執行"
+}
+
+@test "run.sh --lang zh-CN prints Simplified Chinese bootstrap log" {
+  run bash "${SANDBOX}/run.sh" --lang zh-CN --dry-run
+  assert_success
+  assert_output --partial "首次运行"
+}
+
+@test "run.sh --lang ja prints Japanese bootstrap log" {
+  run bash "${SANDBOX}/run.sh" --lang ja --dry-run
+  assert_success
+  assert_output --partial "初回実行"
+}
+
+@test "run.sh default bootstrap log is English" {
+  run bash "${SANDBOX}/run.sh" --dry-run
+  assert_success
+  assert_output --partial "First run"
+}
+
+@test "run.sh --lang zh-TW prints Chinese already-running error" {
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+  echo "mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/run.sh" --lang zh-TW
+  assert_failure
+  assert_output --partial "已在執行中"
+}
+
+@test "run.sh --lang ja prints Japanese already-running error" {
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+  echo "mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/run.sh" --lang ja
+  assert_failure
+  assert_output --partial "すでに実行中"
+}

--- a/test/unit/stop_sh_spec.bats
+++ b/test/unit/stop_sh_spec.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+#
+# Unit tests for script/docker/stop.sh argument handling and i18n log lines.
+# Sandbox tree mirrors build_sh_spec.bats. A PATH-shimmed `docker` stub
+# lets tests control `docker ps -a` output so the --all branch can be
+# exercised without a real docker daemon.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+
+  # shellcheck disable=SC2154
+  TEMP_DIR="$(mktemp -d)"
+  export TEMP_DIR
+
+  SANDBOX="${TEMP_DIR}/repo"
+  mkdir -p "${SANDBOX}/template/script/docker"
+
+  cp /source/script/docker/_lib.sh  "${SANDBOX}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh  "${SANDBOX}/template/script/docker/i18n.sh"
+  ln -s /source/script/docker/stop.sh "${SANDBOX}/stop.sh"
+
+  # Seed .env so _load_env succeeds.
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+
+  BIN_DIR="${TEMP_DIR}/bin"
+  mkdir -p "${BIN_DIR}"
+
+  DOCKER_PS_A_FILE="${TEMP_DIR}/docker_ps_a.out"
+  export DOCKER_PS_A_FILE
+  : > "${DOCKER_PS_A_FILE}"
+
+  cat > "${BIN_DIR}/docker" <<'EOS'
+#!/usr/bin/env bash
+if [[ "$1" == "ps" ]]; then
+  cat "${DOCKER_PS_A_FILE}"
+  exit 0
+fi
+printf 'docker'
+printf ' %q' "$@"
+printf '\n'
+EOS
+  chmod +x "${BIN_DIR}/docker"
+
+  export PATH="${BIN_DIR}:${PATH}"
+}
+
+teardown() {
+  rm -rf "${TEMP_DIR}"
+}
+
+@test "stop.sh --help exits 0 and shows usage" {
+  run bash "${SANDBOX}/stop.sh" --help
+  assert_success
+  assert_output --partial "stop.sh"
+}
+
+@test "stop.sh --lang zh-TW prints Chinese usage text" {
+  run bash "${SANDBOX}/stop.sh" --lang zh-TW --help
+  assert_success
+  assert_output --partial "用法"
+}
+
+@test "stop.sh --lang zh-CN prints Simplified Chinese usage text" {
+  run bash "${SANDBOX}/stop.sh" --lang zh-CN --help
+  assert_success
+  assert_output --partial "用法"
+}
+
+@test "stop.sh --lang ja prints Japanese usage text" {
+  run bash "${SANDBOX}/stop.sh" --lang ja --help
+  assert_success
+  assert_output --partial "使用法"
+}
+
+@test "stop.sh --lang requires a value" {
+  run bash "${SANDBOX}/stop.sh" --lang
+  assert_failure
+}
+
+@test "stop.sh --instance requires a value" {
+  run bash "${SANDBOX}/stop.sh" --instance
+  assert_failure
+}
+
+@test "stop.sh default stops default instance via docker compose down" {
+  run bash "${SANDBOX}/stop.sh" --dry-run
+  assert_success
+  assert_output --partial "down"
+}
+
+@test "stop.sh --instance foo stops named instance" {
+  run bash "${SANDBOX}/stop.sh" --dry-run --instance foo
+  assert_success
+  assert_output --partial "mockuser-mockimg-foo"
+}
+
+@test "stop.sh --all with no instances prints English no-instances message" {
+  # docker_ps_a.out is empty → mapfile builds a single-element array with
+  # an empty string. Grep filters out lines not starting with the prefix,
+  # leaving an empty list → stop.sh prints the no_instances message.
+  : > "${DOCKER_PS_A_FILE}"
+  run bash "${SANDBOX}/stop.sh" --all
+  assert_success
+  assert_output --partial "No instances found"
+}
+
+@test "stop.sh --all --lang zh-TW translates no-instances message" {
+  : > "${DOCKER_PS_A_FILE}"
+  run bash "${SANDBOX}/stop.sh" --all --lang zh-TW
+  assert_success
+  assert_output --partial "未找到"
+}
+
+@test "stop.sh --all --lang zh-CN translates no-instances message" {
+  : > "${DOCKER_PS_A_FILE}"
+  run bash "${SANDBOX}/stop.sh" --all --lang zh-CN
+  assert_success
+  assert_output --partial "未找到"
+}
+
+@test "stop.sh --all --lang ja translates no-instances message" {
+  : > "${DOCKER_PS_A_FILE}"
+  run bash "${SANDBOX}/stop.sh" --all --lang ja
+  assert_success
+  assert_output --partial "見つかりません"
+}
+
+@test "stop.sh --all with multiple projects tears down each one" {
+  {
+    echo "mockuser-mockimg"
+    echo "mockuser-mockimg-foo"
+    echo "mockuser-mockimg-bar"
+  } > "${DOCKER_PS_A_FILE}"
+  run bash "${SANDBOX}/stop.sh" --all --dry-run
+  assert_success
+  assert_output --partial "mockuser-mockimg-foo"
+  assert_output --partial "mockuser-mockimg-bar"
+}
+
+# ── Fallback _detect_lang (no template/ tree) ──────────────────────────────
+
+@test "stop.sh fallback _detect_lang maps zh_TW.UTF-8 to zh-TW" {
+  local _tmp
+  _tmp="$(mktemp -d)"
+  ln -s /source/script/docker/stop.sh "${_tmp}/stop.sh"
+  LANG=zh_TW.UTF-8 run bash "${_tmp}/stop.sh" -h
+  assert_success
+  assert_output --partial "用法"
+  rm -rf "${_tmp}"
+}
+
+@test "stop.sh fallback _detect_lang maps zh_CN.UTF-8 to zh-CN" {
+  local _tmp
+  _tmp="$(mktemp -d)"
+  ln -s /source/script/docker/stop.sh "${_tmp}/stop.sh"
+  LANG=zh_CN.UTF-8 run bash "${_tmp}/stop.sh" -h
+  assert_success
+  assert_output --partial "用法"
+  rm -rf "${_tmp}"
+}
+
+@test "stop.sh fallback _detect_lang maps ja_JP.UTF-8 to ja" {
+  local _tmp
+  _tmp="$(mktemp -d)"
+  ln -s /source/script/docker/stop.sh "${_tmp}/stop.sh"
+  LANG=ja_JP.UTF-8 run bash "${_tmp}/stop.sh" -h
+  assert_success
+  assert_output --partial "使用法"
+  rm -rf "${_tmp}"
+}


### PR DESCRIPTION
## Summary

- Completes i18n for the four CLI scripts. Previously `--lang` only
  translated `usage()` (help text); runtime log lines like
  `First run — bootstrapping...`, `regenerating .env / compose.yaml`,
  `ERROR: setup did not produce .env`, `Container '%s' is already
  running`, `is not running`, and `No instances found for %s` were
  hardcoded English regardless of the selected language. Each script
  now ships a local `_msg()` translation table covering `en`,
  `zh-TW`, `zh-CN`, `ja`, matching the existing pattern in `setup.sh`.
- English remains the default when `--lang` / `SETUP_LANG` is not
  supplied, so existing CI output and tooling is unchanged.

## Log lines translated

`build.sh`:
- `INFO: First run — bootstrapping...`
- `regenerating .env / compose.yaml (setup.conf drifted)`
- `ERROR: setup did not produce .env.`
- `Re-run with './build.sh --setup' to open the editor.`

`run.sh`:
- `INFO: First run — bootstrapping...`
- `regenerating .env / compose.yaml (setup.conf drifted)`
- `ERROR: setup did not produce .env.`
- `Re-run with './run.sh --setup' to open the editor.`
- `ERROR: Container '%s' is already running.`
- `Either stop it with './stop.sh%s'`
- `or start a parallel instance with './run.sh --instance NAME'.`

`exec.sh`:
- `ERROR: Container '%s' is not running.`
- `Start it first with './run.sh --instance %s'.`
- `Start it first with './run.sh' (or use './run.sh --instance NAME' for a parallel one).`

`stop.sh`:
- `No instances found for %s`

## Scope notes

`_print_config_summary` strings in `_lib.sh` (emitted by `build.sh` /
`run.sh` but not authored by the scripts themselves) remain English-only
and are explicitly out of scope. The `_sanitize_lang` warning in
`i18n.sh` likewise remains English-only. Both can be covered in a
follow-up once the per-script coverage proves out.

## Test plan

Baseline was 543 tests (508 unit + 35 integration). Delta:

- `test/unit/build_sh_spec.bats`: 25 -> 32 (+7) — runtime log-line
  translations (bootstrap en/zh-TW/zh-CN/ja/default, drift-regen zh-TW,
  err_no_env zh-TW + ja).
- `test/unit/run_sh_spec.bats`: 24 -> 30 (+6) — bootstrap en/zh-TW/
  zh-CN/ja/default, already-running zh-TW + ja.
- `test/unit/exec_sh_spec.bats`: new (18 tests) — help in 4 langs, arg
  validation, not-running error en + zh-TW/zh-CN/ja, instance-specific
  hint + translation, --dry-run bypass, compose-exec routing, fallback
  `_detect_lang` branches.
- `test/unit/stop_sh_spec.bats`: new (16 tests) — help in 4 langs,
  arg validation, default + --instance teardown, no-instances message
  en + zh-TW/zh-CN/ja, --all multi-project teardown, fallback
  `_detect_lang`.

New total: 590 tests (555 unit + 35 integration).

Verification:

- [x] `make -f Makefile.ci test` — 590/590 green
- [x] `shellcheck -x script/docker/{build,run,exec,stop}.sh` — clean
- [x] Manually verified `./build.sh --lang zh-TW --dry-run` prints
  Chinese bootstrap log; `./build.sh --dry-run` (no flag) prints
  English.
- [x] CHANGELOG.md `[Unreleased]` entry added under `### Changed` and
  `### Added`.
- [x] TEST.md total updated 543 -> 590 and per-file counts match.