### PR TITLE
fix(upgrade): guard against destructive subtree pull fast-forwards

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`upgrade.sh` no longer leaves the repo destroyed if `git subtree
+  pull` misbehaves**. On Jetson L4T (ships an older `git-subtree.sh`),
+  running `upgrade.sh v0.9.5 → v0.9.7` fast-forwarded the synthetic
+  squash commit onto HEAD, moving `template/*` to repo root and
+  deleting repo-specific files (Dockerfile, compose.yaml, bridge.yaml,
+  etc.). `upgrade.sh` now:
+  - **Pre-flight** — fails fast with actionable messages when `git
+    config user.name / user.email` is unset (a Jetson-specific trigger
+    for the partial-state bug), or when a merge / rebase / cherry-pick
+    is in progress (`.git/MERGE_HEAD`, `.git/rebase-merge`, etc.).
+  - **Post-flight integrity check** — after the subtree pull, verifies
+    `template/.version`, `template/init.sh`, and
+    `template/script/docker/setup.sh` still exist. If any is missing,
+    hard-resets to the pre-pull HEAD and exits with a diagnostic. The
+    working tree is restored; no manual cleanup required.
+  - **Step numbering** — corrected from mixed "1/4 / 2/3 / 3/3" to
+    "1/4 / 2/4 / 3/4 / 4/4".
+- **`test/unit/upgrade_spec.bats`** gains 12 regression tests covering
+  the three new guards + structural invariants (ordering: identity
+  check before pull, integrity check after pull, HEAD snapshotted for
+  rollback).
+- **`test/integration/upgrade_spec.bats`** (new, 6 tests) drives the
+  real `upgrade.sh` end-to-end against a fake template remote (bare
+  repo with `v0.9.5` / `v0.9.7` tags) attached to a sandbox downstream
+  repo. Covers happy path (version bump, new content, `main.yaml`
+  `@tag` rewrite), idempotent re-run, `--check`, the two pre-flight
+  guards, and the destructive-FF rollback (stubs `git-subtree pull`
+  via `GIT_EXEC_PATH` to simulate the Jetson bug, asserts repo is
+  restored to pre-pull HEAD). Total: 592 → 610 (+12 unit + 6
+  integration).
+
 ## [v0.9.7] - 2026-04-23
 
 ### Changed

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **592 tests** total (555 unit + 37 integration).
+Template self-tests: **610 tests** total (567 unit + 43 integration).
 
 ## Test Files
 
@@ -440,6 +440,43 @@ Exercises the runtime assertion helpers shipped in
 | `main copies tmux.conf to config directory` | Config copy |
 | `script runs entry_point when executed directly` | Direct-run guard |
 
+### test/unit/upgrade_spec.bats (20)
+
+Unit tests for `upgrade.sh` helpers. Uses the sed-range pattern to extract
+one function at a time into a minimal harness (with `_log` / `_error`
+stubs), so each helper runs in a sandboxed git repo without needing to
+source the full `upgrade.sh` (which would trigger its top-level
+`cd REPO_ROOT`).
+
+Covers: `_warn_config_drift` (silent / fires on drift / diff hint),
+the three safety guards added after the v0.9.7 Jetson incident
+(`_require_git_identity`, `_require_clean_merge_state`,
+`_verify_subtree_intact` with rollback), and structural invariants that
+pin call-ordering in `_upgrade` (identity check runs before subtree
+pull, integrity verification runs after, pre-pull HEAD is snapshotted
+for rollback).
+
+| Test | Description |
+|------|-------------|
+| `_warn_config_drift silent when no template/config in HEAD` | Initial setup |
+| `_warn_config_drift silent when pre and post hashes match` | No drift |
+| `_warn_config_drift prints WARNING + diff hint when hashes differ` | Drift reported |
+| `upgrade.sh defines _warn_config_drift` | Helper present |
+| `upgrade.sh invokes _warn_config_drift after subtree pull` | Call site present |
+| `upgrade.sh captures pre-pull template/config tree hash` | Snapshot taken |
+| `_require_git_identity succeeds when name + email are set` | Happy path |
+| `_require_git_identity fails when user.email is unset` | Email guard |
+| `_require_git_identity fails when user.name is unset` | Name guard |
+| `_require_clean_merge_state succeeds in clean repo` | Happy path |
+| `_require_clean_merge_state fails when MERGE_HEAD exists` | Mid-merge guard |
+| `_require_clean_merge_state fails when rebase-merge dir exists` | Mid-rebase guard |
+| `_verify_subtree_intact succeeds when all markers present` | Happy path |
+| `_verify_subtree_intact rolls back when template/.version is missing` | Destructive-FF rollback |
+| `_verify_subtree_intact rolls back when template/script/docker/setup.sh is missing` | Marker rollback |
+| `upgrade.sh calls _require_git_identity before subtree pull` | Pre-flight ordering |
+| `upgrade.sh calls _verify_subtree_intact after subtree pull` | Post-flight ordering |
+| `upgrade.sh snapshots pre-pull HEAD for rollback` | Rollback anchor |
+
 ### test/integration/init_new_repo_spec.bats (35)
 
 End-to-end verification that `init.sh` produces a complete repo skeleton in
@@ -492,3 +529,22 @@ invocation — `build.sh --dry-run`).
 |------|-------------|
 | `fresh clone with stale absolute mount_1: build.sh auto-migrates + generates local .env` | Stale-path auto-migrate |
 | `fresh clone with portable ${WS_PATH} mount_1: no warning, .env gets local path` | Happy path round-trip |
+
+### test/integration/upgrade_spec.bats (6)
+
+End-to-end verification for `upgrade.sh` driving a real subtree update
+against a fake template remote (bare repo with `v0.9.5` / `v0.9.7` tags
+on a minimal subtree layout) attached to a sandbox downstream repo.
+**Level 1** (no Docker). Exercises the happy path, the pre-flight
+guards, and — most importantly — the destructive-FF rollback path added
+after the Jetson v0.9.7 incident (stubs `git-subtree pull` via
+`GIT_EXEC_PATH` to simulate the bug and asserts the repo is restored).
+
+| Test | Description |
+|------|-------------|
+| `upgrade.sh v0.9.7: bumps template/.version, pulls new content, updates main.yaml` | Happy path |
+| `upgrade.sh v0.9.7 is idempotent on a second run` | Re-run is no-op |
+| `upgrade.sh --check reports update available from v0.9.5 → v0.9.7` | --check flag |
+| `upgrade.sh fails fast when git identity is missing` | Pre-flight identity guard |
+| `upgrade.sh fails fast when MERGE_HEAD is present` | Pre-flight merge-state guard |
+| `upgrade.sh rolls back when git-subtree does a destructive fast-forward` | Destructive-FF rollback |

--- a/test/integration/upgrade_spec.bats
+++ b/test/integration/upgrade_spec.bats
@@ -1,0 +1,223 @@
+#!/usr/bin/env bats
+#
+# Integration tests for upgrade.sh end-to-end.
+#
+# Fixture: a bare "template" remote seeded with two tags (v0.9.5, v0.9.7) plus a
+# "downstream" consumer repo that has template added as a subtree at v0.9.5.
+# Tests drive the real upgrade.sh against this fake remote and assert on
+# the resulting working tree + git state.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/../unit/test_helper"
+  UPGRADE="/source/upgrade.sh"
+
+  TMPL_WORK="${BATS_TEST_TMPDIR}/template_work"
+  TMPL_BARE="${BATS_TEST_TMPDIR}/template.git"
+  DOWN_DIR="${BATS_TEST_TMPDIR}/downstream"
+
+  _seed_template_remote
+  _seed_downstream_repo
+}
+
+# ── Fixture helpers ─────────────────────────────────────────────────────────
+
+# _seed_template_remote
+#   Build a tiny template layout matching what upgrade.sh's post-flight
+#   checks look for (markers: template/.version, template/init.sh,
+#   template/script/docker/setup.sh), wrap two tagged versions around it,
+#   and push to a bare repo we can treat as TEMPLATE_REMOTE.
+_seed_template_remote() {
+  mkdir -p "${TMPL_WORK}/script/docker"
+  git -C "${TMPL_WORK}" init -q -b main
+  git -C "${TMPL_WORK}" config user.email t@t
+  git -C "${TMPL_WORK}" config user.name t
+
+  # v0.9.5: baseline subtree content. Use the real upgrade.sh under test so
+  # the downstream repo (which invokes ./template/upgrade.sh) runs the
+  # same code these tests validate.
+  echo "v0.9.5" > "${TMPL_WORK}/.version"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${TMPL_WORK}/init.sh"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${TMPL_WORK}/script/docker/setup.sh"
+  cp "${UPGRADE}" "${TMPL_WORK}/upgrade.sh"
+  chmod +x "${TMPL_WORK}/init.sh" "${TMPL_WORK}/script/docker/setup.sh" "${TMPL_WORK}/upgrade.sh"
+  git -C "${TMPL_WORK}" add -A
+  git -C "${TMPL_WORK}" commit -q -m "v0.9.5"
+  git -C "${TMPL_WORK}" tag v0.9.5
+
+  # v0.9.7: version bump + a new file (lets tests assert the new payload arrived).
+  echo "v0.9.7" > "${TMPL_WORK}/.version"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${TMPL_WORK}/script/docker/new_script.sh"
+  chmod +x "${TMPL_WORK}/script/docker/new_script.sh"
+  git -C "${TMPL_WORK}" add -A
+  git -C "${TMPL_WORK}" commit -q -m "v0.9.7"
+  git -C "${TMPL_WORK}" tag v0.9.7
+
+  git init --bare -q "${TMPL_BARE}"
+  git -C "${TMPL_WORK}" push -q "${TMPL_BARE}" v0.9.5 v0.9.7 main
+}
+
+# _seed_downstream_repo
+#   Simulate a consumer repo at the moment right after `git subtree add
+#   --prefix=template ... v0.9.5 --squash`: a committed README, a
+#   main.yaml with @v0.9.5 references ready to be bumped, and template/ as
+#   a proper subtree.
+_seed_downstream_repo() {
+  mkdir -p "${DOWN_DIR}/.github/workflows"
+  git -C "${DOWN_DIR}" init -q -b main
+  git -C "${DOWN_DIR}" config user.email t@t
+  git -C "${DOWN_DIR}" config user.name t
+
+  echo "DOWNSTREAM" > "${DOWN_DIR}/README.md"
+  cat > "${DOWN_DIR}/.github/workflows/main.yaml" <<'YAML'
+jobs:
+  build:
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v0.9.5
+  release:
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@v0.9.5
+YAML
+  git -C "${DOWN_DIR}" add -A
+  git -C "${DOWN_DIR}" commit -q -m "initial downstream"
+
+  git -C "${DOWN_DIR}" subtree add -q --prefix=template \
+    "file://${TMPL_BARE}" v0.9.5 --squash
+}
+
+# ── Happy path ──────────────────────────────────────────────────────────────
+
+@test "upgrade.sh v0.9.7: bumps template/.version, pulls new content, updates main.yaml" {
+  cd "${DOWN_DIR}"
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" ./template/upgrade.sh v0.9.7
+  assert_success
+  assert_output --partial "Upgrading: v0.9.5 → v0.9.7"
+  assert_output --partial "Done! Upgraded to v0.9.7"
+
+  # Version bumped
+  [ "$(cat template/.version)" = "v0.9.7" ]
+  # New file from v0.9.7 arrived under the subtree prefix
+  [ -f "template/script/docker/new_script.sh" ]
+  # main.yaml @tag references bumped to v0.9.7
+  grep -Fq "build-worker.yaml@v0.9.7" .github/workflows/main.yaml
+  grep -Fq "release-worker.yaml@v0.9.7" .github/workflows/main.yaml
+  # README.md and other downstream content untouched
+  [ "$(cat README.md)" = "DOWNSTREAM" ]
+}
+
+@test "upgrade.sh v0.9.7 is idempotent on a second run" {
+  cd "${DOWN_DIR}"
+
+  env TEMPLATE_REMOTE="file://${TMPL_BARE}" ./template/upgrade.sh v0.9.7 >/dev/null
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" ./template/upgrade.sh v0.9.7
+  assert_success
+  assert_output --partial "Already at v0.9.7"
+  [ "$(cat template/.version)" = "v0.9.7" ]
+}
+
+@test "upgrade.sh --check reports update available from v0.9.5 → v0.9.7" {
+  cd "${DOWN_DIR}"
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" ./template/upgrade.sh --check
+  # _check exits 1 when an update is available (documented contract).
+  assert_failure
+  assert_output --partial "Local:  v0.9.5"
+  assert_output --partial "Latest: v0.9.7"
+  assert_output --partial "Update available"
+}
+
+# ── Pre-flight guards ───────────────────────────────────────────────────────
+
+@test "upgrade.sh fails fast when git identity is missing" {
+  cd "${DOWN_DIR}"
+
+  # Strip both repo-local and inherited identity so git config resolves empty.
+  git config --unset user.email
+  git config --unset user.name
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" \
+      HOME="${BATS_TEST_TMPDIR}" \
+      GIT_CONFIG_GLOBAL=/dev/null \
+      GIT_CONFIG_SYSTEM=/dev/null \
+      ./template/upgrade.sh v0.9.7
+  assert_failure
+  assert_output --partial "git identity not configured"
+  # Pre-flight aborted before subtree pull ran.
+  [ "$(cat template/.version)" = "v0.9.5" ]
+}
+
+@test "upgrade.sh fails fast when MERGE_HEAD is present" {
+  cd "${DOWN_DIR}"
+  touch .git/MERGE_HEAD
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" ./template/upgrade.sh v0.9.7
+  assert_failure
+  assert_output --partial "MERGE_HEAD present"
+  [ "$(cat template/.version)" = "v0.9.5" ]
+}
+
+# ── Rollback on destructive subtree pull ────────────────────────────────────
+
+@test "upgrade.sh rolls back when git-subtree does a destructive fast-forward" {
+  cd "${DOWN_DIR}"
+
+  # Install a git-subtree stub that simulates the Jetson v0.9.7 failure
+  # mode: fetches the tag, then hard-resets HEAD to FETCH_HEAD (which
+  # has template content at REPO ROOT, not under template/). The
+  # resulting working tree loses template/.version and template-prefixed
+  # files.
+  #
+  # `git subtree` resolves via GIT_EXEC_PATH (default /usr/lib/git-core),
+  # NOT PATH, so a plain PATH-prepended stub is ignored. We point
+  # GIT_EXEC_PATH at our stub dir; the stub forwards non-`pull`
+  # subcommands back to the distro location for any incidental use.
+  local _stub_dir="${BATS_TEST_TMPDIR}/stub_bin"
+  mkdir -p "${_stub_dir}"
+  cat > "${_stub_dir}/git-subtree" <<'STUB'
+#!/usr/bin/env bash
+# Forward everything except `pull` to the real git-subtree. Relies on
+# /usr/lib/git-core/git-subtree being present; if the distro places it
+# elsewhere, the test will need to be adjusted.
+if [[ "$1" != "pull" ]]; then
+  exec /usr/lib/git-core/git-subtree "$@"
+fi
+shift
+_remote=""
+_ref=""
+while (( $# )); do
+  case "$1" in
+    --prefix=*) shift ;;
+    --squash) shift ;;
+    -m) shift 2 ;;
+    file://*|https://*|git@*) _remote="$1"; shift ;;
+    v*) _ref="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+git fetch "${_remote}" "${_ref}" >/dev/null 2>&1
+git reset --hard FETCH_HEAD >/dev/null 2>&1
+STUB
+  chmod +x "${_stub_dir}/git-subtree"
+
+  local _pre_head
+  _pre_head="$(git rev-parse HEAD)"
+
+  run env GIT_EXEC_PATH="${_stub_dir}" \
+      TEMPLATE_REMOTE="file://${TMPL_BARE}" \
+      ./template/upgrade.sh v0.9.7
+
+  assert_failure
+  assert_output --partial "integrity check failed"
+  assert_output --partial "template/.version"
+  assert_output --partial "Rolling back"
+  assert_output --partial "upgrade aborted"
+
+  # Post-condition: repo restored. HEAD back to pre-pull, subtree markers
+  # present, version still v0.9.5 — the user's working copy is usable.
+  [ "$(git rev-parse HEAD)" = "${_pre_head}" ]
+  [ -f "template/.version" ]
+  [ "$(cat template/.version)" = "v0.9.5" ]
+  [ -f "template/script/docker/setup.sh" ]
+  [ -f "README.md" ]
+}

--- a/test/unit/upgrade_spec.bats
+++ b/test/unit/upgrade_spec.bats
@@ -12,15 +12,19 @@ setup() {
   UPGRADE="/source/upgrade.sh"
 
   # Build a self-contained test harness: a shell script that redefines
-  # `_log` (avoids pulling in upgrade.sh's top-level `cd REPO_ROOT`)
-  # and extracts `_warn_config_drift` from upgrade.sh by sed range so
-  # tests exercise the real function body, not a copy.
+  # `_log` / `_error` (avoids pulling in upgrade.sh's top-level `cd
+  # REPO_ROOT`) and extracts helpers from upgrade.sh by sed range so
+  # tests exercise the real function bodies, not copies.
   TEMP_DIR="$(mktemp -d)"
   HARNESS="${TEMP_DIR}/harness.sh"
   cat > "${HARNESS}" <<'EOS'
 _log() { printf '[upgrade] %s\n' "$*"; }
+_error() { printf '[upgrade] ERROR: %s\n' "$*" >&2; exit 1; }
 EOS
   sed -n '/^_warn_config_drift() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
+  sed -n '/^_require_git_identity() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
+  sed -n '/^_require_clean_merge_state() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
+  sed -n '/^_verify_subtree_intact() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
 }
 
 teardown() {
@@ -100,5 +104,170 @@ teardown() {
   # The WARNING only fires when we have both pre and post hashes —
   # guard against dropping the snapshot line.
   run grep -F 'HEAD:template/config' "${UPGRADE}"
+  assert_success
+}
+
+# ── _require_git_identity ───────────────────────────────────────────────────
+
+@test "_require_git_identity succeeds when name + email are set" {
+  local _git_dir="${TEMP_DIR}/ident_ok"
+  mkdir -p "${_git_dir}"
+  git -C "${_git_dir}" init -q
+  git -C "${_git_dir}" config user.name "t"
+  git -C "${_git_dir}" config user.email "t@t"
+  run bash -c "cd '${_git_dir}' && source '${HARNESS}' && _require_git_identity"
+  assert_success
+}
+
+@test "_require_git_identity fails when user.email is unset" {
+  local _git_dir="${TEMP_DIR}/ident_noemail"
+  mkdir -p "${_git_dir}"
+  git -C "${_git_dir}" init -q
+  git -C "${_git_dir}" config user.name "t"
+  # GIT_CONFIG_GLOBAL=/dev/null + HOME= isolates from inherited identity
+  run bash -c "
+    cd '${_git_dir}'
+    export HOME='${TEMP_DIR}/ident_noemail' GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+    source '${HARNESS}'
+    _require_git_identity
+  "
+  assert_failure
+  assert_output --partial "git identity not configured"
+}
+
+@test "_require_git_identity fails when user.name is unset" {
+  local _git_dir="${TEMP_DIR}/ident_noname"
+  mkdir -p "${_git_dir}"
+  git -C "${_git_dir}" init -q
+  git -C "${_git_dir}" config user.email "t@t"
+  run bash -c "
+    cd '${_git_dir}'
+    export HOME='${TEMP_DIR}/ident_noname' GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+    source '${HARNESS}'
+    _require_git_identity
+  "
+  assert_failure
+  assert_output --partial "git identity not configured"
+}
+
+# ── _require_clean_merge_state ──────────────────────────────────────────────
+
+@test "_require_clean_merge_state succeeds in clean repo" {
+  local _git_dir="${TEMP_DIR}/clean"
+  mkdir -p "${_git_dir}"
+  git -C "${_git_dir}" init -q
+  run bash -c "cd '${_git_dir}' && source '${HARNESS}' && _require_clean_merge_state"
+  assert_success
+}
+
+@test "_require_clean_merge_state fails when MERGE_HEAD exists" {
+  local _git_dir="${TEMP_DIR}/midmerge"
+  mkdir -p "${_git_dir}"
+  git -C "${_git_dir}" init -q
+  touch "${_git_dir}/.git/MERGE_HEAD"
+  run bash -c "cd '${_git_dir}' && source '${HARNESS}' && _require_clean_merge_state"
+  assert_failure
+  assert_output --partial "MERGE_HEAD present"
+}
+
+@test "_require_clean_merge_state fails when rebase-merge dir exists" {
+  local _git_dir="${TEMP_DIR}/midrebase"
+  mkdir -p "${_git_dir}"
+  git -C "${_git_dir}" init -q
+  mkdir -p "${_git_dir}/.git/rebase-merge"
+  run bash -c "cd '${_git_dir}' && source '${HARNESS}' && _require_clean_merge_state"
+  assert_failure
+  assert_output --partial "rebase-merge present"
+}
+
+# ── _verify_subtree_intact ──────────────────────────────────────────────────
+
+# Helper: build a minimal repo resembling a subtree consumer, then
+# return its _pre_head so the test can call _verify_subtree_intact.
+_mk_subtree_repo() {
+  local _dir="$1"
+  mkdir -p "${_dir}/template/script/docker"
+  echo "v0.9.5" > "${_dir}/template/.version"
+  echo "#!/usr/bin/env bash" > "${_dir}/template/init.sh"
+  echo "#!/usr/bin/env bash" > "${_dir}/template/script/docker/setup.sh"
+  git -C "${_dir}" init -q -b main
+  git -C "${_dir}" config user.email t@t
+  git -C "${_dir}" config user.name t
+  git -C "${_dir}" add -A
+  git -C "${_dir}" commit -q -m "initial"
+}
+
+@test "_verify_subtree_intact succeeds when all markers present" {
+  local _git_dir="${TEMP_DIR}/intact_ok"
+  _mk_subtree_repo "${_git_dir}"
+  run bash -c "
+    cd '${_git_dir}'
+    _pre=\$(git rev-parse HEAD)
+    source '${HARNESS}'
+    _verify_subtree_intact \"\${_pre}\"
+  "
+  assert_success
+}
+
+@test "_verify_subtree_intact rolls back when template/.version is missing" {
+  local _git_dir="${TEMP_DIR}/intact_noversion"
+  _mk_subtree_repo "${_git_dir}"
+  local _pre
+  _pre="$(git -C "${_git_dir}" rev-parse HEAD)"
+  # Simulate the destructive FF: template/* moved up, template/.version gone.
+  rm "${_git_dir}/template/.version"
+
+  run bash -c "
+    cd '${_git_dir}'
+    source '${HARNESS}'
+    _verify_subtree_intact '${_pre}'
+  "
+  assert_failure
+  assert_output --partial "integrity check failed"
+  assert_output --partial "template/.version"
+  # Post-condition: marker is restored by the rollback `git reset --hard`.
+  [ -f "${_git_dir}/template/.version" ]
+}
+
+@test "_verify_subtree_intact rolls back when template/script/docker/setup.sh is missing" {
+  local _git_dir="${TEMP_DIR}/intact_nosetup"
+  _mk_subtree_repo "${_git_dir}"
+  local _pre
+  _pre="$(git -C "${_git_dir}" rev-parse HEAD)"
+  rm "${_git_dir}/template/script/docker/setup.sh"
+
+  run bash -c "
+    cd '${_git_dir}'
+    source '${HARNESS}'
+    _verify_subtree_intact '${_pre}'
+  "
+  assert_failure
+  assert_output --partial "template/script/docker/setup.sh"
+  [ -f "${_git_dir}/template/script/docker/setup.sh" ]
+}
+
+# ── upgrade.sh structural invariants (safety guards) ───────────────────────
+
+@test "upgrade.sh calls _require_git_identity before subtree pull" {
+  # Confirm both that the helper is called AND the ordering is correct.
+  local _id_line _pull_line
+  _id_line="$(grep -n '_require_git_identity$' "${UPGRADE}" | tail -1 | cut -d: -f1)"
+  _pull_line="$(grep -n 'git subtree pull' "${UPGRADE}" | head -1 | cut -d: -f1)"
+  [ -n "${_id_line}" ]
+  [ -n "${_pull_line}" ]
+  (( _id_line < _pull_line ))
+}
+
+@test "upgrade.sh calls _verify_subtree_intact after subtree pull" {
+  local _pull_line _verify_line
+  _pull_line="$(grep -n 'git subtree pull' "${UPGRADE}" | head -1 | cut -d: -f1)"
+  _verify_line="$(grep -n '_verify_subtree_intact "\${_pre_head}"' "${UPGRADE}" | head -1 | cut -d: -f1)"
+  [ -n "${_pull_line}" ]
+  [ -n "${_verify_line}" ]
+  (( _verify_line > _pull_line ))
+}
+
+@test "upgrade.sh snapshots pre-pull HEAD for rollback" {
+  run grep -F 'git rev-parse HEAD' "${UPGRADE}"
   assert_success
 }

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -26,6 +26,72 @@ cd "${REPO_ROOT}"
 _log() { printf "[upgrade] %s\n" "$*"; }
 _error() { printf "[upgrade] ERROR: %s\n" "$*" >&2; exit 1; }
 
+# ── Safety guards ────────────────────────────────────────────────────────────
+#
+# git-subtree pull is known to misbehave on some versions (reports of
+# destructive fast-forward have been seen on Jetson L4T shipping older
+# git-subtree.sh). These helpers keep `upgrade.sh` safe regardless: fail
+# fast if the repo is not in a state where subtree pull can succeed
+# cleanly, and roll back if the pull ran but left `template/` in a shape
+# that doesn't match a subtree (e.g. markers missing, working tree
+# contains template-repo root files at <repo>/ root).
+
+# _require_git_identity
+#   git-subtree internally calls `git commit-tree`, which needs
+#   user.name + user.email. Missing identity on Jetson was observed to
+#   leave git in a partial state that the next run then fast-forwarded
+#   destructively. Fail fast with an actionable message instead.
+_require_git_identity() {
+  local _name _email
+  _name="$(git config user.name 2>/dev/null || true)"
+  _email="$(git config user.email 2>/dev/null || true)"
+  if [[ -z "${_name}" || -z "${_email}" ]]; then
+    _error "git identity not configured. Set it before upgrading:
+  git config --global user.name \"Your Name\"
+  git config --global user.email \"you@example.com\""
+  fi
+}
+
+# _require_clean_merge_state
+#   Refuse to start if a merge / rebase / cherry-pick / revert is in
+#   progress; our subtree merge would be conflated with the user's
+#   in-flight operation.
+_require_clean_merge_state() {
+  local _git_dir _state
+  _git_dir="$(git rev-parse --git-dir)"
+  for _state in MERGE_HEAD CHERRY_PICK_HEAD REVERT_HEAD rebase-merge rebase-apply; do
+    if [[ -e "${_git_dir}/${_state}" ]]; then
+      _error "${_state} present in ${_git_dir} — resolve or abort it before upgrading."
+    fi
+  done
+}
+
+# _verify_subtree_intact <pre_head_sha>
+#   Post-pull sanity check: `template/` must still contain the subtree
+#   markers. A known failure mode (older git-subtree) is to fast-forward
+#   the synthetic squash commit, replacing <repo> root with template's
+#   tree (moves `template/*` to `<repo>/*` and deletes repo-specific
+#   files). Detect that by checking subtree markers, and hard-reset back
+#   to <pre_head_sha> if integrity is lost.
+_verify_subtree_intact() {
+  local _pre_head="$1"
+  local _markers=(
+    "template/.version"
+    "template/init.sh"
+    "template/script/docker/setup.sh"
+  )
+  local _marker
+  for _marker in "${_markers[@]}"; do
+    if [[ ! -f "${_marker}" ]]; then
+      printf "[upgrade] ERROR: post-pull integrity check failed — '%s' missing.\n" "${_marker}" >&2
+      printf "[upgrade] Likely cause: git-subtree fast-forwarded destructively.\n" >&2
+      printf "[upgrade] Rolling back to %s ...\n" "${_pre_head:0:12}" >&2
+      git reset --hard "${_pre_head}" >/dev/null 2>&1 || true
+      _error "upgrade aborted; repo restored to pre-upgrade state"
+    fi
+  done
+}
+
 # ── Get versions ─────────────────────────────────────────────────────────────
 
 _get_local_version() {
@@ -78,6 +144,16 @@ _upgrade() {
     return 0
   fi
 
+  # Pre-flight safety checks. Any failure exits non-zero without
+  # touching the working tree.
+  _require_git_identity
+  _require_clean_merge_state
+
+  # Snapshot HEAD so the post-pull integrity check can roll back if
+  # git-subtree corrupts the tree.
+  local _pre_head
+  _pre_head="$(git rev-parse HEAD)"
+
   _log "Upgrading: ${local_ver} → ${target_ver}"
 
   # Snapshot the pre-pull tree hash of template/config so we can tell
@@ -98,12 +174,16 @@ _upgrade() {
     "${TEMPLATE_REMOTE}" "${target_ver}" --squash \
     -m "chore: upgrade template subtree to ${target_ver}"
 
-  # Step 2: re-run init.sh to sync symlinks (in case template structure changed)
-  _log "Step 2/3: re-run init.sh to sync symlinks"
+  # Step 2: post-pull integrity check (rolls back on corruption)
+  _log "Step 2/4: verify template/ subtree integrity"
+  _verify_subtree_intact "${_pre_head}"
+
+  # Step 3: re-run init.sh to sync symlinks (in case template structure changed)
+  _log "Step 3/4: re-run init.sh to sync symlinks"
   ./template/init.sh
 
-  # Step 3: update main.yaml @tag references
-  _log "Step 3/3: update workflow @tag references"
+  # Step 4: update main.yaml @tag references
+  _log "Step 4/4: update workflow @tag references"
   local main_yaml="${REPO_ROOT}/.github/workflows/main.yaml"
   if [[ -f "${main_yaml}" ]]; then
     # Replace @vX.Y.Z with new version in reusable workflow references.


### PR DESCRIPTION
## Summary

- Three safety guards in `upgrade.sh` that neutralise the destructive-FF failure observed on Jetson L4T during the v0.9.7 upgrade (moved `template/*` to repo root and deleted consumer repo files).
- Pre-flight: git identity must be set; no merge / rebase / cherry-pick in progress.
- Post-flight: `template/.version`, `template/init.sh`, `template/script/docker/setup.sh` must still exist; otherwise hard-reset to pre-pull HEAD and exit.
- Tests: 592 → 610 (+12 unit, +6 integration). New integration spec drives real `upgrade.sh` against a fake template remote, including stubbing `git-subtree pull` (via `GIT_EXEC_PATH`) to reproduce the destructive-FF bug and assert rollback.

## Test plan
- [ ] `test` job green on CI
- [ ] `Integration E2E` job green on CI
- [ ] After merge: tag `v0.9.8`, push tag, verify release worker uploads archive
- [ ] Local Jetson re-verification: fresh-clone ros1_bridge, set git identity, run `./template/upgrade.sh v0.9.8`