### PR TITLE
feat: migrate test-tools to pre-built GHCR image (closes #106)

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -116,17 +116,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        # docker-container driver is required even on single-platform
-        # builds now: the downstream Dockerfile's `test` stage
-        # references `test-tools:local` via `COPY --from=`, and with
-        # docker-container the tag built in the previous buildx step
-        # stays in the same builder's internal store, which subsequent
-        # build-push-action steps can resolve. The legacy `docker`
-        # driver stores images in the host daemon, which isn't
-        # accessible from a matrix job's buildx container.
         uses: docker/setup-buildx-action@v3
-        with:
-          driver: docker-container
 
       - name: Generate .env
         run: |
@@ -143,31 +133,30 @@ jobs:
           EOF
           mkdir -p /tmp/workspace
 
-      - name: Build test-tools image
-        # `load: true` is critical: without it, build-push-action@v6
-        # with push: false just discards the image after build, leaving
-        # the tag `test-tools:local` unresolvable by the next step.
-        # `COPY --from=test-tools:local` then falls back to registry
-        # lookup (docker.io/library/test-tools:local) → pull access
-        # denied → CI fails. `load: true` pushes it into the runner's
-        # host Docker daemon, which the subsequent buildx step reads
-        # from when resolving the COPY --from source.
-        #
-        # `load: true` is incompatible with multi-platform values for
-        # `platforms:` (Docker's image store can't hold a multi-arch
-        # manifest locally), but this workflow's compute-matrix already
-        # splits platforms across separate matrix shards so each shard
-        # only builds a single platform here.
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: template/dockerfile/Dockerfile.test-tools
-          tags: test-tools:local
-          platforms: ${{ matrix.platform }}
-          push: false
-          load: true
+      - name: Resolve template version for test-tools image
+        # The downstream repo's main.yaml pins this workflow via
+        #   uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@vX.Y.Z
+        # GITHUB_WORKFLOW_REF exposes that full ref at runtime. Parse
+        # out the tag so we can pin the test-tools GHCR image to the
+        # matching template release (prevents version skew between the
+        # workflow logic and the test-tools contract it assumes).
+        id: tplver
+        shell: bash
+        run: |
+          ref="${GITHUB_WORKFLOW_REF##*@}"
+          case "${ref}" in
+            refs/tags/v*) ver="${ref##refs/tags/}" ;;
+            *)            ver="latest" ;;
+          esac
+          printf 'image=ghcr.io/ycpss91255-docker/test-tools:%s\n' "${ver}" >> "${GITHUB_OUTPUT}"
 
       - name: Build test stage (includes smoke tests)
+        # The downstream Dockerfile consumes TEST_TOOLS_IMAGE as the
+        # source of `COPY --from=${TEST_TOOLS_IMAGE}`; buildx auto-pulls
+        # the image from GHCR on `COPY --from=<name:tag>` when the tag
+        # is not present locally, so no explicit docker-pull step is
+        # needed here. Public visibility of the GHCR package means
+        # anonymous pull works, keeping the build-args simple.
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -180,6 +169,7 @@ jobs:
             UID=1000
             GID=1000
             HARDWARE=${{ matrix.hardware }}
+            TEST_TOOLS_IMAGE=${{ steps.tplver.outputs.image }}
             ${{ inputs.build_args }}
 
       - name: Build devel stage

--- a/.github/workflows/release-test-tools.yaml
+++ b/.github/workflows/release-test-tools.yaml
@@ -1,0 +1,68 @@
+name: Release test-tools image to GHCR
+
+# Multi-arch (linux/amd64 + linux/arm64) build of
+# template/dockerfile/Dockerfile.test-tools, pushed to
+# ghcr.io/ycpss91255-docker/test-tools tagged with the release version
+# and :latest. Downstream repo Dockerfiles consume this via
+# `ARG TEST_TOOLS_IMAGE=ghcr.io/ycpss91255-docker/test-tools:<ver>`,
+# avoiding the cross-step image-store isolation that sank the previous
+# `test-tools:local` approach (v0.9.11 pre-D migration).
+#
+# Triggers:
+#   push of a vX.Y.Z tag -> pushes :<tag> and :latest
+#   workflow_dispatch    -> manual bootstrap; pushes only :latest
+#
+# Needs packages: write to push to GHCR under the org namespace.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  release-test-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Resolve tags
+        id: tags
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            ver="${GITHUB_REF##refs/tags/}"
+            printf 'tags=ghcr.io/ycpss91255-docker/test-tools:%s,ghcr.io/ycpss91255-docker/test-tools:latest\n' "${ver}" >> "${GITHUB_OUTPUT}"
+          else
+            printf 'tags=ghcr.io/ycpss91255-docker/test-tools:latest\n' >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Set up QEMU
+        # Needed for the arm64 leg; amd64 alone could skip it, but the
+        # QEMU setup is a no-op on native arch so we keep the workflow
+        # simple with a single builder.
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push multi-arch test-tools image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: template/dockerfile/Dockerfile.test-tools
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.tags.outputs.tags }}
+          push: true

--- a/README.md
+++ b/README.md
@@ -156,9 +156,16 @@ Notes:
 - `test` is always built from `devel`, so runtime assertions inside
   `test/smoke/<repo>_env.bats` see the same binaries / files a user would
   find after `docker run ... <repo>:devel`.
-- `Dockerfile.test-tools` builds a separate `test-tools:local` image (not
-  part of the stage chain above) that the `test` stage copies bats /
-  shellcheck / hadolint binaries from via `COPY --from=test-tools:local`.
+- `Dockerfile.test-tools` builds the lint/test tool bundle (bats + shellcheck +
+  hadolint). The downstream `test` stage consumes it through an `ARG
+  TEST_TOOLS_IMAGE` build arg — defaults to `test-tools:local` (matches the
+  local `./build.sh` flow that builds `Dockerfile.test-tools` into the host
+  Docker daemon). CI overrides it to
+  `ghcr.io/ycpss91255-docker/test-tools:vX.Y.Z` (pre-built multi-arch image
+  pushed by `.github/workflows/release-test-tools.yaml` on every tag) so
+  buildx pulls the arch-correct binaries over the wire instead of rebuilding
+  them per run, and sidesteps the cross-step image-store isolation that
+  `docker-container` buildx drivers enforce.
 
 ### Smoke test helpers (for downstream repos)
 

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`.github/workflows/release-test-tools.yaml`** — on every tag push (and manual `workflow_dispatch`), builds multi-arch (amd64 + arm64) `Dockerfile.test-tools` and publishes to `ghcr.io/ycpss91255-docker/test-tools:<tag>` + `:latest`. First release triggered by this tag; package visibility should be set to public on first push so downstream Dockerfiles can pull anonymously.
+- **`TEST_TOOLS_IMAGE` build-arg** in `Dockerfile.example` — defaults to `test-tools:local` (preserves the local `./build.sh` flow that builds `Dockerfile.test-tools` into the host daemon). Override in CI to `ghcr.io/ycpss91255-docker/test-tools:vX.Y.Z` so buildx pulls the arch-correct pre-built image over the wire.
+
+### Changed
+- **BREAKING for downstream repos adopting v0.9.13+ workflows**: `build-worker.yaml` no longer builds `test-tools:local` in-job. Instead it parses the template version from `GITHUB_WORKFLOW_REF` and passes `TEST_TOOLS_IMAGE=ghcr.io/ycpss91255-docker/test-tools:<template-ver>` as a build-arg to the test stage. Downstream Dockerfiles must add `ARG TEST_TOOLS_IMAGE="test-tools:local"` + `FROM ${TEST_TOOLS_IMAGE} AS test-tools-stage` + `COPY --from=test-tools-stage` (the previous `COPY --from=test-tools:local` literal stops working once repos bump their `main.yaml` `@tag` to `v0.9.13`). Existing repos pinned to `@v0.9.12` or earlier remain unaffected until they upgrade.
+- `Dockerfile.example` test stage restructured: new `FROM ${TEST_TOOLS_IMAGE} AS test-tools-stage` alias, 4 `COPY --from=test-tools:local` → `COPY --from=test-tools-stage`, top-level comment updated.
+
+### Fixed
+- **CI `COPY --from=test-tools:local` no longer fails with `pull access denied` on downstream repos** (follow-up to v0.9.12 `load: true` attempt, which turned out not to share images between buildx steps — [docker/build-push-action#581](https://github.com/docker/build-push-action/issues/581)). GHCR-backed approach sidesteps the cross-step image-store isolation entirely.
+
 ## [v0.9.12] - 2026-04-24
 
 ### Added

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -156,10 +156,7 @@ flowchart LR
 - `test` は常に `devel` を継承するため、`test/smoke/<repo>_env.bats` の
   runtime assertion が確認するバイナリやファイルは、ユーザーが
   `docker run ... <repo>:devel` で目にするものと一致します。
-- `Dockerfile.test-tools` は別途 `test-tools:local` image をビルドし
-  （上記ステージ連鎖には含まれません）、`test` ステージが
-  `COPY --from=test-tools:local` で bats / shellcheck / hadolint
-  バイナリを取り込みます。
+- `Dockerfile.test-tools` は lint/test ツールセット（bats + shellcheck + hadolint）をビルドします。ダウンストリームの `test` ステージは `ARG TEST_TOOLS_IMAGE` build arg で参照します — デフォルト `test-tools:local`（ローカル `./build.sh` フロー、`Dockerfile.test-tools` を host Docker daemon に load）。CI では `ghcr.io/ycpss91255-docker/test-tools:vX.Y.Z`（`.github/workflows/release-test-tools.yaml` がタグ push ごとに publish するマルチアーキ image）で override し、buildx が registry からアーキ対応の bats / shellcheck / hadolint binary を直接 pull します。`docker-container` buildx driver の step 間 image store 分離問題を回避。
 
 ### Smoke test ヘルパー（ダウンストリーム repo 用）
 

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -155,9 +155,7 @@ flowchart LR
 - `test` 总是从 `devel` 继承，所以 `test/smoke/<repo>_env.bats` 中的
   runtime assertion 所看到的二进制与文件，就是用户 `docker run ...
   <repo>:devel` 后会看到的内容。
-- `Dockerfile.test-tools` 另外构建一个 `test-tools:local` image（不在
-  上面的阶段链中），`test` 阶段通过 `COPY --from=test-tools:local`
-  把 bats / shellcheck / hadolint 二进制拉进来。
+- `Dockerfile.test-tools` 构建 lint/test 工具集（bats + shellcheck + hadolint）。下游 `test` 阶段通过 `ARG TEST_TOOLS_IMAGE` build arg 引用 — 默认 `test-tools:local`（对应本地 `./build.sh` 流程,把 `Dockerfile.test-tools` 构建到 host Docker daemon）。CI 则覆盖成 `ghcr.io/ycpss91255-docker/test-tools:vX.Y.Z`（由 `.github/workflows/release-test-tools.yaml` 在每次 tag 推的预构建 multi-arch image）,buildx 直接从 registry 拉对应架构的 bats / shellcheck / hadolint binary,避开 `docker-container` buildx driver 跨 step 不共享 image store 的问题。
 
 ### Smoke test helpers（供下游 repo 使用）
 

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -155,9 +155,7 @@ flowchart LR
 - `test` 永遠從 `devel` 繼承，所以 `test/smoke/<repo>_env.bats` 裡的
   runtime assertion 所看到的二進位與檔案，就是使用者 `docker run ...
   <repo>:devel` 後會看到的內容。
-- `Dockerfile.test-tools` 另外建置一個 `test-tools:local` image（不在
-  上面的階段鏈中），`test` 階段透過 `COPY --from=test-tools:local`
-  把 bats / shellcheck / hadolint 二進位拉進來。
+- `Dockerfile.test-tools` 建置 lint/test 工具集（bats + shellcheck + hadolint）。下游 `test` 階段透過 `ARG TEST_TOOLS_IMAGE` build arg 引用 — 預設 `test-tools:local`（對應本地 `./build.sh` 流程,把 `Dockerfile.test-tools` 建到 host Docker daemon）。CI 則覆寫成 `ghcr.io/ycpss91255-docker/test-tools:vX.Y.Z`（由 `.github/workflows/release-test-tools.yaml` 在每次 tag 推的預建 multi-arch image）,buildx 直接從 registry 拉對應架構的 bats / shellcheck / hadolint binary,避開 `docker-container` buildx driver 跨 step 不共享 image store 的問題。
 
 ### Smoke test helpers（供下游 repo 使用）
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **655 tests** total (612 unit + 43 integration).
+Template self-tests: **663 tests** total (620 unit + 43 integration).
 
 ## Test Files
 
@@ -181,7 +181,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `empty extras => no extra mount lines` | empty list |
 | `with GUI+GPU+extras => all sections present` | fully loaded |
 
-### test/unit/template_spec.bats (106)
+### test/unit/template_spec.bats (114)
 
 | Test | Description |
 |------|-------------|
@@ -280,7 +280,15 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `upgrade.sh --gen-conf delegates to init.sh --gen-conf` | Delegation |
 | `upgrade.sh --help mentions --gen-conf` | Help text |
 | `upgrade.sh updates main.yaml @tag without clobbering release-worker.yaml` | sed regression |
-| `build-worker.yaml test-tools step has load:true` | buildx image-store share |
+| `build-worker.yaml: no legacy in-job test-tools build step` | v0.9.13 GHCR migration |
+| `build-worker.yaml: resolves template version from GITHUB_WORKFLOW_REF` | GHCR tag resolution |
+| `build-worker.yaml: test build passes TEST_TOOLS_IMAGE build-arg` | build-arg wiring |
+| `Dockerfile.example has ARG TEST_TOOLS_IMAGE with test-tools:local default` | ARG default |
+| `Dockerfile.example FROM ${TEST_TOOLS_IMAGE} AS test-tools-stage` | named stage alias |
+| `Dockerfile.example test stage copies from test-tools-stage, not test-tools:local` | stage rename migration |
+| `release-test-tools.yaml exists and pushes to ghcr.io/ycpss91255-docker/test-tools` | GHCR publisher |
+| `release-test-tools.yaml declares packages:write permission` | ghcr auth scope |
+| `release-test-tools.yaml builds multi-arch (amd64 + arm64)` | arch coverage |
 | `run.sh contains XDG_SESSION_TYPE check` | X11/Wayland branch |
 | `run.sh contains xhost +SI:localuser for wayland` | Wayland xhost |
 | `run.sh contains xhost +local: for X11` | X11 xhost |

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -1,7 +1,13 @@
 # Dockerfile.example - Template for new Docker container repos
 #
 # Copy this file to your repo root as "Dockerfile" and customize.
-# The test-tools image (ShellCheck, Hadolint, Bats) is pre-built by build.sh.
+# The test-tools image (ShellCheck, Hadolint, Bats) is consumed via the
+# TEST_TOOLS_IMAGE build arg. Default `test-tools:local` works for the
+# local `./build.sh` flow (builds Dockerfile.test-tools into the host
+# Docker daemon). CI overrides this to
+# `ghcr.io/ycpss91255-docker/test-tools:vX.Y.Z` so buildx can pull the
+# arch-correct pre-built image without the cross-step image-store
+# isolation that broke the old test-tools:local CI pattern.
 #
 # Stages:
 #   sys     - User/group, locale, timezone
@@ -11,6 +17,7 @@
 #   runtime - Minimal runtime image (optional)
 
 ARG BASE_IMAGE="ubuntu:24.04"
+ARG TEST_TOOLS_IMAGE="test-tools:local"
 
 ############################## sys ##############################
 FROM ${BASE_IMAGE} AS sys
@@ -120,13 +127,16 @@ ENTRYPOINT ["/entrypoint.sh"]
 CMD ["bash"]
 
 ############################## test ##############################
+# Resolves to test-tools:local (local build.sh) or ghcr.io/.../test-tools:vX.Y.Z (CI).
+FROM ${TEST_TOOLS_IMAGE} AS test-tools-stage
+
 FROM devel AS test
 
 USER root
 
-# Lint tools (from pre-built test-tools image)
-COPY --from=test-tools:local /usr/local/bin/shellcheck /usr/local/bin/shellcheck
-COPY --from=test-tools:local /usr/local/bin/hadolint /usr/local/bin/hadolint
+# Lint tools (from pre-built test-tools image; see TEST_TOOLS_IMAGE at top)
+COPY --from=test-tools-stage /usr/local/bin/shellcheck /usr/local/bin/shellcheck
+COPY --from=test-tools-stage /usr/local/bin/hadolint /usr/local/bin/hadolint
 
 # Lint: ShellCheck (.sh) + Hadolint (Dockerfile)
 COPY .hadolint.yaml /lint/.hadolint.yaml
@@ -146,9 +156,9 @@ COPY template/script/docker/_lib.sh \
 RUN shellcheck -S warning /lint/*.sh
 RUN cd /lint && hadolint Dockerfile
 
-# Bats (from pre-built test-tools image)
-COPY --from=test-tools:local /opt/bats /opt/bats
-COPY --from=test-tools:local /usr/lib/bats /usr/lib/bats
+# Bats (from pre-built test-tools image; see TEST_TOOLS_IMAGE at top)
+COPY --from=test-tools-stage /opt/bats /opt/bats
+COPY --from=test-tools-stage /usr/lib/bats /usr/lib/bats
 RUN ln -sf /opt/bats/bin/bats /usr/local/bin/bats
 
 ENV BATS_LIB_PATH="/usr/lib/bats"

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -703,29 +703,98 @@ EOF
 }
 
 # ════════════════════════════════════════════════════════════════════
-# build-worker.yaml: test-tools step must load:true
+# build-worker.yaml: GHCR test-tools migration (D plan)
 # ════════════════════════════════════════════════════════════════════
 
-@test "build-worker.yaml test-tools step has load:true" {
-  # Regression guard for the docker-container buildx driver:
-  # build-push-action@v6 with `push: false` and no `load: true` discards
-  # the built image. Subsequent `COPY --from=test-tools:local` then
-  # can't resolve the tag, buildx falls back to pulling from Docker
-  # Hub, and the run fails with `pull access denied`. Seen in practice
-  # when ros1_bridge became the first downstream repo to consume the
-  # test-tools:local pattern post-v0.9.11.
+@test "build-worker.yaml: no legacy in-job test-tools build step" {
+  # The old `Build test-tools image` step is replaced by GHCR pull
+  # via the TEST_TOOLS_IMAGE build-arg. If it reappears, CI will hit
+  # the cross-step buildx image-store isolation again (v0.9.12 regression).
   local _yaml="/source/.github/workflows/build-worker.yaml"
   [[ -f "${_yaml}" ]] || skip "build-worker.yaml not present in /source"
+  run grep -c 'Build test-tools image' "${_yaml}"
+  assert_output "0"
+}
 
-  # Grab the block starting at "Build test-tools image" up to the next
-  # "- name:" step and assert load: true is inside.
+@test "build-worker.yaml: resolves template version from GITHUB_WORKFLOW_REF" {
+  local _yaml="/source/.github/workflows/build-worker.yaml"
+  [[ -f "${_yaml}" ]] || skip "build-worker.yaml not present in /source"
+  run grep -F 'GITHUB_WORKFLOW_REF' "${_yaml}"
+  assert_success
+  # outputs var must carry the ghcr.io tag for downstream build-arg pass-through
+  run grep -F 'ghcr.io/ycpss91255-docker/test-tools' "${_yaml}"
+  assert_success
+}
+
+@test "build-worker.yaml: test build passes TEST_TOOLS_IMAGE build-arg" {
+  local _yaml="/source/.github/workflows/build-worker.yaml"
+  [[ -f "${_yaml}" ]] || skip "build-worker.yaml not present in /source"
+  # The test-stage build step must include TEST_TOOLS_IMAGE so the
+  # downstream Dockerfile's `FROM ${TEST_TOOLS_IMAGE}` stage resolves
+  # to the GHCR image (not the local fallback tag).
   run awk '
-    /- name: Build test-tools image/ { inside = 1; next }
-    inside && /^[[:space:]]*- name:/ { inside = 0 }
+    /- name: Build test stage/ { inside = 1 }
+    inside && /^[[:space:]]*- name:/ && !/Build test stage/ { inside = 0 }
     inside { print }
   ' "${_yaml}"
   assert_success
-  assert_output --partial 'load: true'
+  assert_output --partial 'TEST_TOOLS_IMAGE='
+}
+
+# ════════════════════════════════════════════════════════════════════
+# Dockerfile.example: TEST_TOOLS_IMAGE ARG + named stage
+# ════════════════════════════════════════════════════════════════════
+
+@test "Dockerfile.example has ARG TEST_TOOLS_IMAGE with test-tools:local default" {
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  run grep -E '^ARG TEST_TOOLS_IMAGE="test-tools:local"' "${_df}"
+  assert_success
+}
+
+@test "Dockerfile.example FROM \${TEST_TOOLS_IMAGE} AS test-tools-stage" {
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  run grep -F 'FROM ${TEST_TOOLS_IMAGE} AS test-tools-stage' "${_df}"
+  assert_success
+}
+
+@test "Dockerfile.example test stage copies from test-tools-stage, not test-tools:local" {
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  # All COPY --from referring to the test-tools image must now use the
+  # named stage alias.
+  run grep -c 'COPY --from=test-tools-stage' "${_df}"
+  # 4 copies expected: shellcheck, hadolint, /opt/bats, /usr/lib/bats
+  assert_output "4"
+  # Legacy tag reference must be gone:
+  run grep -c 'COPY --from=test-tools:local' "${_df}"
+  assert_output "0"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# release-test-tools.yaml: GHCR publisher workflow
+# ════════════════════════════════════════════════════════════════════
+
+@test "release-test-tools.yaml exists and pushes to ghcr.io/ycpss91255-docker/test-tools" {
+  local _yaml="/source/.github/workflows/release-test-tools.yaml"
+  [[ -f "${_yaml}" ]] || skip "release-test-tools.yaml not present in /source"
+  run grep -F 'ghcr.io/ycpss91255-docker/test-tools' "${_yaml}"
+  assert_success
+}
+
+@test "release-test-tools.yaml declares packages:write permission" {
+  local _yaml="/source/.github/workflows/release-test-tools.yaml"
+  [[ -f "${_yaml}" ]] || skip "release-test-tools.yaml not present in /source"
+  run grep -F 'packages: write' "${_yaml}"
+  assert_success
+}
+
+@test "release-test-tools.yaml builds multi-arch (amd64 + arm64)" {
+  local _yaml="/source/.github/workflows/release-test-tools.yaml"
+  [[ -f "${_yaml}" ]] || skip "release-test-tools.yaml not present in /source"
+  run grep -F 'platforms: linux/amd64,linux/arm64' "${_yaml}"
+  assert_success
 }
 
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

v0.9.12 tried to fix `test-tools:local` CI resolution with `load: true`, but that turned out not to share images between buildx steps ([docker/build-push-action#581](https://github.com/docker/build-push-action/issues/581)). First caught when `ros1_bridge` PR #25 became the first downstream repo to actually consume `test-tools:local` — CI died at `pull access denied, repository does not exist` trying to fall back to Docker Hub.

This PR ships the **D plan**: publish test-tools to GHCR per tag, and parameterize the downstream Dockerfile with `ARG TEST_TOOLS_IMAGE` so buildx pulls the arch-correct pre-built image directly.

## Changes

### New workflow: `release-test-tools.yaml`
Triggers on `push: tags: ['v*']` + `workflow_dispatch`. Multi-arch (amd64 + arm64) build of `Dockerfile.test-tools`, pushed to `ghcr.io/ycpss91255-docker/test-tools:<tag>` + `:latest`. Uses `GITHUB_TOKEN` with `packages: write`.

### `build-worker.yaml`
- Removes the in-job `Build test-tools image` step (eliminates cross-step buildx image-store race).
- Adds a version-resolution step that parses `GITHUB_WORKFLOW_REF` to derive the template tag the downstream pinned (e.g. `v0.9.13`), then passes `TEST_TOOLS_IMAGE=ghcr.io/ycpss91255-docker/test-tools:v0.9.13` as a build-arg.

### `Dockerfile.example`
- Top-level `ARG TEST_TOOLS_IMAGE="test-tools:local"` default keeps local `./build.sh` flow unchanged.
- New `FROM ${TEST_TOOLS_IMAGE} AS test-tools-stage` alias before the test stage.
- All four `COPY --from=test-tools:local` call sites switched to `--from=test-tools-stage`.

### Tests (+9 / -1)
- Dropped the v0.9.12 `load: true` assertion (no longer applies; the step is gone).
- Added regression guards: no leftover test-tools build step, `GITHUB_WORKFLOW_REF` parsing present, `TEST_TOOLS_IMAGE` build-arg wired, Dockerfile.example `ARG` + named stage + 4 `--from=test-tools-stage` + 0 legacy `--from=test-tools:local`, release-test-tools.yaml publishes to correct GHCR path with `packages:write` + multi-arch.

### Docs
- CHANGELOG `[Unreleased]` flags **BREAKING** for downstream repos pinning `@v0.9.13+` (they must adopt the ARG + named stage pattern).
- README (en / zh-TW / zh-CN / ja) `Dockerfile.test-tools` paragraph rewritten to document the dual local/CI paths.
- TEST.md 655 → 663 (template_spec 106 → 114).

## Bootstrap sequence (post-merge)

1. Merge this PR to main.
2. Manually run `release-test-tools.yaml` via `workflow_dispatch` → publishes `ghcr.io/ycpss91255-docker/test-tools:latest`. Set GHCR package visibility to **public** so anonymous pulls work.
3. Open release PR for **v0.9.13** (bumps `.version` + CHANGELOG cut).
4. Merge release PR, tag `v0.9.13` → `release-test-tools.yaml` auto-publishes `:v0.9.13`.
5. Update downstream `ros1_bridge` PR #25: Dockerfile `ARG TEST_TOOLS_IMAGE` + named stage pattern, `main.yaml` bumps `@v0.9.12` → `@v0.9.13`, CI validates the end-to-end flow for the first time.

## Test plan
- [x] `make -f Makefile.ci test` local — 663/663 pass
- [ ] CI template self-test green on this PR
- [ ] Post-merge + tag + ros1_bridge downstream: CI resolves TEST_TOOLS_IMAGE to GHCR tag and builds successfully

Closes #106.