### PR TITLE
feat(v0.9.9): complete i18n coverage + Jetson NVIDIA runtime support

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`_lib.sh` `_print_config_summary` now honours `${_LANG}`**. Previously
+  the build/run config summary (Files / Identity / Resolved / Customize
+  sections, plus user / hardware / workspace / GPU enabled / GUI enabled
+  / network / privileged labels) was hardcoded English regardless of
+  `--lang` / `SETUP_LANG`. Agent A's v0.9.7 i18n PR explicitly scoped
+  this out as "too much to bite off"; user feedback after the Jetson
+  upgrade: `./run.sh --lang zh-TW` still looked English because the
+  summary is 90% of the output. A new `_lib_msg` translation table
+  covers `en` / `zh-TW` / `zh-CN` / `ja`. Technical identifiers kept
+  untranslated: file names (`setup.conf` / `.env` / `compose.yaml`),
+  INI section names (`[image]` / ...), `.env` variable names (`TZ`,
+  `APT_MIRROR_*`, `IPC`, `CAPS`), and command strings in the Customize
+  hint.
+
 ## [v0.9.8] - 2026-04-23
 
 ### Fixed

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`[deploy] runtime` setup.conf key** — Docker runtime override at
+  service level in compose.yaml. Required on Jetson (JetPack) because
+  its nvidia-container-toolkit runs in csv mode and refuses the modern
+  `--gpus` flow that `deploy.resources.reservations.devices` uses.
+  Values:
+  - `auto` — emit `runtime: nvidia` on Jetson (detected via
+    `/etc/nv_tegra_release`), omit on desktop (default).
+  - `nvidia` — force emit on all hosts (e.g. csv-mode toolkit on x86).
+  - `off` — never emit (Docker default runc).
+
+  `setup.sh` resolves via new `_detect_jetson` + `_resolve_runtime`
+  helpers; `SETUP_DETECT_JETSON=true|false` env var overrides the
+  filesystem probe (used by tests). `setup_tui.sh` gains a matching
+  picker in `[deploy]` section with 4-language i18n;
+  `_validate_runtime` accepts `auto|nvidia|off` or empty.
+
 ### Changed
 - **`_lib.sh` `_print_config_summary` now honours `${_LANG}`**. Previously
   the build/run config summary (Files / Identity / Resolved / Customize

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **610 tests** total (567 unit + 43 integration).
+Template self-tests: **618 tests** total (575 unit + 43 integration).
 
 ## Test Files
 
-### test/unit/lib_spec.bats (26)
+### test/unit/lib_spec.bats (34)
 
 | Test | Description |
 |------|-------------|

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **618 tests** total (575 unit + 43 integration).
+Template self-tests: **632 tests** total (589 unit + 43 integration).
 
 ## Test Files
 
@@ -34,7 +34,7 @@ Template self-tests: **618 tests** total (575 unit + 43 integration).
 | `_print_config_summary hides sections that are empty in setup.conf` | Empty-section skip |
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
 
-### test/unit/setup_spec.bats (97)
+### test/unit/setup_spec.bats (105)
 
 Covers core detection (user/hardware/docker/GPU/GUI), the INI parser
 (`_parse_ini_section`), setup.conf section merging (`_load_setup_conf`
@@ -61,7 +61,7 @@ writeback (first-time bootstrap / user-edit respect / opt-out).
 | `[build]` apt_mirror (empty fallback, override) | 2 |
 | Workspace writeback (first-time, respect user edit, opt-out) | 3 |
 
-### test/unit/tui_spec.bats (70)
+### test/unit/tui_spec.bats (73)
 
 Pure-logic unit tests for the TUI support libraries (`_tui_conf.sh`).
 No dialog/whiptail invocations here — strictly validators, mount-string
@@ -156,7 +156,7 @@ Chinese / Simplified Chinese / Japanese translations of the
 no-instances message, `--all` multi-project teardown loop, and
 fallback `_detect_lang` branches.
 
-### test/unit/compose_gen_spec.bats (35)
+### test/unit/compose_gen_spec.bats (38)
 
 Covers `generate_compose_yaml` conditional output: AUTO-GENERATED
 header, baseline workspace volume, network/ipc/privileged env-var

--- a/script/docker/_lib.sh
+++ b/script/docker/_lib.sh
@@ -96,6 +96,97 @@ _dump_conf_section() {
   ' "${_file}"
 }
 
+# _lib_msg <key>
+#
+# Translation table for labels printed by `_print_config_summary`.
+# Uses the same `${_LANG}:${_key}` → output pattern as setup.sh /
+# build.sh's `_msg`. Kept in a separate namespace (`_lib_msg`) so
+# caller scripts can still define their own `_msg` for script-specific
+# log lines without name collisions.
+#
+# Translated: section headings + descriptive labels. Left untranslated
+# (technical terms / identifiers users recognise across locales): file
+# names (setup.conf / .env / compose.yaml), INI section names in [ ],
+# .env variable names (TZ, APT_MIRROR_*, IPC, CAPS), command strings
+# in "Customize" hint.
+_lib_msg() {
+  local _key="${1:?}"
+  case "${_LANG:-en}:${_key}" in
+    # Section headings
+    zh-TW:files)             echo "檔案" ;;
+    zh-CN:files)             echo "文件" ;;
+    ja:files)                echo "ファイル" ;;
+    *:files)                 echo "Files" ;;
+    zh-TW:identity)          echo "身分" ;;
+    zh-CN:identity)          echo "身份" ;;
+    ja:identity)             echo "ID" ;;
+    *:identity)              echo "Identity" ;;
+    zh-TW:resolved)          echo "解析結果" ;;
+    zh-CN:resolved)          echo "解析结果" ;;
+    ja:resolved)             echo "解決済み" ;;
+    *:resolved)              echo "Resolved" ;;
+    # Identity field labels
+    zh-TW:user)              echo "使用者" ;;
+    zh-CN:user)              echo "用户" ;;
+    ja:user)                 echo "ユーザー" ;;
+    *:user)                  echo "user" ;;
+    zh-TW:group)             echo "群組" ;;
+    zh-CN:group)             echo "组" ;;
+    ja:group)                echo "グループ" ;;
+    *:group)                 echo "group" ;;
+    zh-TW:hardware)          echo "硬體" ;;
+    zh-CN:hardware)          echo "硬件" ;;
+    ja:hardware)             echo "ハードウェア" ;;
+    *:hardware)              echo "hardware" ;;
+    zh-TW:image_tag)         echo "映像 / 標籤" ;;
+    zh-CN:image_tag)         echo "镜像 / 标签" ;;
+    ja:image_tag)            echo "イメージ / タグ" ;;
+    *:image_tag)             echo "image / tag" ;;
+    zh-TW:project)           echo "專案" ;;
+    zh-CN:project)           echo "项目" ;;
+    ja:project)              echo "プロジェクト" ;;
+    *:project)               echo "project" ;;
+    zh-TW:workspace)         echo "工作區" ;;
+    zh-CN:workspace)         echo "工作区" ;;
+    ja:workspace)            echo "ワークスペース" ;;
+    *:workspace)             echo "workspace" ;;
+    # Resolved field labels
+    zh-TW:gpu_enabled)       echo "GPU 已啟用" ;;
+    zh-CN:gpu_enabled)       echo "GPU 已启用" ;;
+    ja:gpu_enabled)          echo "GPU 有効" ;;
+    *:gpu_enabled)           echo "GPU enabled" ;;
+    zh-TW:count)             echo "數量" ;;
+    zh-CN:count)             echo "数量" ;;
+    ja:count)                echo "数量" ;;
+    *:count)                 echo "count" ;;
+    zh-TW:caps)              echo "能力" ;;
+    zh-CN:caps)              echo "能力" ;;
+    ja:caps)                 echo "ケーパビリティ" ;;
+    *:caps)                  echo "caps" ;;
+    zh-TW:gui_enabled)       echo "GUI 已啟用" ;;
+    zh-CN:gui_enabled)       echo "GUI 已启用" ;;
+    ja:gui_enabled)          echo "GUI 有効" ;;
+    *:gui_enabled)           echo "GUI enabled" ;;
+    zh-TW:network)           echo "網路" ;;
+    zh-CN:network)           echo "网络" ;;
+    ja:network)              echo "ネットワーク" ;;
+    *:network)               echo "network" ;;
+    zh-TW:privileged)        echo "特權" ;;
+    zh-CN:privileged)        echo "特权" ;;
+    ja:privileged)           echo "特権" ;;
+    *:privileged)            echo "privileged" ;;
+    # Hints / errors
+    zh-TW:conf_missing)      echo "(找不到 setup.conf — 執行 ./setup_tui.sh 或 ./%s.sh --setup)" ;;
+    zh-CN:conf_missing)      echo "(找不到 setup.conf — 运行 ./setup_tui.sh 或 ./%s.sh --setup)" ;;
+    ja:conf_missing)         echo "(setup.conf が見つかりません — ./setup_tui.sh または ./%s.sh --setup を実行してください)" ;;
+    *:conf_missing)          echo "(setup.conf not found — run ./setup_tui.sh or ./%s.sh --setup)" ;;
+    zh-TW:customize)         echo "自訂" ;;
+    zh-CN:customize)         echo "自定义" ;;
+    ja:customize)            echo "カスタマイズ" ;;
+    *:customize)             echo "Customize" ;;
+  esac
+}
+
 # _print_config_summary <tag>
 #
 # Print the resolved runtime config right before the main action
@@ -109,6 +200,9 @@ _dump_conf_section() {
 # Expects FILE_PATH + standard .env variables already in scope
 # (caller must `_load_env` first). Missing values render as "-".
 #
+# Labels honor ${_LANG} via `_lib_msg`; technical terms stay
+# untranslated (see _lib_msg header).
+#
 # Args:
 #   $1: short tag prefix for log lines (e.g. "build", "run")
 _print_config_summary() {
@@ -120,17 +214,18 @@ _print_config_summary() {
   local _proj="${PROJECT_NAME:-${DOCKER_HUB_USER:-local}-${IMAGE_NAME:-unknown}}"
 
   printf "[%s] %s\n" "${_tag}" "${_line}"
-  printf "[%s] Files\n" "${_tag}"
+  printf "[%s] %s\n" "${_tag}" "$(_lib_msg files)"
   printf "[%s]   setup.conf   : %s\n"   "${_tag}" "${_conf}"
   printf "[%s]   .env         : %s\n"   "${_tag}" "${_fp}/.env"
   printf "[%s]   compose.yaml : %s\n"   "${_tag}" "${_fp}/compose.yaml"
-  printf "[%s] Identity\n" "${_tag}"
-  printf "[%s]   user         : %s (uid=%s)  group=%s (gid=%s)\n" "${_tag}" \
-    "${USER_NAME:--}" "${USER_UID:--}" "${USER_GROUP:--}" "${USER_GID:--}"
-  printf "[%s]   hardware     : %s\n" "${_tag}" "${HARDWARE:--}"
-  printf "[%s]   image / tag  : %s\n" "${_tag}" "${_img}"
-  printf "[%s]   project      : %s\n" "${_tag}" "${_proj}"
-  printf "[%s]   workspace    : %s\n" "${_tag}" "${WS_PATH:--}"
+  printf "[%s] %s\n" "${_tag}" "$(_lib_msg identity)"
+  printf "[%s]   %-12s : %s (uid=%s)  %s=%s (gid=%s)\n" "${_tag}" \
+    "$(_lib_msg user)" "${USER_NAME:--}" "${USER_UID:--}" \
+    "$(_lib_msg group)" "${USER_GROUP:--}" "${USER_GID:--}"
+  printf "[%s]   %-12s : %s\n" "${_tag}" "$(_lib_msg hardware)" "${HARDWARE:--}"
+  printf "[%s]   %-12s : %s\n" "${_tag}" "$(_lib_msg image_tag)" "${_img}"
+  printf "[%s]   %-12s : %s\n" "${_tag}" "$(_lib_msg project)" "${_proj}"
+  printf "[%s]   %-12s : %s\n" "${_tag}" "$(_lib_msg workspace)" "${WS_PATH:--}"
 
   # setup.conf section-by-section dump. Each section prints only if
   # non-empty to stay readable. Order matches the TUI main menu so
@@ -148,23 +243,25 @@ _print_config_summary() {
       done <<< "${_content}"
     done
   else
-    printf "[%s]   (setup.conf not found — run ./setup_tui.sh or ./%s.sh --setup)\n" \
-      "${_tag}" "${_tag}"
+    # shellcheck disable=SC2059  # format string is intentional (i18n table owns %s)
+    printf "[%s]   $(_lib_msg conf_missing)\n" "${_tag}" "${_tag}"
   fi
 
   # Resolved post-merge flags that the user can't infer from setup.conf
   # alone (GPU/GUI depend on host detection in addition to mode=auto).
-  printf "[%s] Resolved\n" "${_tag}"
-  printf "[%s]   GPU enabled : %s  count=%s  caps=%s\n" "${_tag}" \
-    "${GPU_ENABLED:--}" "${GPU_COUNT:--}" "${GPU_CAPABILITIES:--}"
-  printf "[%s]   GUI enabled : %s\n" "${_tag}" "${SETUP_GUI_DETECTED:--}"
-  printf "[%s]   network     : %s  ipc=%s  privileged=%s\n" "${_tag}" \
-    "${NETWORK_MODE:--}" "${IPC_MODE:--}" "${PRIVILEGED:--}"
+  printf "[%s] %s\n" "${_tag}" "$(_lib_msg resolved)"
+  printf "[%s]   %s : %s  count=%s  caps=%s\n" "${_tag}" \
+    "$(_lib_msg gpu_enabled)" "${GPU_ENABLED:--}" "${GPU_COUNT:--}" "${GPU_CAPABILITIES:--}"
+  printf "[%s]   %s : %s\n" "${_tag}" \
+    "$(_lib_msg gui_enabled)" "${SETUP_GUI_DETECTED:--}"
+  printf "[%s]   %s     : %s  ipc=%s  %s=%s\n" "${_tag}" \
+    "$(_lib_msg network)" "${NETWORK_MODE:--}" "${IPC_MODE:--}" \
+    "$(_lib_msg privileged)" "${PRIVILEGED:--}"
   printf "[%s]   TZ=%s  apt_ubuntu=%s  apt_debian=%s\n" "${_tag}" \
     "${TZ:--}" "${APT_MIRROR_UBUNTU:--}" "${APT_MIRROR_DEBIAN:--}"
 
-  printf "[%s] Customize: ./setup_tui.sh  |  ./%s.sh --setup  |  edit setup.conf\n" \
-    "${_tag}" "${_tag}"
+  printf "[%s] %s: ./setup_tui.sh  |  ./%s.sh --setup  |  edit setup.conf\n" \
+    "${_tag}" "$(_lib_msg customize)" "${_tag}"
   printf "[%s] %s\n" "${_tag}" "${_line}"
 }
 

--- a/script/docker/_tui_conf.sh
+++ b/script/docker/_tui_conf.sh
@@ -170,6 +170,24 @@ _validate_build_network() {
   esac
 }
 
+# _validate_runtime <value>
+#
+# Validates [deploy] runtime override. Controls whether setup.sh emits
+# `runtime: nvidia` at service level in compose.yaml (needed on Jetson
+# / csv-mode nvidia-container-toolkit hosts).
+#   auto   — auto-detect Jetson (/etc/nv_tegra_release); emit on match
+#   nvidia — force emit on all hosts
+#   off    — never emit (Docker default runc)
+#   ""     — treated as off
+_validate_runtime() {
+  local _v="${1-}"
+  [[ -z "${_v}" ]] && return 0
+  case "${_v}" in
+    auto|nvidia|off) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # ════════════════════════════════════════════════════════════════════
 # Mount-string parsers
 # ════════════════════════════════════════════════════════════════════

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -542,6 +542,40 @@ _resolve_gui() {
   esac
 }
 
+# _detect_jetson
+#   True if running on Jetson (JetPack / L4T) — NVIDIA ships
+#   /etc/nv_tegra_release as the canonical marker on tegra-based boards.
+#   Env override: SETUP_DETECT_JETSON=true|false forces detection result
+#   (used by tests to avoid touching /etc/).
+_detect_jetson() {
+  if [[ -n "${SETUP_DETECT_JETSON:-}" ]]; then
+    [[ "${SETUP_DETECT_JETSON}" == "true" ]]
+    return
+  fi
+  [[ -f "/etc/nv_tegra_release" ]]
+}
+
+# _resolve_runtime <mode> <outvar>
+#   mode=nvidia → "nvidia" (force, e.g. desktop with csv-mode toolkit)
+#   mode=auto   → "nvidia" iff _detect_jetson, else ""
+#   mode=off|"" → "" (no runtime key emitted; Docker default runc)
+#
+# When non-empty, setup.sh emits `runtime: <value>` at service level in
+# compose.yaml. Required on Jetson because its nvidia-container-toolkit
+# runs in csv mode, which refuses the modern `--gpus` flow that
+# `deploy.resources.reservations.devices` translates to.
+_resolve_runtime() {
+  local _mode="${1:-off}"
+  local -n _rr_out="${2:?}"
+  case "${_mode}" in
+    nvidia) _rr_out="nvidia" ;;
+    auto)
+      if _detect_jetson; then _rr_out="nvidia"; else _rr_out=""; fi
+      ;;
+    off|""|*) _rr_out="" ;;
+  esac
+}
+
 # ════════════════════════════════════════════════════════════════════
 # _compute_conf_hash <base_path> <outvar>
 #
@@ -608,6 +642,7 @@ generate_compose_yaml() {
   local _user_build_args_str="${20:-}"
   local _target_arch="${21:-}"
   local _build_network="${22:-}"
+  local _runtime="${23:-}"
 
   # TARGETARCH line emitter: only when target_arch is set. Empty =
   # omit the line entirely so BuildKit auto-fills TARGETARCH from the
@@ -625,6 +660,16 @@ generate_compose_yaml() {
   _emit_build_network_line() {
     [[ -z "${_build_network}" ]] && return 0
     printf '      network: %s\n' "${_build_network}"
+  }
+
+  # runtime emitter: Jetson / csv-mode nvidia-container-toolkit hosts
+  # need `runtime: nvidia` at service level to bypass the modern
+  # --gpus flow (which `deploy.resources.reservations.devices`
+  # translates to). Empty = omit so Docker uses the default runc.
+  # Only emitted for the devel service; test doesn't run.
+  _emit_runtime_line() {
+    [[ -z "${_runtime}" ]] && return 0
+    printf '    runtime: %s\n' "${_runtime}"
   }
 
   # Convert space-separated caps to YAML array form [a, b, c]
@@ -691,6 +736,7 @@ YAML
     stdin_open: true
     tty: true
 YAML
+    _emit_runtime_line
     # cap_add / cap_drop / security_opt from [security] section
     if [[ -n "${_cap_add_str}" ]]; then
       echo "    cap_add:"
@@ -1156,12 +1202,13 @@ main() {
   local build_network=""
   _get_conf_value _build_k _build_v "network" "" build_network
 
-  local gpu_mode="" gpu_count="" gpu_caps=""
+  local gpu_mode="" gpu_count="" gpu_caps="" runtime_mode=""
   local gui_mode=""
   local net_mode="" ipc_mode="" privileged="" network_name=""
   _get_conf_value _dep_k _dep_v "gpu_mode"         "auto" gpu_mode
   _get_conf_value _dep_k _dep_v "gpu_count"        "all"  gpu_count
   _get_conf_value _dep_k _dep_v "gpu_capabilities" "gpu"  gpu_caps
+  _get_conf_value _dep_k _dep_v "runtime"          "auto" runtime_mode
   _get_conf_value _gui_k _gui_v "mode"             "auto" gui_mode
   _get_conf_value _net_k _net_v "mode"             "host" net_mode
   _get_conf_value _net_k _net_v "ipc"              "host" ipc_mode
@@ -1350,6 +1397,9 @@ main() {
     "${target_arch}" \
     "${build_network}"
 
+  local runtime_resolved=""
+  _resolve_runtime "${runtime_mode}" runtime_resolved
+
   generate_compose_yaml "${_base_path}/compose.yaml" "${image_name}" \
     "${gui_enabled_eff}" "${gpu_enabled_eff}" \
     "${gpu_count}" "${gpu_caps}" \
@@ -1361,7 +1411,8 @@ main() {
     "${_cgroup_rule_str}" \
     "${_user_build_args_str}" \
     "${target_arch}" \
-    "${build_network}"
+    "${build_network}" \
+    "${runtime_resolved}"
 
   printf "[setup] %s\n" "$(_msg env_done)"
   printf "[setup] USER=%s (%s:%s)  GPU=%s/%s  GUI=%s/%s  IMAGE=%s  WS=%s\n" \

--- a/script/docker/setup_tui.sh
+++ b/script/docker/setup_tui.sh
@@ -122,6 +122,10 @@ declare -gA _TUI_MSG_EN=(
   [deploy.caps.compute]="compute (CUDA compute)"
   [deploy.caps.utility]="utility (nvidia-smi, monitoring)"
   [deploy.caps.graphics]="graphics (OpenGL, Vulkan)"
+  [deploy.runtime.prompt]="Docker runtime override (Jetson / csv-mode toolkit)"
+  [deploy.runtime.auto]="auto (emit runtime: nvidia on Jetson — /etc/nv_tegra_release)"
+  [deploy.runtime.nvidia]="nvidia (force emit on all hosts)"
+  [deploy.runtime.off]="off (no runtime override — Docker default runc)"
   [deploy.mig.title]="Deploy — NVIDIA MIG detected"
   [deploy.mig.warning]=$'NVIDIA MIG (Multi-Instance GPU) mode is enabled on this host.\n\nDocker\'s deploy `count=N` reservation addresses whole GPUs; it cannot pin a specific MIG slice. To target one slice, leave count as-is and add to the [environment] section:\n  NVIDIA_VISIBLE_DEVICES=<MIG-UUID>\n\nAvailable GPU / MIG instances:\n%s'
   [gui.title]="GUI"
@@ -168,6 +172,7 @@ declare -gA _TUI_MSG_EN=(
   [err.invalid_mount]="Invalid mount format (expected <host>:<container>[:ro|rw])"
   [err.invalid_cgroup_rule]="Invalid cgroup rule (expected: <c|b|a> <major>:<minor|*> <r|w|m>)"
   [err.invalid_gpu_count]="Invalid GPU count (expected 'all' or a positive integer)"
+  [err.invalid_runtime]="Invalid runtime (expected 'auto', 'nvidia', or 'off')"
   [err.invalid_shm_size]=$'Invalid shm_size\n  - Expected: <num><unit>\n  - Units: b, k/kb, m/mb, g/gb (case-insensitive)\n  - Example: 2gb, 512mb'
   [err.invalid_port_mapping]=$'Invalid port mapping\n  - Expected: <host>:<container>[/tcp|udp]\n  - Example: 8080:80, 5000:5000/udp'
   [err.invalid_env_kv]=$'Invalid env var\n  - Expected: KEY=VALUE\n  - KEY must start with letter or _ and contain only [A-Za-z0-9_]'
@@ -270,6 +275,10 @@ declare -gA _TUI_MSG_ZH_TW=(
   [deploy.caps.compute]="compute（CUDA 運算）"
   [deploy.caps.utility]="utility（nvidia-smi、監控）"
   [deploy.caps.graphics]="graphics（OpenGL、Vulkan）"
+  [deploy.runtime.prompt]="Docker runtime 覆寫（Jetson / csv 模式 toolkit）"
+  [deploy.runtime.auto]="auto（Jetson 自動輸出 runtime: nvidia — /etc/nv_tegra_release）"
+  [deploy.runtime.nvidia]="nvidia（所有主機強制輸出）"
+  [deploy.runtime.off]="off（不覆寫 — Docker 預設 runc）"
   [deploy.mig.title]="Deploy — 偵測到 NVIDIA MIG"
   [deploy.mig.warning]=$'此主機已啟用 NVIDIA MIG（Multi-Instance GPU）模式。\n\nDocker 的 deploy `count=N` 只能預留整張 GPU，無法指定特定 MIG slice。若要使用單一 slice，請維持 count 不變，並在 [environment] 區塊加入：\n  NVIDIA_VISIBLE_DEVICES=<MIG-UUID>\n\n主機上的 GPU / MIG 實例：\n%s'
   [gui.title]="GUI"
@@ -316,6 +325,7 @@ declare -gA _TUI_MSG_ZH_TW=(
   [err.invalid_mount]="掛載格式錯誤（預期 <host>:<container>[:ro|rw]）"
   [err.invalid_cgroup_rule]="Cgroup 規則格式錯誤（預期：<c|b|a> <major>:<minor|*> <r|w|m>）"
   [err.invalid_gpu_count]="GPU 數量格式錯誤（預期 'all' 或正整數）"
+  [err.invalid_runtime]="runtime 值不合法（預期 'auto'、'nvidia' 或 'off'）"
   [err.invalid_shm_size]=$'shm_size 格式錯誤\n  - 預期：<數字><單位>\n  - 單位：b、k/kb、m/mb、g/gb（大小寫不限）\n  - 範例：2gb、512mb'
   [err.invalid_port_mapping]=$'Port 映射格式錯誤\n  - 預期：<host>:<container>[/tcp|udp]\n  - 範例：8080:80、5000:5000/udp'
   [err.invalid_env_kv]=$'環境變數格式錯誤\n  - 預期：KEY=VALUE\n  - KEY 需以字母或 _ 開頭，僅含 [A-Za-z0-9_]'
@@ -416,6 +426,10 @@ declare -gA _TUI_MSG_ZH_CN=(
   [deploy.caps.compute]="compute（CUDA 计算）"
   [deploy.caps.utility]="utility（nvidia-smi、监控）"
   [deploy.caps.graphics]="graphics（OpenGL、Vulkan）"
+  [deploy.runtime.prompt]="Docker runtime 覆盖（Jetson / csv 模式 toolkit）"
+  [deploy.runtime.auto]="auto（Jetson 自动输出 runtime: nvidia — /etc/nv_tegra_release）"
+  [deploy.runtime.nvidia]="nvidia（所有主机强制输出）"
+  [deploy.runtime.off]="off（不覆盖 — Docker 默认 runc）"
   [deploy.mig.title]="Deploy — 检测到 NVIDIA MIG"
   [deploy.mig.warning]=$'此主机已启用 NVIDIA MIG（Multi-Instance GPU）模式。\n\nDocker 的 deploy `count=N` 只能预留整张 GPU，无法指定特定 MIG slice。若要使用单一 slice，请保持 count 不变，并在 [environment] 区块加入：\n  NVIDIA_VISIBLE_DEVICES=<MIG-UUID>\n\n主机上的 GPU / MIG 实例：\n%s'
   [gui.title]="GUI"
@@ -462,6 +476,7 @@ declare -gA _TUI_MSG_ZH_CN=(
   [err.invalid_mount]="挂载格式错误（预期 <host>:<container>[:ro|rw]）"
   [err.invalid_cgroup_rule]="Cgroup 规则格式错误（预期：<c|b|a> <major>:<minor|*> <r|w|m>）"
   [err.invalid_gpu_count]="GPU 数量格式错误（预期 'all' 或正整数）"
+  [err.invalid_runtime]="runtime 值不合法（预期 'auto'、'nvidia' 或 'off'）"
   [err.no_backend]="未安装 dialog 或 whiptail，请执行：sudo apt install dialog"
   [saved]="已保存至 %s，正在重新生成 .env + compose.yaml..."
   [action.prompt]="选择动作"
@@ -557,6 +572,10 @@ declare -gA _TUI_MSG_JA=(
   [deploy.caps.compute]="compute（CUDA 計算）"
   [deploy.caps.utility]="utility（nvidia-smi、監視）"
   [deploy.caps.graphics]="graphics（OpenGL、Vulkan）"
+  [deploy.runtime.prompt]="Docker ランタイムオーバーライド（Jetson / csv モード toolkit）"
+  [deploy.runtime.auto]="auto（Jetson で自動的に runtime: nvidia を出力 — /etc/nv_tegra_release）"
+  [deploy.runtime.nvidia]="nvidia（全ホストで強制出力）"
+  [deploy.runtime.off]="off（オーバーライドなし — Docker 既定の runc）"
   [deploy.mig.title]="Deploy — NVIDIA MIG を検出"
   [deploy.mig.warning]=$'このホストでは NVIDIA MIG（Multi-Instance GPU）モードが有効です。\n\nDocker の deploy `count=N` は GPU 単位の予約であり、特定の MIG スライスを指定できません。特定スライスを使う場合は count を変更せず、[environment] セクションに次を追加してください：\n  NVIDIA_VISIBLE_DEVICES=<MIG-UUID>\n\nホストで利用可能な GPU / MIG インスタンス：\n%s'
   [gui.title]="GUI"
@@ -603,6 +622,7 @@ declare -gA _TUI_MSG_JA=(
   [err.invalid_mount]="マウント形式が不正（<host>:<container>[:ro|rw] を期待）"
   [err.invalid_cgroup_rule]="Cgroup ルール形式が不正（<c|b|a> <major>:<minor|*> <r|w|m> を期待）"
   [err.invalid_gpu_count]="GPU 数が不正（'all' または正の整数を期待）"
+  [err.invalid_runtime]="無効な runtime（'auto'、'nvidia'、'off' のいずれか）"
   [err.no_backend]="dialog または whiptail がインストールされていません：sudo apt install dialog"
   [saved]="%s に保存しました。.env + compose.yaml を再生成中..."
   [action.prompt]="アクションを選択"
@@ -1222,6 +1242,19 @@ _edit_section_deploy() {
   _v="$(echo "${_v}" | tr '\n' ' ' | sed -e 's/ *$//')"
   [[ -z "${_v}" ]] && _v="gpu"
   _override_set "deploy.gpu_capabilities" "${_v}"
+
+  # runtime override (Jetson / csv-mode nvidia-container-toolkit).
+  _cur="$(_override_get "deploy.runtime" "auto")"
+  _v="$(_tui_select "$(_tui_msg deploy.title)" "$(_tui_msg deploy.runtime.prompt)" \
+    auto   "$(_tui_msg deploy.runtime.auto)"   "$([[ "${_cur}" == auto ]]   && echo ON || echo off)" \
+    nvidia "$(_tui_msg deploy.runtime.nvidia)" "$([[ "${_cur}" == nvidia ]] && echo ON || echo off)" \
+    off    "$(_tui_msg deploy.runtime.off)"    "$([[ "${_cur}" == off ]]    && echo ON || echo off)")" \
+    || return 0
+  if _validate_runtime "${_v}"; then
+    _override_set "deploy.runtime" "${_v}"
+  else
+    _tui_msgbox "$(_tui_msg deploy.title)" "$(_tui_msg err.invalid_runtime)"
+  fi
 }
 
 _edit_section_gui() {

--- a/setup.conf
+++ b/setup.conf
@@ -116,10 +116,23 @@ arg_3 = TZ=Asia/Taipei
 #                     utility     nvidia-smi etc.
 #                     graphics    OpenGL/Vulkan rendering.
 #                   Combine by space: "compute utility graphics"
+#
+# runtime           Docker runtime override (emitted as `runtime:` at
+#                   service level in compose.yaml). Needed on Jetson
+#                   (JetPack) because its nvidia-container-toolkit runs
+#                   in csv mode and refuses the modern `--gpus` flow
+#                   that deploy.resources.reservations.devices uses.
+#                     auto     Emit runtime: nvidia on Jetson
+#                              (detected via /etc/nv_tegra_release),
+#                              omit on desktop (default).
+#                     nvidia   Force emit runtime: nvidia on all hosts
+#                              (e.g. csv-mode toolkit on x86).
+#                     off      Never emit (Docker default runc).
 [deploy]
 gpu_mode = auto
 gpu_count = all
 gpu_capabilities = gpu compute utility graphics
+runtime = auto
 
 # ═════════════════════════════════════════════════════════════════════
 # [gui] — GUI display support

--- a/test/unit/compose_gen_spec.bats
+++ b/test/unit/compose_gen_spec.bats
@@ -458,3 +458,47 @@ teardown() {
   run grep -F 'device_cgroup_rules:' "${COMPOSE_OUT}"
   assert_failure
 }
+
+# ════════════════════════════════════════════════════════════════════
+# [deploy] runtime → compose.yaml service-level runtime key (Jetson)
+# ════════════════════════════════════════════════════════════════════
+
+@test "generate_compose_yaml omits runtime: when runtime arg is empty (desktop default)" {
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras
+  run grep -E '^    runtime:' "${COMPOSE_OUT}"
+  assert_failure
+}
+
+@test "generate_compose_yaml emits runtime: nvidia under devel when runtime=nvidia" {
+  local _extras=()
+  # positional args 1..22 unchanged; 23rd is _runtime.
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "true" "all" "gpu" _extras "" \
+    "" "" "" "" \
+    "" "host" "host" "" "" "" \
+    "" "" "" "" \
+    "nvidia"
+  run grep -F '    runtime: nvidia' "${COMPOSE_OUT}"
+  assert_success
+  # Only in devel (one occurrence); test service must not get runtime:
+  [ "$(grep -c '^    runtime:' "${COMPOSE_OUT}")" = "1" ]
+}
+
+@test "generate_compose_yaml placement: runtime: appears between tty and cap_add region" {
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "true" "all" "gpu" _extras "" \
+    "" "" "" "" \
+    "" "host" "host" "SYS_ADMIN" "" "" \
+    "" "" "" "" \
+    "nvidia"
+  # runtime: must appear after `tty: true` and before `cap_add:` in devel
+  local _tty_line _runtime_line _cap_line
+  _tty_line="$(grep -n '^    tty: true' "${COMPOSE_OUT}" | head -1 | cut -d: -f1)"
+  _runtime_line="$(grep -n '^    runtime:' "${COMPOSE_OUT}" | head -1 | cut -d: -f1)"
+  _cap_line="$(grep -n '^    cap_add:' "${COMPOSE_OUT}" | head -1 | cut -d: -f1)"
+  (( _tty_line < _runtime_line ))
+  (( _runtime_line < _cap_line ))
+}

--- a/test/unit/lib_spec.bats
+++ b/test/unit/lib_spec.bats
@@ -331,3 +331,106 @@ EOF
   assert_output --partial "setup.conf not found"
   assert_output --partial "./setup_tui.sh"
 }
+
+# ── _lib_msg / _print_config_summary i18n ──────────────────────────────────
+
+@test "_lib_msg returns English by default" {
+  run bash -c "source ${LIB}; unset _LANG; echo \"\$(_lib_msg files)|\$(_lib_msg identity)|\$(_lib_msg resolved)|\$(_lib_msg customize)\""
+  assert_success
+  assert_output "Files|Identity|Resolved|Customize"
+}
+
+@test "_lib_msg returns zh-TW translations" {
+  run bash -c "source ${LIB}; _LANG=zh-TW; echo \"\$(_lib_msg files)|\$(_lib_msg identity)|\$(_lib_msg user)|\$(_lib_msg hardware)|\$(_lib_msg gpu_enabled)|\$(_lib_msg network)\""
+  assert_success
+  assert_output "檔案|身分|使用者|硬體|GPU 已啟用|網路"
+}
+
+@test "_lib_msg returns zh-CN translations" {
+  run bash -c "source ${LIB}; _LANG=zh-CN; echo \"\$(_lib_msg files)|\$(_lib_msg user)|\$(_lib_msg hardware)|\$(_lib_msg workspace)\""
+  assert_success
+  assert_output "文件|用户|硬件|工作区"
+}
+
+@test "_lib_msg returns ja translations" {
+  run bash -c "source ${LIB}; _LANG=ja; echo \"\$(_lib_msg files)|\$(_lib_msg identity)|\$(_lib_msg user)|\$(_lib_msg hardware)\""
+  assert_success
+  assert_output "ファイル|ID|ユーザー|ハードウェア"
+}
+
+@test "_lib_msg falls back to English for unknown _LANG value" {
+  # unknown locale should not silently output empty — falls through to *:.
+  run bash -c "source ${LIB}; _LANG=de; echo \"\$(_lib_msg files)|\$(_lib_msg identity)\""
+  assert_success
+  assert_output "Files|Identity"
+}
+
+@test "_print_config_summary uses zh-TW labels when _LANG=zh-TW" {
+  local _fp="${BATS_TEST_TMPDIR}"
+  _write_sample_conf "${_fp}/setup.conf"
+  run bash -c "
+    source ${LIB}
+    _LANG=zh-TW
+    FILE_PATH='${_fp}'
+    USER_NAME=alice USER_UID=1000 USER_GROUP=alice USER_GID=1000
+    HARDWARE=aarch64 DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
+    WS_PATH=/home/alice/work
+    GPU_ENABLED=true GPU_COUNT=all GPU_CAPABILITIES='gpu compute'
+    SETUP_GUI_DETECTED=false NETWORK_MODE=host IPC_MODE=host PRIVILEGED=true
+    TZ=Asia/Taipei APT_MIRROR_UBUNTU=tw.archive.ubuntu.com
+    APT_MIRROR_DEBIAN=mirror.twds.com.tw
+    PROJECT_NAME=alice-myrepo
+    _print_config_summary run
+  "
+  assert_success
+  # Translated section headings
+  assert_output --partial "[run] 檔案"
+  assert_output --partial "[run] 身分"
+  assert_output --partial "[run] 解析結果"
+  # Translated field labels
+  assert_output --partial "使用者"
+  assert_output --partial "硬體"
+  assert_output --partial "工作區"
+  assert_output --partial "GPU 已啟用"
+  assert_output --partial "GUI 已啟用"
+  assert_output --partial "網路"
+  assert_output --partial "特權"
+  # Customize hint translated
+  assert_output --partial "自訂:"
+  # English key labels preserved (technical terms / .env var names)
+  assert_output --partial "TZ=Asia/Taipei"
+  assert_output --partial "ipc=host"
+}
+
+@test "_print_config_summary uses ja labels when _LANG=ja" {
+  local _fp="${BATS_TEST_TMPDIR}"
+  _write_sample_conf "${_fp}/setup.conf"
+  run bash -c "
+    source ${LIB}
+    _LANG=ja
+    FILE_PATH='${_fp}'
+    USER_NAME=alice USER_UID=1000 USER_GROUP=alice USER_GID=1000
+    HARDWARE=x86_64 DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
+    WS_PATH=/home/alice/work
+    GPU_ENABLED=true GPU_COUNT=all GPU_CAPABILITIES='gpu'
+    SETUP_GUI_DETECTED=true NETWORK_MODE=host IPC_MODE=host PRIVILEGED=false
+    PROJECT_NAME=alice-myrepo
+    _print_config_summary build
+  "
+  assert_success
+  assert_output --partial "[build] ファイル"
+  assert_output --partial "[build] ID"
+  assert_output --partial "[build] 解決済み"
+  assert_output --partial "ユーザー"
+  assert_output --partial "ハードウェア"
+  assert_output --partial "ワークスペース"
+}
+
+@test "_print_config_summary conf_missing hint is translated (zh-TW)" {
+  local _fp="${BATS_TEST_TMPDIR}/no_conf_zh"
+  mkdir -p "${_fp}"
+  run bash -c "source ${LIB}; _LANG=zh-TW; FILE_PATH='${_fp}'; _print_config_summary build"
+  assert_success
+  assert_output --partial "找不到 setup.conf"
+  assert_output --partial "./build.sh --setup"
+}

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -488,6 +488,54 @@ EOF
 }
 
 # ════════════════════════════════════════════════════════════════════
+# _resolve_runtime / _detect_jetson (Jetson NVIDIA runtime)
+# ════════════════════════════════════════════════════════════════════
+
+@test "_detect_jetson honors SETUP_DETECT_JETSON=true override" {
+  SETUP_DETECT_JETSON=true _detect_jetson
+}
+
+@test "_detect_jetson honors SETUP_DETECT_JETSON=false override" {
+  ! SETUP_DETECT_JETSON=false _detect_jetson
+}
+
+@test "_resolve_runtime auto on Jetson => nvidia" {
+  local _out
+  SETUP_DETECT_JETSON=true _resolve_runtime "auto" _out
+  assert_equal "${_out}" "nvidia"
+}
+
+@test "_resolve_runtime auto off Jetson => empty" {
+  local _out
+  SETUP_DETECT_JETSON=false _resolve_runtime "auto" _out
+  assert_equal "${_out}" ""
+}
+
+@test "_resolve_runtime nvidia => always nvidia" {
+  local _out
+  SETUP_DETECT_JETSON=false _resolve_runtime "nvidia" _out
+  assert_equal "${_out}" "nvidia"
+}
+
+@test "_resolve_runtime off => empty" {
+  local _out
+  SETUP_DETECT_JETSON=true _resolve_runtime "off" _out
+  assert_equal "${_out}" ""
+}
+
+@test "_resolve_runtime empty => empty" {
+  local _out
+  SETUP_DETECT_JETSON=true _resolve_runtime "" _out
+  assert_equal "${_out}" ""
+}
+
+@test "_resolve_runtime unknown mode falls through to empty (safe default)" {
+  local _out
+  SETUP_DETECT_JETSON=true _resolve_runtime "garbage" _out
+  assert_equal "${_out}" ""
+}
+
+# ════════════════════════════════════════════════════════════════════
 # detect_image_name (now reads [image] rules from setup.conf)
 # ════════════════════════════════════════════════════════════════════
 

--- a/test/unit/tui_spec.bats
+++ b/test/unit/tui_spec.bats
@@ -250,6 +250,31 @@ teardown() {
 }
 
 # ════════════════════════════════════════════════════════════════════
+# _validate_runtime
+# ════════════════════════════════════════════════════════════════════
+
+@test "_validate_runtime accepts empty (treated as off)" {
+  _validate_runtime ""
+}
+
+@test "_validate_runtime accepts auto / nvidia / off" {
+  _validate_runtime auto
+  _validate_runtime nvidia
+  _validate_runtime off
+}
+
+@test "_validate_runtime rejects unknown values" {
+  run _validate_runtime "NVIDIA"   # case-sensitive
+  [ "${status}" -ne 0 ]
+  run _validate_runtime "runc"     # not a supported override
+  [ "${status}" -ne 0 ]
+  run _validate_runtime "sysbox"
+  [ "${status}" -ne 0 ]
+  run _validate_runtime "true"
+  [ "${status}" -ne 0 ]
+}
+
+# ════════════════════════════════════════════════════════════════════
 # _warn_if_lang_rejected — TUI msgbox when --lang fell back to "en"
 # ════════════════════════════════════════════════════════════════════
 #


### PR DESCRIPTION
## Summary

Two tightly-scoped features driven by v0.9.8 Jetson feedback.

### Commit 1 — `feat(lib): i18n _print_config_summary labels`
Agent A's v0.9.7 i18n PR explicitly scoped `_lib.sh`'s summary out. Users running `./run.sh --lang zh-TW` on Jetson reported the output still looked mostly English because the summary is ~90% of it. New `_lib_msg` table covers Files / Identity / Resolved / Customize headings, Identity labels (user / group / hardware / image / tag / project / workspace), and Resolved labels (GPU enabled / GUI enabled / network / privileged) in four languages. Technical identifiers (file names, INI section names, .env variable names, command strings) stay untranslated.

### Commit 2 — `feat(deploy): add runtime key with Jetson auto-detect`
Jetson's nvidia-container-toolkit runs in csv mode; the modern `--gpus` flow that `deploy.resources.reservations.devices` translates to fails with `invoking the NVIDIA Container Runtime Hook directly ... is not supported`. New `[deploy] runtime` key emits `runtime: nvidia` at service level so Jetson containers launch with the legacy `--runtime=nvidia` path. `auto` auto-detects via `/etc/nv_tegra_release`, `nvidia` forces, `off` suppresses. TUI has a matching picker in `[deploy]` section with 4-language i18n and `_validate_runtime`.

## Test plan
- [ ] CI `test` + `Integration E2E` green
- [ ] After merge: tag v0.9.9, push tag
- [ ] Downstream upgrade: ros1_bridge `./template/upgrade.sh v0.9.9`, verify `./run.sh` produces compose.yaml with `runtime: nvidia` on Jetson