### PR TITLE
feat(setup): expose setup.sh as root-level CLI + add --help

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   output are unchanged.
 
 ### Added
+- **Root-level `setup.sh` symlink**. `init.sh` now links
+  `<repo>/setup.sh` to `template/script/docker/setup.sh` alongside the
+  existing `build.sh` / `run.sh` / `exec.sh` / `stop.sh` / `setup_tui.sh`
+  / `Makefile` symlinks. Consumer repos can now invoke `./setup.sh`
+  directly for scripted / CI regeneration of `.env` + `compose.yaml`,
+  instead of relying on the indirect `./build.sh --setup` or
+  `./setup_tui.sh` Save paths.
+- **`setup.sh -h` / `--help`**. `script/docker/setup.sh` gains a
+  `usage()` block documenting `--base-path` and `--lang`, following the
+  existing `build.sh` case-per-`_LANG` scaffolding (English-only for
+  now; future translations plug in via the existing `_msg` framework).
 - **`test/unit/exec_sh_spec.bats`** (18 tests) and
   **`test/unit/stop_sh_spec.bats`** (17 tests): new unit specs
   covering argument parsing, the container-running precheck hints in
@@ -31,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (+7) and `test/unit/run_sh_spec.bats` (+6) assert that `--lang
   <code>` actually translates the runtime logs (bootstrap, drift-regen,
   err_no_env, already-running), not just `--help`.
+
+### Fixed
+- **`setup.sh` symlink-invocation robustness**. `setup.sh` previously
+  located its `i18n.sh` / `_tui_conf.sh` siblings and the template
+  `setup.conf` via `dirname "${BASH_SOURCE[0]}"`, which resolved to the
+  repo root when the script was invoked through `<repo>/setup.sh`
+  (symlink). `setup.sh` now runs `readlink -f` once at load and stores
+  the real script directory in `_SETUP_SCRIPT_DIR`; every sibling
+  source and template-relative path reads from that variable.
 
 ## [v0.9.6] - 2026-04-23
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **590 tests** total (555 unit + 35 integration).
+Template self-tests: **592 tests** total (555 unit + 37 integration).
 
 ## Test Files
 
@@ -440,7 +440,7 @@ Exercises the runtime assertion helpers shipped in
 | `main copies tmux.conf to config directory` | Config copy |
 | `script runs entry_point when executed directly` | Direct-run guard |
 
-### test/integration/init_new_repo_spec.bats (33)
+### test/integration/init_new_repo_spec.bats (35)
 
 End-to-end verification that `init.sh` produces a complete repo skeleton in
 an empty directory. **Level 1** (file generation only, no Docker). The

--- a/init.sh
+++ b/init.sh
@@ -47,6 +47,7 @@ _create_symlinks() {
   _symlink "${TEMPLATE_REL}/script/docker/run.sh" "run.sh"
   _symlink "${TEMPLATE_REL}/script/docker/exec.sh" "exec.sh"
   _symlink "${TEMPLATE_REL}/script/docker/stop.sh" "stop.sh"
+  _symlink "${TEMPLATE_REL}/script/docker/setup.sh" "setup.sh"
   _symlink "${TEMPLATE_REL}/script/docker/setup_tui.sh" "setup_tui.sh"
   # Upgrade hygiene: drop the pre-rename `tui.sh` symlink if present
   # so we don't leave a dangling pointer after the file was renamed.

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -12,13 +12,18 @@
 # setup.conf + system detection. WS_PATH is detected once and written back
 # to <repo>/setup.conf [volumes] mount_1; subsequent runs read mount_1.
 #
-# Usage: setup.sh [--base-path <path>] [--lang zh|zh-CN|ja]
+# Usage: setup.sh [-h|--help] [--base-path <path>] [--lang en|zh-TW|zh-CN|ja]
 
 # ── i18n messages ──────────────────────────────────────────────
+# Resolve the symlink (<repo>/setup.sh → template/script/docker/setup.sh)
+# so sibling sources (i18n.sh / _tui_conf.sh) are located in the
+# template directory regardless of how the script was invoked.
+_SETUP_SELF="$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || printf '%s' "${BASH_SOURCE[0]}")"
+_SETUP_SCRIPT_DIR="$(cd -- "$(dirname -- "${_SETUP_SELF}")" && pwd -P)"
 # shellcheck disable=SC1091
-source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/i18n.sh"
+source "${_SETUP_SCRIPT_DIR}/i18n.sh"
 # shellcheck disable=SC1091
-source "$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)/_tui_conf.sh"
+source "${_SETUP_SCRIPT_DIR}/_tui_conf.sh"
 
 _msg() {
   local _key="${1}"
@@ -54,6 +59,43 @@ _msg() {
 if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
   set -euo pipefail
 fi
+
+# ════════════════════════════════════════════════════════════════════
+# usage
+#
+# Prints CLI help. Phase A: English-only text; case scaffolding is in
+# place so per-language translations can be added without restructuring.
+# ════════════════════════════════════════════════════════════════════
+usage() {
+  case "${_LANG}" in
+    *)
+      cat >&2 <<'EOF'
+Usage: ./setup.sh [-h|--help] [--base-path <path>] [--lang <en|zh-TW|zh-CN|ja>]
+
+Regenerate .env + compose.yaml from setup.conf + system detection.
+Normally invoked indirectly via `./build.sh --setup` or `./setup_tui.sh`
+Save; run directly for non-interactive / scripted / CI use.
+
+Options:
+  -h, --help            Show this help and exit.
+  --base-path PATH      Repo root to operate on. Defaults to the repo
+                        containing this script (template/../..).
+  --lang LANG           Set message language (en|zh-TW|zh-CN|ja).
+                        Defaults to $SETUP_LANG or auto-detected from
+                        $LANG.
+
+Outputs (both derived artifacts, gitignored):
+  <base-path>/.env          Exported variables + SETUP_* drift metadata
+  <base-path>/compose.yaml  Full compose with baseline + conditional
+                            blocks (GPU / GUI / extra volumes / etc.)
+
+Source of truth is setup.conf (template default + optional per-repo
+override via section-replace). Edit setup.conf, not the derived files.
+EOF
+      ;;
+  esac
+  exit 0
+}
 
 # ════════════════════════════════════════════════════════════════════
 # detect_user_info
@@ -225,8 +267,7 @@ _load_setup_conf() {
     return 0
   fi
 
-  local _self_dir
-  _self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
+  local _self_dir="${_SETUP_SCRIPT_DIR}"
   local _template_conf="${_self_dir}/../../setup.conf"
   local _repo_conf="${_base}/setup.conf"
 
@@ -510,8 +551,7 @@ _resolve_gui() {
 _compute_conf_hash() {
   local _base="${1:?}"
   local -n _cch_out="${2:?}"
-  local _self_dir
-  _self_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)"
+  local _self_dir="${_SETUP_SCRIPT_DIR}"
   local _template_conf="${_self_dir}/../../setup.conf"
   local _repo_conf="${_base}/setup.conf"
 
@@ -989,13 +1029,16 @@ _check_setup_drift() {
 # ════════════════════════════════════════════════════════════════════
 # main
 #
-# Usage: main [--base-path <path>] [--lang <en|zh-TW|zh-CN|ja>]
+# Usage: main [-h|--help] [--base-path <path>] [--lang <en|zh-TW|zh-CN|ja>]
 # ════════════════════════════════════════════════════════════════════
 main() {
   local _base_path=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
+      -h|--help)
+        usage
+        ;;
       --base-path)
         _base_path="${2:?"--base-path requires a value"}"
         shift 2
@@ -1013,7 +1056,7 @@ main() {
   done
 
   if [[ -z "${_base_path}" ]]; then
-    _base_path="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")/../../.." && pwd -P)"
+    _base_path="$(cd -- "${_SETUP_SCRIPT_DIR}/../../.." && pwd -P)"
   fi
 
   local _env_file="${_base_path}/.env"
@@ -1161,7 +1204,7 @@ main() {
     fi
     [[ -d "${ws_path}" ]] && ws_path="$(cd "${ws_path}" && pwd -P)"
     local _tpl_conf
-    _tpl_conf="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)/../../setup.conf"
+    _tpl_conf="${_SETUP_SCRIPT_DIR}/../../setup.conf"
     if [[ -f "${_tpl_conf}" ]]; then
       cp "${_tpl_conf}" "${_repo_conf}"
       _upsert_conf_value "${_repo_conf}" "volumes" "mount_1" \
@@ -1258,7 +1301,7 @@ main() {
   # down default — avoids surprising the user with "my container lost
   # SYS_ADMIN / unconfined seccomp after I cleared the list".
   local _tpl_setup_conf
-  _tpl_setup_conf="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" && pwd -P)/../../setup.conf"
+  _tpl_setup_conf="${_SETUP_SCRIPT_DIR}/../../setup.conf"
   local -a _tpl_sec_k=() _tpl_sec_v=()
   [[ -f "${_tpl_setup_conf}" ]] \
     && _parse_ini_section "${_tpl_setup_conf}" "security" _tpl_sec_k _tpl_sec_v

--- a/test/integration/init_new_repo_spec.bats
+++ b/test/integration/init_new_repo_spec.bats
@@ -225,6 +225,20 @@ teardown() {
   assert_success
 }
 
+@test "new repo: setup.sh symlink → template/script/docker/setup.sh" {
+  bash template/init.sh
+  assert [ -L "${REPO_DIR}/setup.sh" ]
+  run readlink "${REPO_DIR}/setup.sh"
+  assert_output "template/script/docker/setup.sh"
+}
+
+@test "new repo: setup.sh -h works against the generated symlink" {
+  bash template/init.sh
+  run bash "${REPO_DIR}/setup.sh" -h
+  assert_success
+  assert_output --partial "Usage"
+}
+
 # ════════════════════════════════════════════════════════════════════
 # init.sh --gen-conf
 # ════════════════════════════════════════════════════════════════════

--- a/test/unit/init_spec.bats
+++ b/test/unit/init_spec.bats
@@ -27,7 +27,7 @@ EOF
 
   # Stub scripts referenced by _create_symlinks — empty files are fine
   # because symlinks only need a valid target path, not a valid payload.
-  for _f in build.sh run.sh exec.sh stop.sh setup_tui.sh Makefile; do
+  for _f in build.sh run.sh exec.sh stop.sh setup.sh setup_tui.sh Makefile; do
     : > "${TMP_REPO}/template/script/docker/${_f}"
   done
   : > "${TMP_REPO}/template/.hadolint.yaml"
@@ -191,10 +191,10 @@ REMOTE
 # _create_symlinks
 # ════════════════════════════════════════════════════════════════════
 
-@test "_create_symlinks: produces all six docker-script symlinks" {
+@test "_create_symlinks: produces all seven docker-script symlinks" {
   _source_init
   _create_symlinks
-  for _f in build.sh run.sh exec.sh stop.sh setup_tui.sh Makefile; do
+  for _f in build.sh run.sh exec.sh stop.sh setup.sh setup_tui.sh Makefile; do
     assert [ -L "${TMP_REPO}/${_f}" ]
     run readlink "${TMP_REPO}/${_f}"
     assert_output "template/script/docker/${_f}"

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -678,6 +678,11 @@ EOF
 }
 
 @test "setup.sh default _base_path uses double parent traversal" {
-  run grep -E "dirname.*BASH_SOURCE.*\.\..*\.\." /source/script/docker/setup.sh
+  # setup.sh resolves the script directory once via readlink -f into
+  # _SETUP_SCRIPT_DIR (so invocation through the root-level symlink works),
+  # then walks up `../../..` to reach the repo root. Accept either the
+  # original inline BASH_SOURCE form or the _SETUP_SCRIPT_DIR indirection.
+  run grep -E "(dirname.*BASH_SOURCE|_SETUP_SCRIPT_DIR).*\.\..*\.\." \
+    /source/script/docker/setup.sh
   assert_success
 }


### PR DESCRIPTION
## Summary

- Adds a root-level `setup.sh` symlink (→ `template/script/docker/setup.sh`) to `init.sh`'s `_create_symlinks`, alongside the existing build/run/exec/stop/setup_tui/Makefile set. Consumer repos can now invoke `./setup.sh` directly for scripted / CI regeneration of `.env` + `compose.yaml`, instead of going through `./build.sh --setup` or `./setup_tui.sh` Save.
- Adds `usage()` + `-h|--help` handling to `script/docker/setup.sh`, documenting `--base-path` and `--lang` (Phase A: English only; case-per-`_LANG` scaffolding stays in place for later translations via the existing `_msg` framework).
- Fixes a symlink-invocation footgun: `setup.sh` previously located `i18n.sh` / `_tui_conf.sh` / the template `setup.conf` via `dirname BASH_SOURCE`, which resolved to the repo root when invoked through `<repo>/setup.sh`. The script now runs `readlink -f` once at load and stores the real script dir in `_SETUP_SCRIPT_DIR`; every sibling-source + template-relative lookup reads from that variable.

## Scope

Phase A only — no new CLI override flags, no i18n translations of `usage()` yet, no release / tag.

## Test plan

- [x] `test/unit/init_spec.bats` `_create_symlinks` loop bumped from six to seven, covers `setup.sh`.
- [x] `test/integration/init_new_repo_spec.bats` asserts (a) `<repo>/setup.sh` is a symlink pointing at `template/script/docker/setup.sh`, (b) `./setup.sh -h` succeeds + prints `Usage`.
- [x] `test/unit/template_spec.bats` `setup.sh default _base_path uses double parent traversal` accepts both the original inline `BASH_SOURCE` form and the new `_SETUP_SCRIPT_DIR` indirection.
- [x] `make -f Makefile.ci test` — 545/545 passing (508 unit + 37 integration; was 543: +2 integration).
- [x] `make -f Makefile.ci lint` — clean (ShellCheck green via docker compose).