### PR TITLE
feat: Jetson auto-detect for [build] network + dedupe _detect_lang (#102 + #104)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -9,16 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`_lib.sh` fallback `_detect_lang` returned `"zh"` for `zh_TW` (issue
-  #103)** — a copy-paste typo in the fallback used when `i18n.sh` is
-  absent (the Dockerfile `/lint` stage). All other detection sites
-  (`i18n.sh`, `build.sh`, `run.sh`) return `"zh-TW"`; the inconsistent
-  `"zh"` meant zh-TW users in that code path fell through to English
-  because the i18n tables are keyed on `zh-TW:`, not `zh:`. Fixed to
-  `"zh-TW"` with a locked-in regression test that spins up `_lib.sh`
-  without a sibling `i18n.sh` and asserts its fallback agrees with the
-  primary for every supported locale.
+  #103)** — a copy-paste typo in the fallback used when `i18n.sh` was
+  absent (the Dockerfile `/lint` stage). Fixed to `"zh-TW"`. The
+  follow-up `#104` dedupe below then REMOVED the fallback entirely; the
+  only remaining `_detect_lang` is in `i18n.sh`.
 
 ### Changed
+- **`[build] network` now defaults to `auto` (issue #102)**. On Jetson
+  (detected via `/etc/nv_tegra_release`) setup.sh resolves `auto` to
+  `host`, so first-time `./build.sh` succeeds without the DNS failures
+  that Jetson's broken bridge NAT used to cause. Desktop hosts stay on
+  Docker's default bridge. Explicit `host` / `bridge` / `none` /
+  `default` still pass through unchanged; new `off` value for explicit
+  opt-out. New `_resolve_build_network` helper mirrors
+  `_resolve_runtime`'s Jetson-aware pattern.
+- **`_detect_lang` deduplicated: single canonical definition in
+  `i18n.sh` (issue #104)**. Previously `build.sh` / `run.sh` /
+  `exec.sh` / `stop.sh` / `_lib.sh` each shipped an inline fallback
+  `_detect_lang` for when `i18n.sh` wasn't reachable (Dockerfile
+  `/lint` stage). That invited drift — see #103 where `_lib.sh`'s
+  copy had silently returned `zh` instead of `zh-TW` for months.
+  `Dockerfile.example`'s test stage now COPYs `_lib.sh` + `i18n.sh` +
+  `_tui_conf.sh` alongside `*.sh`; scripts look up `_lib.sh` in the
+  template layout OR as a sibling, with a clear error when neither
+  exists. Downstream repos using a custom Dockerfile (not based on
+  `Dockerfile.example`) need to mirror this COPY in their test stage.
 - **`_sanitize_lang` warning now localises to the system `$LANG`**. v0.9.7
   Agent A scoped this helper out of i18n; a user with `LANG=zh_TW.UTF-8`
   who typed `--lang xxx` still saw an English WARNING. Now we re-detect

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **645 tests** total (602 unit + 43 integration).
+Template self-tests: **654 tests** total (611 unit + 43 integration).
 
 ## Test Files
 
-### test/unit/lib_spec.bats (39)
+### test/unit/lib_spec.bats (38)
 
 | Test | Description |
 |------|-------------|
@@ -34,7 +34,7 @@ Template self-tests: **645 tests** total (602 unit + 43 integration).
 | `_print_config_summary hides sections that are empty in setup.conf` | Empty-section skip |
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
 
-### test/unit/setup_spec.bats (105)
+### test/unit/setup_spec.bats (111)
 
 Covers core detection (user/hardware/docker/GPU/GUI), the INI parser
 (`_parse_ini_section`), setup.conf section merging (`_load_setup_conf`
@@ -61,7 +61,7 @@ writeback (first-time bootstrap / user-edit respect / opt-out).
 | `[build]` apt_mirror (empty fallback, override) | 2 |
 | Workspace writeback (first-time, respect user edit, opt-out) | 3 |
 
-### test/unit/tui_spec.bats (81)
+### test/unit/tui_spec.bats (82)
 
 Pure-logic unit tests for the TUI support libraries (`_tui_conf.sh`).
 No dialog/whiptail invocations here — strictly validators, mount-string
@@ -181,7 +181,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `empty extras => no extra mount lines` | empty list |
 | `with GUI+GPU+extras => all sections present` | fully loaded |
 
-### test/unit/template_spec.bats (102)
+### test/unit/template_spec.bats (105)
 
 | Test | Description |
 |------|-------------|

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -133,6 +133,16 @@ COPY .hadolint.yaml /lint/.hadolint.yaml
 COPY Dockerfile /lint/Dockerfile
 COPY compose.yaml /lint/compose.yaml
 COPY *.sh /lint/
+# Helpers sourced by the root-level scripts. Must sit next to them so
+# build.sh / run.sh / exec.sh / stop.sh / setup.sh can source _lib.sh
+# (which in turn sources i18n.sh); setup.sh also sources _tui_conf.sh.
+# Issue #104: removing these used to be compensated by inline
+# `_detect_lang` fallbacks in every script — now the canonical
+# definition lives once in i18n.sh.
+COPY template/script/docker/_lib.sh \
+     template/script/docker/i18n.sh \
+     template/script/docker/_tui_conf.sh \
+     /lint/
 RUN shellcheck -S warning /lint/*.sh
 RUN cd /lint && hadolint Dockerfile
 

--- a/script/docker/_lib.sh
+++ b/script/docker/_lib.sh
@@ -16,29 +16,14 @@ if [[ -n "${_DOCKER_LIB_SOURCED:-}" ]]; then
 fi
 _DOCKER_LIB_SOURCED=1
 
-# _detect_lang prints the language code derived from $LANG.
-# KEEP IN SYNC with i18n.sh's _detect_lang (this is a fallback used
-# only when i18n.sh is missing, e.g. the Dockerfile /lint stage).
-# Returning "zh" here was a copy-paste typo (issue #103) — all other
-# detection sites return "zh-TW", so the i18n table keyed on zh-TW:
-# would miss and fall through to English messages.
-_detect_lang() {
-  case "${LANG:-}" in
-    zh_TW*) echo "zh-TW" ;;
-    zh_CN*|zh_SG*) echo "zh-CN" ;;
-    ja*) echo "ja" ;;
-    *) echo "en" ;;
-  esac
-}
-
-# Load i18n.sh if present, otherwise fall back to a minimal _LANG.
+# i18n.sh lives next to _lib.sh in every deployment surface (consumer
+# repo's template/script/docker/, and the /lint/ stage where the
+# Dockerfile COPYs both). Issue #104 removed the duplicate fallback
+# `_detect_lang` definitions that had already drifted (#103) — the
+# one canonical _detect_lang + _LANG assignment lives in i18n.sh.
 _lib_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
-if [[ -f "${_lib_dir}/i18n.sh" ]]; then
-  # shellcheck disable=SC1091
-  source "${_lib_dir}/i18n.sh"
-else
-  _LANG="${SETUP_LANG:-$(_detect_lang)}"
-fi
+# shellcheck disable=SC1091
+source "${_lib_dir}/i18n.sh"
 unset _lib_dir
 
 # _load_env sources the given .env file with allexport so every assignment

--- a/script/docker/_tui_conf.sh
+++ b/script/docker/_tui_conf.sh
@@ -165,7 +165,7 @@ _validate_build_network() {
   local _v="${1-}"
   [[ -z "${_v}" ]] && return 0
   case "${_v}" in
-    host|bridge|none|default) return 0 ;;
+    auto|host|bridge|none|default|off) return 0 ;;
     *) return 1 ;;
   esac
 }

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -5,22 +5,22 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
+# _lib.sh lives at template/script/docker/_lib.sh in normal consumer
+# repos, OR alongside build.sh when the Dockerfile `test` stage COPYs
+# scripts + helpers into /lint/. Issue #104 deduplicated the previously
+# inlined fallback `_detect_lang`; we now always have i18n.sh via
+# _lib.sh's sibling load.
 if [[ -f "${FILE_PATH}/template/script/docker/_lib.sh" ]]; then
   # shellcheck disable=SC1091
   source "${FILE_PATH}/template/script/docker/_lib.sh"
+elif [[ -f "${FILE_PATH}/_lib.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${FILE_PATH}/_lib.sh"
 else
-  # Fallback for /lint stage which COPYs only *.sh from repo root and has
-  # no template/ tree. Only _LANG is needed for `usage()`; other helpers
-  # are unused in this stage.
-  _detect_lang() {
-    case "${LANG:-}" in
-      zh_TW*) echo "zh-TW" ;;
-      zh_CN*|zh_SG*) echo "zh-CN" ;;
-      ja*) echo "ja" ;;
-      *) echo "en" ;;
-    esac
-  }
-  _LANG="${SETUP_LANG:-$(_detect_lang)}"
+  printf "[build] ERROR: cannot find _lib.sh — expected one of:\n" >&2
+  printf "  %s\n" "${FILE_PATH}/template/script/docker/_lib.sh" >&2
+  printf "  %s\n" "${FILE_PATH}/_lib.sh" >&2
+  exit 1
 fi
 
 _msg() {

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -5,20 +5,19 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
+# _lib.sh lookup: template/script/docker/_lib.sh in consumer repos, or
+# sibling _lib.sh in /lint/ (Dockerfile test stage). See build.sh.
 if [[ -f "${FILE_PATH}/template/script/docker/_lib.sh" ]]; then
   # shellcheck disable=SC1091
   source "${FILE_PATH}/template/script/docker/_lib.sh"
+elif [[ -f "${FILE_PATH}/_lib.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${FILE_PATH}/_lib.sh"
 else
-  # Fallback for /lint stage. See build.sh for rationale.
-  _detect_lang() {
-    case "${LANG:-}" in
-      zh_TW*) echo "zh-TW" ;;
-      zh_CN*|zh_SG*) echo "zh-CN" ;;
-      ja*) echo "ja" ;;
-      *) echo "en" ;;
-    esac
-  }
-  _LANG="${SETUP_LANG:-$(_detect_lang)}"
+  printf "[exec] ERROR: cannot find _lib.sh — expected one of:\n" >&2
+  printf "  %s\n" "${FILE_PATH}/template/script/docker/_lib.sh" >&2
+  printf "  %s\n" "${FILE_PATH}/_lib.sh" >&2
+  exit 1
 fi
 
 _msg() {

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -5,20 +5,19 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
+# _lib.sh lookup: template/script/docker/_lib.sh in consumer repos, or
+# sibling _lib.sh in /lint/ (Dockerfile test stage). See build.sh.
 if [[ -f "${FILE_PATH}/template/script/docker/_lib.sh" ]]; then
   # shellcheck disable=SC1091
   source "${FILE_PATH}/template/script/docker/_lib.sh"
+elif [[ -f "${FILE_PATH}/_lib.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${FILE_PATH}/_lib.sh"
 else
-  # Fallback for /lint stage. See build.sh for rationale.
-  _detect_lang() {
-    case "${LANG:-}" in
-      zh_TW*) echo "zh-TW" ;;
-      zh_CN*|zh_SG*) echo "zh-CN" ;;
-      ja*) echo "ja" ;;
-      *) echo "en" ;;
-    esac
-  }
-  _LANG="${SETUP_LANG:-$(_detect_lang)}"
+  printf "[run] ERROR: cannot find _lib.sh — expected one of:\n" >&2
+  printf "  %s\n" "${FILE_PATH}/template/script/docker/_lib.sh" >&2
+  printf "  %s\n" "${FILE_PATH}/_lib.sh" >&2
+  exit 1
 fi
 
 _msg() {

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -576,6 +576,27 @@ _resolve_runtime() {
   esac
 }
 
+# _resolve_build_network <mode> <outvar>
+#   mode=host / bridge / none / default → pass through
+#   mode=auto → "host" iff _detect_jetson, else "" (issue #102)
+#   mode=off | "" → "" (no network key emitted; Docker defaults to bridge)
+#
+# Jetson L4T kernels commonly lack the iptables modules docker's bridge
+# NAT needs, so first-time `docker build` on Jetson dies with DNS
+# resolution failures before the apt step. Auto-promoting to host-net
+# on Jetson removes the trap door; desktop hosts keep default bridge.
+_resolve_build_network() {
+  local _mode="${1:-}"
+  local -n _rbn_out="${2:?}"
+  case "${_mode}" in
+    host|bridge|none|default) _rbn_out="${_mode}" ;;
+    auto)
+      if _detect_jetson; then _rbn_out="host"; else _rbn_out=""; fi
+      ;;
+    off|""|*) _rbn_out="" ;;
+  esac
+}
+
 # ════════════════════════════════════════════════════════════════════
 # _compute_conf_hash <base_path> <outvar>
 #
@@ -1199,8 +1220,10 @@ main() {
   # compose.yaml and `--network <value>` to the auxiliary test-tools
   # docker build. Typical value: `host`, for hosts whose docker bridge
   # NAT is unusable (stripped embedded kernels, iptables:false).
+  local build_network_mode=""
+  _get_conf_value _build_k _build_v "network" "auto" build_network_mode
   local build_network=""
-  _get_conf_value _build_k _build_v "network" "" build_network
+  _resolve_build_network "${build_network_mode}" build_network
 
   local gpu_mode="" gpu_count="" gpu_caps="" runtime_mode=""
   local gui_mode=""

--- a/script/docker/setup_tui.sh
+++ b/script/docker/setup_tui.sh
@@ -95,11 +95,11 @@ declare -gA _TUI_MSG_EN=(
   [build.target_arch.prompt]=$'Docker TARGETARCH override\n  - Empty = let BuildKit auto-fill from host / --platform (default)\n  - amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64\n  - Applies to the main image + the test-tools image\n  - Pin when you need cross-builds or explicit control'
   [build.target_arch.auto]="(auto)"
   [build.network.label]="Build network"
-  [build.network.prompt]=$'Docker build-time network (only the build stage; runtime is separate)\n  - Empty = Docker default (bridge + NAT)\n  - host = use the host network stack. Required when the host\'s bridge\n          NAT is unusable: stripped embedded kernels (e.g. Jetson L4T\n          missing iptable_raw), hosts with iptables: false, or firewall-\n          locked CI runners.\n  - bridge / none / default = explicit variants (rarely needed)'
-  [build.network.default]="(default: bridge)"
+  [build.network.prompt]=$'Docker build-time network (only the build stage; runtime is separate)\n  - auto = detect Jetson (/etc/nv_tegra_release) → host; desktop → Docker default (default)\n  - host = force host network stack. Required when bridge NAT is\n          unusable (stripped kernels, iptables: false, firewall-locked CI)\n  - bridge / none / default = explicit Docker modes\n  - off (or empty) = explicit opt-out; stay on Docker default bridge'
+  [build.network.default]="(default: auto)"
   [build.args.label]="Extra build args"
   [err.invalid_target_arch]="Invalid TARGETARCH. Use empty or amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64."
-  [err.invalid_build_network]="Invalid build network. Use empty or host / bridge / none / default."
+  [err.invalid_build_network]="Invalid build network. Use auto / host / bridge / none / default / off (or empty)."
   [network.title]="Network"
   [network.mode.prompt]="Network mode"
   [network.mode.host]="host (share host network stack)"
@@ -248,11 +248,11 @@ declare -gA _TUI_MSG_ZH_TW=(
   [build.target_arch.prompt]=$'Docker TARGETARCH 覆寫\n  - 留空 = 交給 BuildKit 依 host / --platform 自動填（預設）\n  - amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64\n  - 同時套用主 image 與 test-tools image\n  - 需要跨架構編譯或明確指定時才填'
   [build.target_arch.auto]="（自動）"
   [build.network.label]="Build 網路"
-  [build.network.prompt]=$'Docker build 階段使用的網路（不影響 runtime 容器的網路）\n  - 留空 = Docker 預設（bridge + NAT）\n  - host = 改用 host 網路 stack。當主機的 bridge NAT 無法用時需要：\n          例如 kernel 缺 iptable_raw（Jetson L4T）、\n          daemon.json 有 iptables: false、或 CI runner 防火牆限制。\n  - bridge / none / default = 其他明確選項（很少用到）'
-  [build.network.default]="（預設：bridge）"
+  [build.network.prompt]=$'Docker build 階段使用的網路（不影響 runtime 容器的網路）\n  - auto = 自動偵測 Jetson（/etc/nv_tegra_release）→ host；桌機 → Docker 預設（預設）\n  - host = 強制 host 網路 stack。當主機的 bridge NAT 無法用時需要：\n          例如 kernel 缺 iptable_raw（Jetson L4T）、\n          daemon.json 有 iptables: false、或 CI runner 防火牆限制\n  - bridge / none / default = 其他明確 Docker 選項\n  - off（或留空）= 明確關閉；用 Docker 預設的 bridge'
+  [build.network.default]="（預設：auto）"
   [build.args.label]="額外 build args"
   [err.invalid_target_arch]="TARGETARCH 無效，請填空值或 amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64。"
-  [err.invalid_build_network]="Build 網路無效，請填空值或 host / bridge / none / default。"
+  [err.invalid_build_network]="Build 網路無效，請填 auto / host / bridge / none / default / off（或留空）。"
   [network.title]="Network"
   [network.mode.prompt]="網路模式"
   [network.mode.host]="host（共用主機網路堆疊）"
@@ -399,11 +399,11 @@ declare -gA _TUI_MSG_ZH_CN=(
   [build.target_arch.prompt]=$'Docker TARGETARCH 覆盖\n  - 留空 = 交给 BuildKit 依 host / --platform 自动填（默认）\n  - amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64\n  - 同时应用于主 image 与 test-tools image\n  - 需要跨架构构建或明确指定时才填'
   [build.target_arch.auto]="（自动）"
   [build.network.label]="Build 网络"
-  [build.network.prompt]=$'Docker build 阶段使用的网络（不影响 runtime 容器的网络）\n  - 留空 = Docker 默认（bridge + NAT）\n  - host = 改用 host 网络 stack。当主机的 bridge NAT 无法用时需要：\n          例如 kernel 缺 iptable_raw（Jetson L4T）、\n          daemon.json 有 iptables: false、或 CI runner 防火墙限制。\n  - bridge / none / default = 其他明确选项（很少用到）'
-  [build.network.default]="（默认：bridge）"
+  [build.network.prompt]=$'Docker build 阶段使用的网络（不影响 runtime 容器的网络）\n  - auto = 自动检测 Jetson（/etc/nv_tegra_release）→ host；桌机 → Docker 默认（默认）\n  - host = 强制 host 网络 stack。当主机的 bridge NAT 无法用时需要：\n          例如 kernel 缺 iptable_raw（Jetson L4T）、\n          daemon.json 有 iptables: false、或 CI runner 防火墙限制\n  - bridge / none / default = 其他明确 Docker 选项\n  - off（或留空）= 明确关闭；用 Docker 默认的 bridge'
+  [build.network.default]="（默认：auto）"
   [build.args.label]="额外 build args"
   [err.invalid_target_arch]="TARGETARCH 无效，请填空值或 amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64。"
-  [err.invalid_build_network]="Build 网络无效，请填空值或 host / bridge / none / default。"
+  [err.invalid_build_network]="Build 网络无效，请填 auto / host / bridge / none / default / off（或留空）。"
   [network.title]="Network"
   [network.mode.prompt]="网络模式"
   [network.mode.host]="host（共用主机网络栈）"
@@ -545,11 +545,11 @@ declare -gA _TUI_MSG_JA=(
   [build.target_arch.prompt]=$'Docker TARGETARCH 上書き\n  - 空 = BuildKit が host / --platform から自動補完（デフォルト）\n  - amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64\n  - メイン image と test-tools image の両方に適用\n  - クロスビルドや明示指定が必要なときのみ設定'
   [build.target_arch.auto]="（自動）"
   [build.network.label]="Build ネットワーク"
-  [build.network.prompt]=$'Docker build 時のネットワーク（runtime コンテナは別管理）\n  - 空 = Docker デフォルト（bridge + NAT）\n  - host = ホストのネットワークスタックを利用。ホストの bridge NAT が\n          使えない場合に必要：kernel が iptable_raw 欠落（Jetson L4T）、\n          daemon.json に iptables: false、CI runner のファイアウォール制限など。\n  - bridge / none / default = 明示指定（めったに使用しない）'
-  [build.network.default]="（デフォルト：bridge）"
+  [build.network.prompt]=$'Docker build 時のネットワーク（runtime コンテナは別管理）\n  - auto = Jetson（/etc/nv_tegra_release）検出時は host、デスクトップは Docker 既定（既定）\n  - host = 強制的にホストネットワーク stack を使用。ホストの bridge NAT が\n          使えない場合に必要：kernel が iptable_raw 欠落（Jetson L4T）、\n          daemon.json に iptables: false、CI runner のファイアウォール制限など\n  - bridge / none / default = 明示指定（Docker の既知モード）\n  - off（または空）= 明示的にオプトアウト。Docker 既定の bridge を使用'
+  [build.network.default]="（デフォルト：auto）"
   [build.args.label]="追加 build args"
   [err.invalid_target_arch]="TARGETARCH が不正です。空、または amd64 / arm64 / arm / 386 / ppc64le / s390x / riscv64 を指定してください。"
-  [err.invalid_build_network]="Build ネットワークが不正です。空、または host / bridge / none / default を指定してください。"
+  [err.invalid_build_network]="Build ネットワークが不正です。auto / host / bridge / none / default / off（または空）を指定してください。"
   [network.title]="Network"
   [network.mode.prompt]="ネットワークモード"
   [network.mode.host]="host（ホストネットワークスタックを共有）"

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -5,20 +5,19 @@ set -euo pipefail
 
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 readonly FILE_PATH
+# _lib.sh lookup: template/script/docker/_lib.sh in consumer repos, or
+# sibling _lib.sh in /lint/ (Dockerfile test stage). See build.sh.
 if [[ -f "${FILE_PATH}/template/script/docker/_lib.sh" ]]; then
   # shellcheck disable=SC1091
   source "${FILE_PATH}/template/script/docker/_lib.sh"
+elif [[ -f "${FILE_PATH}/_lib.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "${FILE_PATH}/_lib.sh"
 else
-  # Fallback for /lint stage. See build.sh for rationale.
-  _detect_lang() {
-    case "${LANG:-}" in
-      zh_TW*) echo "zh-TW" ;;
-      zh_CN*|zh_SG*) echo "zh-CN" ;;
-      ja*) echo "ja" ;;
-      *) echo "en" ;;
-    esac
-  }
-  _LANG="${SETUP_LANG:-$(_detect_lang)}"
+  printf "[stop] ERROR: cannot find _lib.sh — expected one of:\n" >&2
+  printf "  %s\n" "${FILE_PATH}/template/script/docker/_lib.sh" >&2
+  printf "  %s\n" "${FILE_PATH}/_lib.sh" >&2
+  exit 1
 fi
 
 _msg() {

--- a/setup.conf
+++ b/setup.conf
@@ -75,20 +75,23 @@ rule_3 = @basename
 # network: Docker build-time network mode. Only the user's own
 # Dockerfile RUN stages (apk/apt/curl/git clone) care — runtime is
 # controlled separately via [network] mode.
-#   <empty>         → Docker default (bridge + NAT via iptables)
-#   host            → build uses the host's network stack. Necessary
-#                     on environments where Docker's default bridge
-#                     NAT is unusable: stripped embedded kernels (e.g.
-#                     Jetson L4T missing iptable_raw), firewall-locked
-#                     CI runners, or hosts with `iptables: false` in
-#                     daemon.json.
-# When non-empty, setup.sh writes BUILD_NETWORK to .env and emits
-# `build.network: <value>` under each service in compose.yaml;
-# build.sh forwards `--network <value>` to the auxiliary `docker build`
-# call for test-tools.
+#   auto            → auto-detect Jetson (/etc/nv_tegra_release) and
+#                     emit host-net only there; desktop hosts stay on
+#                     Docker's default bridge. Default.
+#   host            → force host-net for all hosts. Necessary when
+#                     Docker's default bridge NAT is unusable:
+#                     stripped embedded kernels (Jetson L4T missing
+#                     iptable_raw), firewall-locked CI runners, hosts
+#                     with `iptables: false` in daemon.json.
+#   bridge|none|default → explicit Docker-known network modes.
+#   off             → never emit (explicitly opt out of auto).
+# When non-empty (after resolve), setup.sh writes BUILD_NETWORK to
+# .env and emits `build.network: <value>` under each service in
+# compose.yaml; build.sh forwards `--network <value>` to the
+# auxiliary `docker build` call for test-tools.
 [build]
 target_arch =
-network =
+network = auto
 arg_1 = APT_MIRROR_UBUNTU=tw.archive.ubuntu.com
 arg_2 = APT_MIRROR_DEBIAN=mirror.twds.com.tw
 arg_3 = TZ=Asia/Taipei

--- a/test/unit/build_sh_spec.bats
+++ b/test/unit/build_sh_spec.bats
@@ -352,34 +352,41 @@ EOS
   assert_output --partial "使用法"
 }
 
-# ── Fallback _detect_lang (no template/ tree) ──────────────────────────────
-# Exercises lines 17-19 of build.sh where _lib.sh is missing and _detect_lang
-# maps LANG → {zh, zh-CN, ja}. Symlink (not copy) so kcov attributes runs.
+# ── /lint/-layout _detect_lang (flat dir: build.sh + _lib.sh + i18n.sh) ────
+# After #104 the inline fallback is gone; scripts in the Dockerfile test
+# stage rely on _lib.sh + i18n.sh copied alongside. These tests exercise
+# that layout by symlinking build.sh (for kcov) and copying the helpers.
 
-@test "build.sh fallback _detect_lang maps zh_TW.UTF-8 to zh-TW" {
+@test "build.sh in /lint/ layout maps zh_TW.UTF-8 to zh-TW" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/build.sh "${_tmp}/build.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=zh_TW.UTF-8 run bash "${_tmp}/build.sh" -h
   assert_success
   assert_output --partial "用法"
   rm -rf "${_tmp}"
 }
 
-@test "build.sh fallback _detect_lang maps zh_CN.UTF-8 to zh-CN" {
+@test "build.sh in /lint/ layout maps zh_CN.UTF-8 to zh-CN" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/build.sh "${_tmp}/build.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=zh_CN.UTF-8 run bash "${_tmp}/build.sh" -h
   assert_success
   assert_output --partial "用法"
   rm -rf "${_tmp}"
 }
 
-@test "build.sh fallback _detect_lang maps ja_JP.UTF-8 to ja" {
+@test "build.sh in /lint/ layout maps ja_JP.UTF-8 to ja" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/build.sh "${_tmp}/build.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=ja_JP.UTF-8 run bash "${_tmp}/build.sh" -h
   assert_success
   assert_output --partial "使用法"

--- a/test/unit/exec_sh_spec.bats
+++ b/test/unit/exec_sh_spec.bats
@@ -146,32 +146,38 @@ teardown() {
   assert_output --partial "exec"
 }
 
-# ── Fallback _detect_lang (no template/ tree) ──────────────────────────────
+# ── /lint/-layout _detect_lang (flat dir with _lib.sh + i18n.sh, #104) ─────
 
-@test "exec.sh fallback _detect_lang maps zh_TW.UTF-8 to zh-TW" {
+@test "exec.sh in /lint/ layout maps zh_TW.UTF-8 to zh-TW" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/exec.sh "${_tmp}/exec.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=zh_TW.UTF-8 run bash "${_tmp}/exec.sh" -h
   assert_success
   assert_output --partial "用法"
   rm -rf "${_tmp}"
 }
 
-@test "exec.sh fallback _detect_lang maps zh_CN.UTF-8 to zh-CN" {
+@test "exec.sh in /lint/ layout maps zh_CN.UTF-8 to zh-CN" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/exec.sh "${_tmp}/exec.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=zh_CN.UTF-8 run bash "${_tmp}/exec.sh" -h
   assert_success
   assert_output --partial "用法"
   rm -rf "${_tmp}"
 }
 
-@test "exec.sh fallback _detect_lang maps ja_JP.UTF-8 to ja" {
+@test "exec.sh in /lint/ layout maps ja_JP.UTF-8 to ja" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/exec.sh "${_tmp}/exec.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=ja_JP.UTF-8 run bash "${_tmp}/exec.sh" -h
   assert_success
   assert_output --partial "使用法"

--- a/test/unit/lib_spec.bats
+++ b/test/unit/lib_spec.bats
@@ -50,27 +50,6 @@ setup() {
   assert_output "ja"
 }
 
-@test "_lib.sh fallback _detect_lang (no i18n.sh) agrees with primary for every locale (#103)" {
-  # _lib.sh's fallback `_detect_lang` only fires when i18n.sh is
-  # absent (Dockerfile /lint stage). v0.9.10 had a copy-paste typo
-  # returning "zh" for zh_TW where i18n.sh returns "zh-TW" — zh-TW
-  # users in /lint would fall through to English messages because
-  # the i18n tables are keyed on "zh-TW:", not "zh:". Guard against
-  # the four fallbacks drifting again: copy _lib.sh to a temp dir
-  # without i18n.sh so the `else` branch fires, then compare.
-  local _tmp="${BATS_TEST_TMPDIR}/lib_no_i18n"
-  mkdir -p "${_tmp}"
-  cp "${LIB}" "${_tmp}/_lib.sh"
-  # Deliberately NOT copying i18n.sh → fallback _detect_lang runs.
-
-  local _locale _got _want
-  for _locale in en_US.UTF-8 zh_TW.UTF-8 zh_CN.UTF-8 zh_SG.UTF-8 ja_JP.UTF-8; do
-    _got="$(env LANG="${_locale}" bash -c "source '${_tmp}/_lib.sh'; echo \"\${_LANG}\"")"
-    _want="$(env LANG="${_locale}" bash -c "source '${LIB%/*}/i18n.sh'; echo \"\${_LANG}\"")"
-    assert_equal "${_got}" "${_want}"
-  done
-}
-
 # ── double-source guard ─────────────────────────────────────────────────────
 
 @test "_lib.sh is idempotent when sourced twice" {

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -299,32 +299,38 @@ EOS
   assert_success
 }
 
-# ── Fallback _detect_lang (no template/ tree) ──────────────────────────────
+# ── /lint/-layout _detect_lang (flat dir with _lib.sh + i18n.sh, #104) ─────
 
-@test "run.sh fallback _detect_lang maps zh_TW.UTF-8 to zh-TW" {
+@test "run.sh in /lint/ layout maps zh_TW.UTF-8 to zh-TW" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/run.sh "${_tmp}/run.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=zh_TW.UTF-8 run bash "${_tmp}/run.sh" -h
   assert_success
   assert_output --partial "用法"
   rm -rf "${_tmp}"
 }
 
-@test "run.sh fallback _detect_lang maps zh_CN.UTF-8 to zh-CN" {
+@test "run.sh in /lint/ layout maps zh_CN.UTF-8 to zh-CN" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/run.sh "${_tmp}/run.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=zh_CN.UTF-8 run bash "${_tmp}/run.sh" -h
   assert_success
   assert_output --partial "用法"
   rm -rf "${_tmp}"
 }
 
-@test "run.sh fallback _detect_lang maps ja_JP.UTF-8 to ja" {
+@test "run.sh in /lint/ layout maps ja_JP.UTF-8 to ja" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/run.sh "${_tmp}/run.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=ja_JP.UTF-8 run bash "${_tmp}/run.sh" -h
   assert_success
   assert_output --partial "使用法"

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -536,6 +536,52 @@ EOF
 }
 
 # ════════════════════════════════════════════════════════════════════
+# _resolve_build_network (Jetson build-net auto-detect, issue #102)
+# ════════════════════════════════════════════════════════════════════
+
+@test "_resolve_build_network auto on Jetson => host" {
+  local _out
+  SETUP_DETECT_JETSON=true _resolve_build_network "auto" _out
+  assert_equal "${_out}" "host"
+}
+
+@test "_resolve_build_network auto off Jetson => empty" {
+  local _out
+  SETUP_DETECT_JETSON=false _resolve_build_network "auto" _out
+  assert_equal "${_out}" ""
+}
+
+@test "_resolve_build_network host => always host (explicit override wins)" {
+  local _out
+  SETUP_DETECT_JETSON=false _resolve_build_network "host" _out
+  assert_equal "${_out}" "host"
+}
+
+@test "_resolve_build_network bridge / none / default pass through" {
+  local _out
+  _resolve_build_network "bridge" _out
+  assert_equal "${_out}" "bridge"
+  _resolve_build_network "none" _out
+  assert_equal "${_out}" "none"
+  _resolve_build_network "default" _out
+  assert_equal "${_out}" "default"
+}
+
+@test "_resolve_build_network off / empty => empty (explicitly suppressed)" {
+  local _out
+  SETUP_DETECT_JETSON=true _resolve_build_network "off" _out
+  assert_equal "${_out}" ""
+  SETUP_DETECT_JETSON=true _resolve_build_network "" _out
+  assert_equal "${_out}" ""
+}
+
+@test "_resolve_build_network unknown mode falls through to empty" {
+  local _out
+  SETUP_DETECT_JETSON=true _resolve_build_network "garbage" _out
+  assert_equal "${_out}" ""
+}
+
+# ════════════════════════════════════════════════════════════════════
 # detect_image_name (now reads [image] rules from setup.conf)
 # ════════════════════════════════════════════════════════════════════
 

--- a/test/unit/stop_sh_spec.bats
+++ b/test/unit/stop_sh_spec.bats
@@ -143,32 +143,38 @@ teardown() {
   assert_output --partial "mockuser-mockimg-bar"
 }
 
-# ── Fallback _detect_lang (no template/ tree) ──────────────────────────────
+# ── /lint/-layout _detect_lang (flat dir with _lib.sh + i18n.sh, #104) ─────
 
-@test "stop.sh fallback _detect_lang maps zh_TW.UTF-8 to zh-TW" {
+@test "stop.sh in /lint/ layout maps zh_TW.UTF-8 to zh-TW" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/stop.sh "${_tmp}/stop.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=zh_TW.UTF-8 run bash "${_tmp}/stop.sh" -h
   assert_success
   assert_output --partial "用法"
   rm -rf "${_tmp}"
 }
 
-@test "stop.sh fallback _detect_lang maps zh_CN.UTF-8 to zh-CN" {
+@test "stop.sh in /lint/ layout maps zh_CN.UTF-8 to zh-CN" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/stop.sh "${_tmp}/stop.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=zh_CN.UTF-8 run bash "${_tmp}/stop.sh" -h
   assert_success
   assert_output --partial "用法"
   rm -rf "${_tmp}"
 }
 
-@test "stop.sh fallback _detect_lang maps ja_JP.UTF-8 to ja" {
+@test "stop.sh in /lint/ layout maps ja_JP.UTF-8 to ja" {
   local _tmp
   _tmp="$(mktemp -d)"
   ln -s /source/script/docker/stop.sh "${_tmp}/stop.sh"
+  cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
+  cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   LANG=ja_JP.UTF-8 run bash "${_tmp}/stop.sh" -h
   assert_success
   assert_output --partial "使用法"

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -521,44 +521,99 @@ EOF
   assert_success
 }
 
-@test "build.sh -h works when i18n.sh is missing (consumer Dockerfile /lint scenario)" {
-  # Regression: consumer Dockerfile copies *.sh into /lint without template/
-  # tree, so sourcing template/script/docker/i18n.sh fails. build.sh must
-  # gracefully fall back to inline _detect_lang so smoke tests pass.
+_stage_lint_layout() {
+  # Simulate Dockerfile.example's /lint/ stage: script + helpers in one
+  # flat directory. Callers pass the script file under test.
+  local _dest="${1:?}" _script="${2:?}"
+  cp "/source/script/docker/${_script}" "${_dest}/${_script}"
+  cp /source/script/docker/_lib.sh   "${_dest}/_lib.sh"
+  cp /source/script/docker/i18n.sh   "${_dest}/i18n.sh"
+}
+
+@test "build.sh -h works in /lint/ layout (flat dir with _lib.sh + i18n.sh, issue #104)" {
+  # After #104 we no longer carry inline _detect_lang fallbacks; the
+  # /lint/ stage COPY must include _lib.sh and i18n.sh alongside.
   local _tmp
   _tmp="$(mktemp -d)"
-  cp /source/script/docker/build.sh "${_tmp}/build.sh"
+  _stage_lint_layout "${_tmp}" build.sh
   run bash "${_tmp}/build.sh" -h
   assert_success
   assert_output --partial "Usage"
   rm -rf "${_tmp}"
 }
 
-@test "run.sh -h works when i18n.sh is missing" {
+@test "run.sh -h works in /lint/ layout" {
   local _tmp
   _tmp="$(mktemp -d)"
-  cp /source/script/docker/run.sh "${_tmp}/run.sh"
+  _stage_lint_layout "${_tmp}" run.sh
   run bash "${_tmp}/run.sh" -h
   assert_success
   rm -rf "${_tmp}"
 }
 
-@test "exec.sh -h works when i18n.sh is missing" {
+@test "exec.sh -h works in /lint/ layout" {
   local _tmp
   _tmp="$(mktemp -d)"
-  cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
+  _stage_lint_layout "${_tmp}" exec.sh
   run bash "${_tmp}/exec.sh" -h
   assert_success
   rm -rf "${_tmp}"
 }
 
-@test "stop.sh -h works when i18n.sh is missing" {
+@test "stop.sh -h works in /lint/ layout" {
   local _tmp
   _tmp="$(mktemp -d)"
-  cp /source/script/docker/stop.sh "${_tmp}/stop.sh"
+  _stage_lint_layout "${_tmp}" stop.sh
   run bash "${_tmp}/stop.sh" -h
   assert_success
   rm -rf "${_tmp}"
+}
+
+@test "build.sh errors with a clear diagnostic when _lib.sh missing from both paths (issue #104)" {
+  # No template/script/docker/_lib.sh nor sibling _lib.sh → explicit
+  # non-zero exit + error message pointing the user at the two
+  # expected paths. Better UX than the old silent inline fallback
+  # that hid the absence.
+  local _tmp
+  _tmp="$(mktemp -d)"
+  cp /source/script/docker/build.sh "${_tmp}/build.sh"
+  run bash "${_tmp}/build.sh" -h
+  assert_failure
+  assert_output --partial "cannot find _lib.sh"
+  rm -rf "${_tmp}"
+}
+
+@test "Dockerfile.example copies _lib.sh + i18n.sh + _tui_conf.sh into /lint/ (issue #104)" {
+  # Structural guard: if the Dockerfile COPY is dropped, the /lint/
+  # smoke test (script_help.bats) would break silently for new
+  # downstream repos. Pin it here.
+  run grep -F 'template/script/docker/_lib.sh' /source/dockerfile/Dockerfile.example
+  assert_success
+  run grep -F 'template/script/docker/i18n.sh' /source/dockerfile/Dockerfile.example
+  assert_success
+  run grep -F 'template/script/docker/_tui_conf.sh' /source/dockerfile/Dockerfile.example
+  assert_success
+}
+
+@test "no inline _detect_lang fallbacks remain after dedupe (issue #104)" {
+  # Lock in: only i18n.sh defines _detect_lang. build.sh / run.sh /
+  # exec.sh / stop.sh / _lib.sh previously shipped their own copies,
+  # which drifted (see #103's zh→zh-TW typo) — a single-source
+  # definition prevents further drift.
+  local _count
+  _count="$(grep -cE '^_detect_lang\(\)' \
+    /source/script/docker/build.sh \
+    /source/script/docker/run.sh \
+    /source/script/docker/exec.sh \
+    /source/script/docker/stop.sh \
+    /source/script/docker/_lib.sh \
+    /source/script/docker/setup.sh \
+    | awk -F: '{sum += $2} END {print sum}')"
+  [ "${_count}" = "0" ]
+
+  # i18n.sh must still have exactly one definition.
+  run grep -cE '^_detect_lang\(\)' /source/script/docker/i18n.sh
+  assert_output "1"
 }
 
 @test "setup.sh does not redefine _detect_lang" {

--- a/test/unit/tui_spec.bats
+++ b/test/unit/tui_spec.bats
@@ -238,6 +238,11 @@ teardown() {
   _validate_build_network default
 }
 
+@test "_validate_build_network accepts auto / off (issue #102)" {
+  _validate_build_network auto
+  _validate_build_network off
+}
+
 @test "_validate_build_network rejects unknown values" {
   run _validate_build_network "HOST"   # case-sensitive
   [ "${status}" -ne 0 ]


### PR DESCRIPTION
## Summary

Closes **#102** and **#104**. Two commits, each testable independently.

### Commit 1 — `feat(build): auto-detect Jetson, default [build] network=auto` (#102)
Jetson L4T kernels ship without the iptables modules Docker's bridge NAT needs; every first-time `./build.sh` on fresh Jetson dies with DNS failures before apt. Default changed from empty to `auto`; resolver mirrors v0.9.9's `[deploy] runtime = auto` pattern. New `off` value for explicit opt-out. Desktop behavior unchanged.

### Commit 2 — `refactor: dedupe _detect_lang` (#104, Option A)
Five files (`build.sh` / `run.sh` / `exec.sh` / `stop.sh` / `_lib.sh`) shipped near-identical `_detect_lang` fallbacks for when `i18n.sh` wasn't reachable (Dockerfile `/lint` stage). Kept drifting — #103 is exactly that. Remove all fallbacks; `Dockerfile.example` test stage now COPYs `_lib.sh` + `i18n.sh` + `_tui_conf.sh` into `/lint/` alongside the scripts. Canonical `_detect_lang` now lives only in `i18n.sh`.

## Breaking change notes
- Downstream repos with CUSTOM Dockerfiles (not inheriting `Dockerfile.example`'s test stage) must mirror the new COPY:
  ```dockerfile
  COPY template/script/docker/_lib.sh \
       template/script/docker/i18n.sh \
       template/script/docker/_tui_conf.sh \
       /lint/
  ```
- Default `[build] network = auto` silently turns into `host` on Jetson. Users who previously relied on empty default getting Docker's bridge on Jetson will now get host-net — if that's a problem, set `network = off` explicitly.

## Test plan
- [ ] CI `test` + `Integration E2E` green (654 tests: 611 unit + 43 integration, +9 from main)