### PR TITLE
feat: dependabot.yml + document upgrade.sh automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/README.md
+++ b/README.md
@@ -289,6 +289,31 @@ make upgrade
 ./template/upgrade.sh v0.3.0
 ```
 
+`upgrade.sh` handles the full cycle in one go: `git subtree pull --squash`,
+post-pull integrity check (rolls back on destructive FF), `./template/init.sh`
+to resync root symlinks, and `sed` of `.github/workflows/main.yaml`'s
+`build-worker.yaml@vX.Y.Z` / `release-worker.yaml@vX.Y.Z` references. Don't
+subtree pull by hand — the sed + init steps are easy to forget.
+
+#### Automated version bumps (optional)
+
+Downstream repos can let Dependabot open PRs whenever a new `template` tag
+ships. Add `.github/dependabot.yml`:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+Dependabot notices the `uses: ycpss91255-docker/template/...@vX.Y.Z` refs in
+`main.yaml`, compares against the template's latest tag, and files a PR. You
+still run `./template/upgrade.sh vX.Y.Z` locally to sync the subtree itself —
+Dependabot only bumps the workflow refs.
+
 ## CI Reusable Workflows
 
 Repos replace local `build-worker.yaml` / `release-worker.yaml` with calls to this repo's reusable workflows:

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `.github/dependabot.yml` — weekly `github-actions` ecosystem scan so template's own consumed actions (`actions/checkout`, `docker/*`, etc.) stay current without manual audits.
+
+### Changed
+- README "Updating" section (4 languages) clarifies that `./template/upgrade.sh` already automates subtree pull + integrity check + `init.sh` resync + `main.yaml` `@vX.Y.Z` sed; hand-rolling `git subtree pull` is discouraged since the sed + init steps are easy to forget. Adds a Dependabot snippet downstream repos can drop into their `.github/dependabot.yml` so template version bumps surface as PRs automatically (Dependabot handles workflow refs only; subtree still needs `upgrade.sh`).
+
 ## [v0.9.11] - 2026-04-24
 
 ### Fixed

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -299,6 +299,23 @@ make upgrade
 ./template/upgrade.sh v0.3.0
 ```
 
+`upgrade.sh` は一度に完結します：`git subtree pull --squash`、post-pull 整合性チェック（destructive FF を検出したら自動 rollback）、`./template/init.sh` による root symlinks の再同期、そして `.github/workflows/main.yaml` 内の `build-worker.yaml@vX.Y.Z` / `release-worker.yaml@vX.Y.Z` を sed で更新します。手動で `git subtree pull` しないでください — sed と init の手順を忘れがちです。
+
+#### 自動バージョン更新（任意）
+
+ダウンストリーム repo は、`template` の新しい tag が出るたびに Dependabot が PR を立てるよう設定できます。`.github/dependabot.yml` を追加します：
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+Dependabot は `main.yaml` 内の `uses: ycpss91255-docker/template/...@vX.Y.Z` ref を見て、template の最新 tag と照合して PR を出します。subtree 自体は引き続きローカルで `./template/upgrade.sh vX.Y.Z` を実行する必要があります — Dependabot が扱うのは workflow ref のみです。
+
 ## CI Reusable Workflows
 
 各 repo のローカル `build-worker.yaml` / `release-worker.yaml` を、本 repo の reusable workflows 呼び出しに置き換えます：

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -288,6 +288,23 @@ make upgrade
 ./template/upgrade.sh v0.3.0
 ```
 
+`upgrade.sh` 一次完成：`git subtree pull --squash`、post-pull 完整性检查（检测到 destructive FF 会自动 rollback）、`./template/init.sh` 重整 root symlinks、以及 sed `.github/workflows/main.yaml` 里的 `build-worker.yaml@vX.Y.Z` / `release-worker.yaml@vX.Y.Z`。不要手动 `git subtree pull` — sed 与 init 步骤容易漏掉。
+
+#### 自动升版（可选）
+
+下游 repo 可以让 Dependabot 在 `template` 出新 tag 时自动开 PR。加入 `.github/dependabot.yml`：
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+Dependabot 会读 `main.yaml` 里的 `uses: ycpss91255-docker/template/...@vX.Y.Z` ref，比对 template 最新 tag 后开 PR。subtree 本身仍需在本地跑 `./template/upgrade.sh vX.Y.Z` — Dependabot 只负责 workflow ref。
+
 ## CI Reusable Workflows
 
 各 repo 将本地的 `build-worker.yaml` / `release-worker.yaml` 替换为调用此 repo 的 reusable workflows：

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -288,6 +288,23 @@ make upgrade
 ./template/upgrade.sh v0.3.0
 ```
 
+`upgrade.sh` 一次完成：`git subtree pull --squash`、post-pull 完整性檢查（偵測到 destructive FF 會自動 rollback）、`./template/init.sh` 重整 root symlinks、以及 sed `.github/workflows/main.yaml` 裡的 `build-worker.yaml@vX.Y.Z` / `release-worker.yaml@vX.Y.Z`。不要手動 `git subtree pull` — sed 與 init 步驟很容易漏掉。
+
+#### 自動升版（選用）
+
+下游 repo 可以讓 Dependabot 在 `template` 出新 tag 時自動開 PR。加入 `.github/dependabot.yml`：
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+```
+
+Dependabot 會讀 `main.yaml` 裡的 `uses: ycpss91255-docker/template/...@vX.Y.Z` ref，比對 template 最新 tag 後開 PR。subtree 本身仍需在本地跑 `./template/upgrade.sh vX.Y.Z` — Dependabot 只負責 workflow ref。
+
 ## CI Reusable Workflows
 
 各 repo 將本地的 `build-worker.yaml` / `release-worker.yaml` 替換為呼叫此 repo 的 reusable workflows：


### PR DESCRIPTION
## Summary

- New `.github/dependabot.yml` — weekly `github-actions` scan so template's own consumed actions stay current
- README (en / zh-TW / zh-CN / ja) "Updating" section clarifies `upgrade.sh` already automates the full cycle (subtree pull + integrity check + `init.sh` + `main.yaml` sed)
- Adds a Dependabot snippet downstream repos can adopt to auto-surface template version bumps as PRs

## Context

While upgrading `ros1_bridge` from template v0.9.9 → v0.9.11 I hand-rolled `git subtree pull` + manual `sed` of `main.yaml`, then user asked "can this be automated". Turns out `upgrade.sh` (line 186-202) already does the sed, and `test/integration/upgrade_spec.bats:89-103` verifies it. So this PR closes the **awareness gap**, not a code gap — plus ships a Dependabot config so future version bumps surface as PRs.

No change to `upgrade.sh` itself. No test change needed (existing coverage still applies).

## Test plan
- [ ] CI `test` / `Integration E2E` green (README + yaml only; no executable changes)
- [ ] After merge, verify `.github/dependabot.yml` shows up in GitHub's Dependabot UI