### PR TITLE
fix(ci): release-test-tools Dockerfile path (drop subtree prefix)

### DIFF
--- a/.github/workflows/release-test-tools.yaml
+++ b/.github/workflows/release-test-tools.yaml
@@ -59,10 +59,15 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push multi-arch test-tools image
+        # This workflow runs inside the template repo, not a downstream
+        # consumer, so the Dockerfile lives at `dockerfile/...`, not
+        # `template/dockerfile/...` (the latter is only the subtree path
+        # downstream repos see and is what build-worker.yaml uses since
+        # that workflow executes in the downstream's checkout).
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: template/dockerfile/Dockerfile.test-tools
+          file: dockerfile/Dockerfile.test-tools
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tags.outputs.tags }}
           push: true

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **663 tests** total (620 unit + 43 integration).
+Template self-tests: **664 tests** total (621 unit + 43 integration).
 
 ## Test Files
 
@@ -181,7 +181,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `empty extras => no extra mount lines` | empty list |
 | `with GUI+GPU+extras => all sections present` | fully loaded |
 
-### test/unit/template_spec.bats (114)
+### test/unit/template_spec.bats (115)
 
 | Test | Description |
 |------|-------------|
@@ -289,6 +289,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `release-test-tools.yaml exists and pushes to ghcr.io/ycpss91255-docker/test-tools` | GHCR publisher |
 | `release-test-tools.yaml declares packages:write permission` | ghcr auth scope |
 | `release-test-tools.yaml builds multi-arch (amd64 + arm64)` | arch coverage |
+| `release-test-tools.yaml uses template-repo-local Dockerfile path` | no subtree path confusion |
 | `run.sh contains XDG_SESSION_TYPE check` | X11/Wayland branch |
 | `run.sh contains xhost +SI:localuser for wayland` | Wayland xhost |
 | `run.sh contains xhost +local: for X11` | X11 xhost |

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -797,6 +797,19 @@ EOF
   assert_success
 }
 
+@test "release-test-tools.yaml uses template-repo-local Dockerfile path" {
+  # Regression: this workflow runs in the template repo, so Dockerfile.test-tools
+  # path must be `dockerfile/...` (not `template/dockerfile/...` which is the
+  # downstream subtree path used by build-worker.yaml).
+  local _yaml="/source/.github/workflows/release-test-tools.yaml"
+  [[ -f "${_yaml}" ]] || skip "release-test-tools.yaml not present in /source"
+  run grep -E '^\s*file: dockerfile/Dockerfile\.test-tools$' "${_yaml}"
+  assert_success
+  # And must NOT have the subtree-prefixed path:
+  run grep -c 'file: template/dockerfile/Dockerfile.test-tools' "${_yaml}"
+  assert_output "0"
+}
+
 # ════════════════════════════════════════════════════════════════════
 # run.sh: XDG_SESSION_TYPE branching
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Bootstrap `workflow_dispatch` of `release-test-tools.yaml` failed:

```
ERROR: failed to build: resolve : lstat template: no such file or directory
```

`release-test-tools.yaml` runs in the **template** repo, so `Dockerfile.test-tools` is at `dockerfile/Dockerfile.test-tools` — not `template/dockerfile/Dockerfile.test-tools` (that's the subtree path downstream consumers see, used by `build-worker.yaml` which executes in a downstream's checkout).

## Changes

- `.github/workflows/release-test-tools.yaml`: `template/dockerfile/` → `dockerfile/` + comment explaining the path asymmetry.
- `test/unit/template_spec.bats`: regression test asserting the template-repo-local path and no subtree prefix leak.
- `TEST.md`: 663 → 664.

## Test plan
- [x] `make -f Makefile.ci test` local — 664/664 pass
- [ ] CI template self-test green
- [ ] Post-merge: re-trigger `release-test-tools.yaml` via `workflow_dispatch` → pushes `ghcr.io/ycpss91255-docker/test-tools:latest` successfully