### PR TITLE
fix(ci): build-worker.yaml test-tools build must use load:true

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -144,11 +144,20 @@ jobs:
           mkdir -p /tmp/workspace
 
       - name: Build test-tools image
-        # Must use buildx (not plain `docker build`) so `test-tools:local`
-        # lands in buildx's internal image store — subsequent build
-        # steps on the same builder resolve `COPY --from=test-tools:local`
-        # from there. docker-container's builder container doesn't see
-        # host daemon images.
+        # `load: true` is critical: without it, build-push-action@v6
+        # with push: false just discards the image after build, leaving
+        # the tag `test-tools:local` unresolvable by the next step.
+        # `COPY --from=test-tools:local` then falls back to registry
+        # lookup (docker.io/library/test-tools:local) → pull access
+        # denied → CI fails. `load: true` pushes it into the runner's
+        # host Docker daemon, which the subsequent buildx step reads
+        # from when resolving the COPY --from source.
+        #
+        # `load: true` is incompatible with multi-platform values for
+        # `platforms:` (Docker's image store can't hold a multi-arch
+        # manifest locally), but this workflow's compute-matrix already
+        # splits platforms across separate matrix shards so each shard
+        # only builds a single platform here.
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -156,6 +165,7 @@ jobs:
           tags: test-tools:local
           platforms: ${{ matrix.platform }}
           push: false
+          load: true
 
       - name: Build test stage (includes smoke tests)
         uses: docker/build-push-action@v6

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - README "Updating" section (4 languages) clarifies that `./template/upgrade.sh` already automates subtree pull + integrity check + `init.sh` resync + `main.yaml` `@vX.Y.Z` sed; hand-rolling `git subtree pull` is discouraged since the sed + init steps are easy to forget. Adds a Dependabot snippet downstream repos can drop into their `.github/dependabot.yml` so template version bumps surface as PRs automatically (Dependabot handles workflow refs only; subtree still needs `upgrade.sh`).
 
+### Fixed
+- **`build-worker.yaml` test-tools build now uses `load: true`.** Without it, `docker/build-push-action@v6` with `push: false` discards the built image, so subsequent `COPY --from=test-tools:local` in the downstream Dockerfile can't resolve the tag. buildx then falls back to registry pull → `docker.io/library/test-tools:local: pull access denied` → CI fail. Surfaced when `ros1_bridge` became the first downstream repo to adopt `test-tools:local` post-v0.9.11 (issue #106 migration PR). Added `test/unit/template_spec.bats` regression test asserting the `load: true` flag is present.
+
 ## [v0.9.11] - 2026-04-24
 
 ### Fixed

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **654 tests** total (611 unit + 43 integration).
+Template self-tests: **655 tests** total (612 unit + 43 integration).
 
 ## Test Files
 
@@ -181,7 +181,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `empty extras => no extra mount lines` | empty list |
 | `with GUI+GPU+extras => all sections present` | fully loaded |
 
-### test/unit/template_spec.bats (105)
+### test/unit/template_spec.bats (106)
 
 | Test | Description |
 |------|-------------|
@@ -280,6 +280,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `upgrade.sh --gen-conf delegates to init.sh --gen-conf` | Delegation |
 | `upgrade.sh --help mentions --gen-conf` | Help text |
 | `upgrade.sh updates main.yaml @tag without clobbering release-worker.yaml` | sed regression |
+| `build-worker.yaml test-tools step has load:true` | buildx image-store share |
 | `run.sh contains XDG_SESSION_TYPE check` | X11/Wayland branch |
 | `run.sh contains xhost +SI:localuser for wayland` | Wayland xhost |
 | `run.sh contains xhost +local: for X11` | X11 xhost |

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -703,6 +703,32 @@ EOF
 }
 
 # ════════════════════════════════════════════════════════════════════
+# build-worker.yaml: test-tools step must load:true
+# ════════════════════════════════════════════════════════════════════
+
+@test "build-worker.yaml test-tools step has load:true" {
+  # Regression guard for the docker-container buildx driver:
+  # build-push-action@v6 with `push: false` and no `load: true` discards
+  # the built image. Subsequent `COPY --from=test-tools:local` then
+  # can't resolve the tag, buildx falls back to pulling from Docker
+  # Hub, and the run fails with `pull access denied`. Seen in practice
+  # when ros1_bridge became the first downstream repo to consume the
+  # test-tools:local pattern post-v0.9.11.
+  local _yaml="/source/.github/workflows/build-worker.yaml"
+  [[ -f "${_yaml}" ]] || skip "build-worker.yaml not present in /source"
+
+  # Grab the block starting at "Build test-tools image" up to the next
+  # "- name:" step and assert load: true is inside.
+  run awk '
+    /- name: Build test-tools image/ { inside = 1; next }
+    inside && /^[[:space:]]*- name:/ { inside = 0 }
+    inside { print }
+  ' "${_yaml}"
+  assert_success
+  assert_output --partial 'load: true'
+}
+
+# ════════════════════════════════════════════════════════════════════
 # run.sh: XDG_SESSION_TYPE branching
 # ════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

**Latent bug since v0.9.10**: `build-worker.yaml`'s "Build test-tools image" step used `docker/build-push-action@v6` with `push: false` and no `load:`. That silently discards the built image; `COPY --from=test-tools:local` in the downstream Dockerfile can't resolve the tag, buildx falls back to a registry pull (`docker.io/library/test-tools:local`), gets `pull access denied`, and the build fails.

Template's own self-test never goes through `build-worker.yaml`, so the bug slipped through v0.9.10 / v0.9.11. First caught when `ros1_bridge` PR #25 (issue #106 migration) became the first downstream repo to actually use `test-tools:local`.

## Fix

- `build-worker.yaml`: add `load: true` to the test-tools step so the image lands in the runner's host Docker daemon. The subsequent buildx step reads from there when resolving `COPY --from=test-tools:local`.
- `load: true` is incompatible with multi-platform `platforms:` values, but `compute-matrix` already shards platforms across separate jobs so each shard is single-platform here.

## Test plan

- [x] TDD: added `build-worker.yaml test-tools step has load:true` unit test in `template_spec.bats` — red without fix, green with fix.
- [x] Local `make -f Makefile.ci test` — 655/655 pass.
- [ ] CI template self-test green.
- [ ] After merge + v0.9.12 tag: ros1_bridge PR #25 bumps `main.yaml` → `@v0.9.12`, CI green on the `test-tools:local` flow for the first time.

## Files

- `.github/workflows/build-worker.yaml` — add `load: true` + inline comment explaining why.
- `test/unit/template_spec.bats` — regression test.
- `doc/changelog/CHANGELOG.md` — `[Unreleased]` Fixed entry.
- `doc/test/TEST.md` — test count 654 → 655.