### PR TITLE
test: coverage audit fills + i18n.sh localisation + #103 fix

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`_lib.sh` fallback `_detect_lang` returned `"zh"` for `zh_TW` (issue
+  #103)** — a copy-paste typo in the fallback used when `i18n.sh` is
+  absent (the Dockerfile `/lint` stage). All other detection sites
+  (`i18n.sh`, `build.sh`, `run.sh`) return `"zh-TW"`; the inconsistent
+  `"zh"` meant zh-TW users in that code path fell through to English
+  because the i18n tables are keyed on `zh-TW:`, not `zh:`. Fixed to
+  `"zh-TW"` with a locked-in regression test that spins up `_lib.sh`
+  without a sibling `i18n.sh` and asserts its fallback agrees with the
+  primary for every supported locale.
+
+### Changed
+- **`_sanitize_lang` warning now localises to the system `$LANG`**. v0.9.7
+  Agent A scoped this helper out of i18n; a user with `LANG=zh_TW.UTF-8`
+  who typed `--lang xxx` still saw an English WARNING. Now we re-detect
+  from the system env (can't trust `_LANG` — it holds the invalid input
+  the user just passed) and print the warning in zh-TW / zh-CN / ja
+  where applicable, falling back to English for other locales.
+
+### Added
+- **Coverage audit follow-up (+9 unit tests)**. Kcov run flagged four
+  small untested branches in `_lib.sh` and `_tui_conf.sh`; filling them
+  raised non-TUI coverage from 94.4% → 95.7%. New tests:
+  - `_lib_msg count` / `caps` translation keys exercised in all four
+    languages (previously only Files / Identity / etc. were asserted).
+  - `_mount_container_path` helper — four cases (plain /
+    with-mode / env-var-interpolated / no-colon fallback). The symmetric
+    `_mount_host_path` was already covered; the container-side parser
+    had zero unit tests.
+  - `_upsert_conf_value` "section not found" branch — appends a fresh
+    `[section]` header + key when called against a conf that doesn't
+    yet have that section.
+  - `_upsert_conf_value` "section present, key absent at EOF" branch —
+    appends the key to the last section when target key isn't there.
+  - `_write_setup_conf` final-section override flush — an override key
+    whose target is the LAST section in the template gets emitted
+    via the EOF-flush path (previously only the mid-file append branch
+    was asserted).
+  - `_write_setup_conf` removed_keys + flush interplay — ensures a key
+    listed in `removed_keys` does NOT reappear via the EOF flush.
+
+  TUI interactive flows (`_edit_section_*`) in `setup_tui.sh` remain
+  at ~17% — they require a dialog/whiptail stub framework to drive,
+  cost doesn't justify coverage-for-its-own-sake. `setup_tui.sh`
+  validators / I/O helpers are covered at unit level via `tui_spec`.
+
 ## [v0.9.10] - 2026-04-24
 
 ### Added

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **632 tests** total (589 unit + 43 integration).
+Template self-tests: **645 tests** total (602 unit + 43 integration).
 
 ## Test Files
 
-### test/unit/lib_spec.bats (34)
+### test/unit/lib_spec.bats (39)
 
 | Test | Description |
 |------|-------------|
@@ -61,7 +61,7 @@ writeback (first-time bootstrap / user-edit respect / opt-out).
 | `[build]` apt_mirror (empty fallback, override) | 2 |
 | Workspace writeback (first-time, respect user edit, opt-out) | 3 |
 
-### test/unit/tui_spec.bats (73)
+### test/unit/tui_spec.bats (81)
 
 Pure-logic unit tests for the TUI support libraries (`_tui_conf.sh`).
 No dialog/whiptail invocations here — strictly validators, mount-string

--- a/script/docker/_lib.sh
+++ b/script/docker/_lib.sh
@@ -17,9 +17,14 @@ fi
 _DOCKER_LIB_SOURCED=1
 
 # _detect_lang prints the language code derived from $LANG.
+# KEEP IN SYNC with i18n.sh's _detect_lang (this is a fallback used
+# only when i18n.sh is missing, e.g. the Dockerfile /lint stage).
+# Returning "zh" here was a copy-paste typo (issue #103) — all other
+# detection sites return "zh-TW", so the i18n table keyed on zh-TW:
+# would miss and fall through to English messages.
 _detect_lang() {
   case "${LANG:-}" in
-    zh_TW*) echo "zh" ;;
+    zh_TW*) echo "zh-TW" ;;
     zh_CN*|zh_SG*) echo "zh-CN" ;;
     ja*) echo "ja" ;;
     *) echo "en" ;;

--- a/script/docker/i18n.sh
+++ b/script/docker/i18n.sh
@@ -25,19 +25,41 @@ _detect_lang() {
 # _sanitize_lang <outvar_name> [<script_name>]
 #
 # Reads the current value of the nameref, and if it's not in
-# {en, zh-TW, zh-CN, ja} prints a WARNING to stderr and rewrites
+# {en, zh-TW, zh-CN, ja} prints a warning to stderr and rewrites
 # the nameref to "en". Callers invoke this right after parsing
 # --lang so typos don't silently fall through to English at message
 # lookup time (visible warning, safe default, non-fatal).
+#
+# Warning language: the user just demonstrated they don't know the
+# right --lang value, so we can't trust _LANG (it holds the invalid
+# input). Instead we re-detect from the system's $LANG env var so
+# the warning appears in the user's actual locale.
 _sanitize_lang() {
   local -n _sl_ref="${1:?"${FUNCNAME[0]}: missing outvar name"}"
   local _who="${2:-tui}"
   case "${_sl_ref}" in
     en|zh-TW|zh-CN|ja) return 0 ;;
   esac
-  printf "[%s] WARNING: unsupported --lang value %q, falling back to 'en'\n" \
-    "${_who}" "${_sl_ref}" >&2
-  printf "[%s]          allowed: en | zh-TW | zh-CN | ja\n" "${_who}" >&2
+  local _sys_lang
+  _sys_lang="$(_detect_lang)"
+  case "${_sys_lang}" in
+    zh-TW)
+      printf "[%s] 警告：不支援的 --lang 值 %q，改用 'en'\n" "${_who}" "${_sl_ref}" >&2
+      printf "[%s]       可用值：en | zh-TW | zh-CN | ja\n" "${_who}" >&2
+      ;;
+    zh-CN)
+      printf "[%s] 警告：不支持的 --lang 值 %q，改用 'en'\n" "${_who}" "${_sl_ref}" >&2
+      printf "[%s]       可用值：en | zh-TW | zh-CN | ja\n" "${_who}" >&2
+      ;;
+    ja)
+      printf "[%s] 警告: サポート外の --lang 値 %q, 'en' にフォールバックします\n" "${_who}" "${_sl_ref}" >&2
+      printf "[%s]       利用可能: en | zh-TW | zh-CN | ja\n" "${_who}" >&2
+      ;;
+    *)
+      printf "[%s] WARNING: unsupported --lang value %q, falling back to 'en'\n" "${_who}" "${_sl_ref}" >&2
+      printf "[%s]          allowed: en | zh-TW | zh-CN | ja\n" "${_who}" >&2
+      ;;
+  esac
   _sl_ref="en"
 }
 

--- a/test/unit/lib_spec.bats
+++ b/test/unit/lib_spec.bats
@@ -50,6 +50,27 @@ setup() {
   assert_output "ja"
 }
 
+@test "_lib.sh fallback _detect_lang (no i18n.sh) agrees with primary for every locale (#103)" {
+  # _lib.sh's fallback `_detect_lang` only fires when i18n.sh is
+  # absent (Dockerfile /lint stage). v0.9.10 had a copy-paste typo
+  # returning "zh" for zh_TW where i18n.sh returns "zh-TW" — zh-TW
+  # users in /lint would fall through to English messages because
+  # the i18n tables are keyed on "zh-TW:", not "zh:". Guard against
+  # the four fallbacks drifting again: copy _lib.sh to a temp dir
+  # without i18n.sh so the `else` branch fires, then compare.
+  local _tmp="${BATS_TEST_TMPDIR}/lib_no_i18n"
+  mkdir -p "${_tmp}"
+  cp "${LIB}" "${_tmp}/_lib.sh"
+  # Deliberately NOT copying i18n.sh → fallback _detect_lang runs.
+
+  local _locale _got _want
+  for _locale in en_US.UTF-8 zh_TW.UTF-8 zh_CN.UTF-8 zh_SG.UTF-8 ja_JP.UTF-8; do
+    _got="$(env LANG="${_locale}" bash -c "source '${_tmp}/_lib.sh'; echo \"\${_LANG}\"")"
+    _want="$(env LANG="${_locale}" bash -c "source '${LIB%/*}/i18n.sh'; echo \"\${_LANG}\"")"
+    assert_equal "${_got}" "${_want}"
+  done
+}
+
 # ── double-source guard ─────────────────────────────────────────────────────
 
 @test "_lib.sh is idempotent when sourced twice" {
@@ -166,8 +187,9 @@ EOF
   assert_output "ja"
 }
 
-@test "_sanitize_lang warns and falls back to 'en' for unsupported values" {
-  run bash -c "source ${LIB}; v=foo; _sanitize_lang v test 2>&1; echo \"--VALUE=\${v}\""
+@test "_sanitize_lang warns and falls back to 'en' for unsupported values (English default)" {
+  # Locale-agnostic / English system: English WARNING is emitted.
+  run bash -c "unset LANG; source ${LIB}; v=foo; _sanitize_lang v test 2>&1; echo \"--VALUE=\${v}\""
   assert_success
   assert_output --partial "WARNING"
   assert_output --partial "foo"
@@ -175,10 +197,36 @@ EOF
 }
 
 @test "_sanitize_lang warns for the old bare 'zh' code (post zh→zh-TW rename)" {
-  run bash -c "source ${LIB}; v=zh; _sanitize_lang v tui 2>&1; echo \"--VALUE=\${v}\""
+  run bash -c "unset LANG; source ${LIB}; v=zh; _sanitize_lang v tui 2>&1; echo \"--VALUE=\${v}\""
   assert_success
   assert_output --partial "WARNING"
   assert_output --partial "--VALUE=en"
+}
+
+@test "_sanitize_lang warning is localized to system LANG (zh-TW)" {
+  # Regression: v0.9.7 Agent A scoped this helper out of i18n coverage.
+  # v0.9.11 localizes the warning using the SYSTEM LANG (not _LANG,
+  # which holds the invalid input), so a user whose shell is zh-TW sees
+  # the warning in Traditional Chinese rather than English.
+  run env LANG=zh_TW.UTF-8 bash -c "source ${LIB}; v=foo; _sanitize_lang v test 2>&1"
+  assert_success
+  assert_output --partial "警告"
+  assert_output --partial "foo"
+  refute_output --partial "WARNING"
+}
+
+@test "_sanitize_lang warning is localized to system LANG (zh-CN)" {
+  run env LANG=zh_CN.UTF-8 bash -c "source ${LIB}; v=foo; _sanitize_lang v test 2>&1"
+  assert_success
+  assert_output --partial "警告"
+  refute_output --partial "WARNING"
+}
+
+@test "_sanitize_lang warning is localized to system LANG (ja)" {
+  run env LANG=ja_JP.UTF-8 bash -c "source ${LIB}; v=foo; _sanitize_lang v test 2>&1"
+  assert_success
+  assert_output --partial "警告: サポート外"
+  refute_output --partial "WARNING"
 }
 
 # ── _dump_conf_section / _print_config_summary ─────────────────────────────
@@ -356,6 +404,27 @@ EOF
   run bash -c "source ${LIB}; _LANG=ja; echo \"\$(_lib_msg files)|\$(_lib_msg identity)|\$(_lib_msg user)|\$(_lib_msg hardware)\""
   assert_success
   assert_output "ファイル|ID|ユーザー|ハードウェア"
+}
+
+@test "_lib_msg returns count / caps across all languages" {
+  # Regression: these two keys are only invoked inline in the
+  # "Resolved" block of _print_config_summary and were missed by
+  # spot-check assertions; kcov flagged both branches as uncovered.
+  run bash -c "source ${LIB}; _LANG=en; echo \"\$(_lib_msg count)|\$(_lib_msg caps)\""
+  assert_success
+  assert_output "count|caps"
+
+  run bash -c "source ${LIB}; _LANG=zh-TW; echo \"\$(_lib_msg count)|\$(_lib_msg caps)\""
+  assert_success
+  assert_output "數量|能力"
+
+  run bash -c "source ${LIB}; _LANG=zh-CN; echo \"\$(_lib_msg count)|\$(_lib_msg caps)\""
+  assert_success
+  assert_output "数量|能力"
+
+  run bash -c "source ${LIB}; _LANG=ja; echo \"\$(_lib_msg count)|\$(_lib_msg caps)\""
+  assert_success
+  assert_output "数量|ケーパビリティ"
 }
 
 @test "_lib_msg falls back to English for unknown _LANG value" {

--- a/test/unit/tui_spec.bats
+++ b/test/unit/tui_spec.bats
@@ -387,6 +387,34 @@ teardown() {
 }
 
 # ════════════════════════════════════════════════════════════════════
+# _mount_container_path
+# ════════════════════════════════════════════════════════════════════
+
+@test "_mount_container_path extracts plain container path" {
+  local _cont=""
+  _mount_container_path "/data:/data" _cont
+  assert_equal "${_cont}" "/data"
+}
+
+@test "_mount_container_path extracts container path with mode" {
+  local _cont=""
+  _mount_container_path "/data:/data:ro" _cont
+  assert_equal "${_cont}" "/data"
+}
+
+@test "_mount_container_path extracts container path with env var" {
+  local _cont=""
+  _mount_container_path '${WS_PATH}:/home/${USER_NAME}/work' _cont
+  assert_equal "${_cont}" '/home/${USER_NAME}/work'
+}
+
+@test "_mount_container_path empty when input has no colon" {
+  local _cont="sentinel"
+  _mount_container_path "/standalone" _cont
+  assert_equal "${_cont}" ""
+}
+
+# ════════════════════════════════════════════════════════════════════
 # _load_setup_conf_full + _write_setup_conf (INI round-trip)
 # ════════════════════════════════════════════════════════════════════
 
@@ -571,6 +599,84 @@ EOF
 
   run grep '^rules' "${TEMP_DIR}/setup.conf"
   [[ "${output}" == "rules = @default:foo" ]]
+}
+
+@test "_upsert_conf_value creates section + key when section absent" {
+  # Coverage gap: `Section not found at all → append new section + key`
+  # branch at the tail of _upsert_conf_value was never exercised.
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[image]
+rule_1 = @default:foo
+EOF
+  _upsert_conf_value "${TEMP_DIR}/setup.conf" "volumes" "mount_1" "/a:/b"
+
+  run cat "${TEMP_DIR}/setup.conf"
+  assert_output --partial "[volumes]"
+  assert_output --partial "mount_1 = /a:/b"
+  # Pre-existing section untouched
+  assert_output --partial "rule_1 = @default:foo"
+}
+
+@test "_upsert_conf_value appends key at EOF when section is the last one without target key" {
+  # Coverage gap: "Still in target section at EOF and key not matched →
+  # append" branch of _upsert_conf_value.
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[image]
+rule_1 = @default:foo
+
+[volumes]
+mount_1 = /a:/a
+EOF
+  _upsert_conf_value "${TEMP_DIR}/setup.conf" "volumes" "mount_2" "/b:/b"
+
+  run cat "${TEMP_DIR}/setup.conf"
+  assert_output --partial "mount_1 = /a:/a"
+  assert_output --partial "mount_2 = /b:/b"
+}
+
+@test "_write_setup_conf flushes unknown override keys that belong to the final template section" {
+  # Coverage gap: the "Flush leftovers belonging to the final section"
+  # block fires when an override's key doesn't match any template line
+  # AND the override's section is the LAST one in the template. Without
+  # that terminal flush, the unknown key would be dropped.
+  cat > "${TEMP_DIR}/template.conf" <<'EOF'
+[image]
+rule_1 = prefix:docker_
+
+[volumes]
+mount_1 = /a:/a
+EOF
+  # volumes is the last section; mount_9 is a new key not in template.
+  local -a _sections=(volumes) \
+    _keys=(volumes.mount_9) \
+    _values=("/extra:/extra")
+  _write_setup_conf "${TEMP_DIR}/out.conf" "${TEMP_DIR}/template.conf" \
+    _sections _keys _values
+
+  run cat "${TEMP_DIR}/out.conf"
+  assert_output --partial "mount_1 = /a:/a"
+  assert_output --partial "mount_9 = /extra:/extra"
+}
+
+@test "_write_setup_conf removed_keys + final-section flush interplay" {
+  # Regression: ensure removed_keys suppresses the EOF flush so a key
+  # the user explicitly cleared doesn't reappear as a trailing override.
+  cat > "${TEMP_DIR}/template.conf" <<'EOF'
+[image]
+rule_1 = prefix:docker_
+
+[volumes]
+mount_1 = /a:/a
+EOF
+  local -a _sections=(volumes) \
+    _keys=(volumes.mount_9) \
+    _values=("/extra:/extra")
+  _write_setup_conf "${TEMP_DIR}/out.conf" "${TEMP_DIR}/template.conf" \
+    _sections _keys _values "volumes.mount_9"
+
+  run cat "${TEMP_DIR}/out.conf"
+  refute_output --partial "mount_9"
+  assert_output --partial "mount_1 = /a:/a"
 }
 
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Closes **#50** (coverage audit) and **#103** (_lib.sh zh_TW typo). Three clusters of small, locally-scoped changes:

### 1. Coverage fills (+9 unit tests)
Kcov audit after v0.9.10 flagged these untested branches. Non-TUI coverage 94.4% → 95.7%.

- `_lib_msg count` / `caps` — only hit transitively through `_print_config_summary`, now asserted directly.
- `_mount_container_path` — entirely untested; 4 new cases mirror the existing `_mount_host_path` coverage.
- `_upsert_conf_value` "section not found" + "section present, key absent at EOF" branches.
- `_write_setup_conf` final-section EOF flush + removed_keys/flush interplay.

`setup_tui.sh` stays at ~17% — `_edit_section_*` dialog flows are out of bats scope. Validators / I/O helpers already covered.

### 2. `_sanitize_lang` i18n (i18n.sh)
Agent A's v0.9.7 PR explicitly left this helper's WARNING English. zh-TW / zh-CN / ja shells now see localised output when they type an invalid `--lang` value. Can't use `_LANG` (holds the invalid input), so it re-detects from system `$LANG`.

### 3. Fix #103 — `_lib.sh` fallback `_detect_lang` typo
Copy-paste bug: returned `"zh"` for `zh_TW` where every other detection site returns `"zh-TW"`. Latent because `_lib.sh`'s fallback only fires when `i18n.sh` is missing (Dockerfile `/lint` stage) — in that branch zh-TW users silently fell through to English. Regression test locks down agreement between fallback and primary for every locale.

## Test plan
- [ ] `test` + `Integration E2E` CI green (645 tests: 602 unit + 43 integration, +13 from main)