### PR TITLE
feat: runtime compose service + run.sh cmd passthrough (#108, #118)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`runtime` compose service auto-emission (closes #108)**. `setup.sh` now detects a `FROM <base> AS runtime` stage in the sibling Dockerfile and emits a paired `runtime` service that `extends: { service: devel }` (inherits volumes / env / network / GPU / caps), overrides `build.target`, `image` (`:runtime` tag), `container_name` (`<name>-runtime`), and flips `stdin_open: false` / `tty: false` for headless auto-run. Gated by `profiles: [runtime]` so plain `compose up` still scopes to `devel`; `compose run runtime` / `compose up runtime` (and `./run.sh -t runtime`) target it explicitly. Repos without an `AS runtime` stage get no emission (no broken service entry).
+
+### Changed
+- **BREAKING: `./run.sh` arg semantics aligned with `docker run <image> [cmd]` (closes #118).**
+  - Target is now the explicit `-t TARGET` / `--target TARGET` flag (default `devel`).
+  - Positional args after options are the CMD to run inside the container, mirroring `exec.sh`. Empty CMD → Dockerfile CMD runs (`devel` = `bash`, `runtime` = its auto-run service). Non-empty CMD → overrides Dockerfile CMD.
+  - `-d` + CMD → error (exit 2) with a pointer to `./exec.sh` for the detached-container cmd case; `-d` alone is unchanged (`compose up -d TARGET`).
+  - Migration: `./run.sh runtime` → `./run.sh -t runtime`. `./run.sh test` → `./run.sh -t test`. Plain `./run.sh` still drops into devel bash (unchanged UX).
+
 ## [v0.9.13] - 2026-04-24
 
 ### Added

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **664 tests** total (621 unit + 43 integration).
+Template self-tests: **674 tests** total (631 unit + 43 integration).
 
 ## Test Files
 
@@ -111,7 +111,7 @@ build invocation, and **runtime log-line i18n** (bootstrap /
 drift-regen / err_no_env messages translate in all four languages via
 the local `_msg()` table; English remains the default).
 
-### test/unit/run_sh_spec.bats (30)
+### test/unit/run_sh_spec.bats (33)
 
 Unit tests for `run.sh`. Mirrors the build_sh_spec.bats harness;
 `docker ps` reads from a controllable stub file so tests can simulate
@@ -156,7 +156,7 @@ Chinese / Simplified Chinese / Japanese translations of the
 no-instances message, `--all` multi-project teardown loop, and
 fallback `_detect_lang` branches.
 
-### test/unit/compose_gen_spec.bats (38)
+### test/unit/compose_gen_spec.bats (45)
 
 Covers `generate_compose_yaml` conditional output: AUTO-GENERATED
 header, baseline workspace volume, network/ipc/privileged env-var
@@ -180,6 +180,13 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `extra volumes appended after baseline` | volumes list |
 | `empty extras => no extra mount lines` | empty list |
 | `with GUI+GPU+extras => all sections present` | fully loaded |
+| `emits runtime service when Dockerfile has AS runtime` | #108 auto-emit |
+| `skips runtime service when Dockerfile lacks AS runtime` | opt-out by absence |
+| `skips runtime service when Dockerfile is absent` | no-Dockerfile guard |
+| `runtime service extends devel and overrides target/image/tty/profile` | compose extends shape |
+| `runtime service appears between devel and test blocks` | ordering |
+| `runtime detection is robust against weird whitespace` | regex tolerance |
+| `runtime detection ignores non-runtime stage names` | strict match |
 
 ### test/unit/template_spec.bats (115)
 

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -58,74 +58,82 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./run.sh [-h] [-d|--detach] [-s|--setup] [--dry-run] [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
+用法: ./run.sh [-h] [-d|--detach] [-s|--setup] [--dry-run] [--instance NAME]
+              [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [CMD...]
 
 選項:
   -h, --help        顯示此說明
-  -d, --detach      背景執行（docker compose up -d）
+  -t, --target T    Compose service 名稱（預設: devel；例: runtime）
+  -d, --detach      背景執行（docker compose up -d，不接受 CMD）
   -s, --setup       強制重跑 setup.sh 重新生成 .env + compose.yaml
                     （預設：.env 不存在時自動 bootstrap；存在時僅印 drift warning）
   --dry-run         只印出將執行的 docker 指令，不實際執行
   --instance NAME   啟動命名 instance（與預設並行,suffix=-NAME）
   --lang LANG       設定訊息語言（預設: en）
 
-目標:
-  devel    開發環境（預設）
-  runtime  最小化 runtime
+CMD: 啟動容器後要執行的指令，對齊 `docker run <image> [cmd]` 語意：
+  無 CMD  → 跑 Dockerfile 的 CMD（例: devel=bash, runtime=auto-run service）
+  有 CMD  → 覆蓋 Dockerfile CMD（例: ./run.sh -t runtime bash 進 runtime shell）
 EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./run.sh [-h] [-d|--detach] [-s|--setup] [--dry-run] [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
+用法: ./run.sh [-h] [-d|--detach] [-s|--setup] [--dry-run] [--instance NAME]
+              [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [CMD...]
 
 选项:
   -h, --help        显示此说明
-  -d, --detach      后台运行（docker compose up -d）
+  -t, --target T    Compose service 名称（默认: devel；例: runtime）
+  -d, --detach      后台运行（docker compose up -d，不接受 CMD）
   -s, --setup       强制重跑 setup.sh 重新生成 .env + compose.yaml
                     （默认：.env 不存在时自动 bootstrap；存在时仅打印 drift warning）
   --dry-run         只打印将执行的 docker 命令，不实际执行
   --instance NAME   启动命名 instance（与默认并行,suffix=-NAME）
   --lang LANG       设置消息语言（默认: en）
 
-目标:
-  devel    开发环境（默认）
-  runtime  最小化 runtime
+CMD: 启动容器后要执行的指令，对齐 `docker run <image> [cmd]` 语义:
+  无 CMD  → 跑 Dockerfile 的 CMD（例: devel=bash, runtime=auto-run service）
+  有 CMD  → 覆盖 Dockerfile CMD（例: ./run.sh -t runtime bash 进 runtime shell）
 EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./run.sh [-h] [-d|--detach] [-s|--setup] [--dry-run] [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
+使用法: ./run.sh [-h] [-d|--detach] [-s|--setup] [--dry-run] [--instance NAME]
+               [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [CMD...]
 
 オプション:
   -h, --help        このヘルプを表示
-  -d, --detach      バックグラウンドで実行（docker compose up -d）
+  -t, --target T    Compose サービス名（デフォルト: devel；例: runtime）
+  -d, --detach      バックグラウンド実行（docker compose up -d、CMD は受け付けない）
   -s, --setup       setup.sh を強制実行して .env + compose.yaml を再生成
                     （デフォルト：.env が無ければ自動 bootstrap、あれば drift warning のみ）
   --dry-run         実行される docker コマンドを表示するのみ（実行はしない）
   --instance NAME   名前付き instance を起動（デフォルトと並行、suffix=-NAME）
   --lang LANG       メッセージ言語を設定（デフォルト: en）
 
-ターゲット:
-  devel    開発環境（デフォルト）
-  runtime  最小化ランタイム
+CMD: コンテナ起動後に実行するコマンド。`docker run <image> [cmd]` セマンティクス:
+  CMD 無し → Dockerfile の CMD を実行（例: devel=bash, runtime=auto-run service）
+  CMD あり → Dockerfile CMD を上書き（例: ./run.sh -t runtime bash で runtime shell）
 EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./run.sh [-h] [-d|--detach] [-s|--setup] [--dry-run] [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
+Usage: ./run.sh [-h] [-d|--detach] [-s|--setup] [--dry-run] [--instance NAME]
+               [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [CMD...]
 
 Options:
   -h, --help        Show this help
-  -d, --detach      Run in background (docker compose up -d)
+  -t, --target T    Compose service name (default: devel; e.g. runtime)
+  -d, --detach      Run in background (docker compose up -d; no CMD accepted)
   -s, --setup       Force rerun setup.sh to regenerate .env + compose.yaml
                     (default: auto-bootstrap if .env missing; warn on drift if present)
   --dry-run         Print the docker commands that would run, but do not execute
   --instance NAME   Start a named parallel instance (suffix=-NAME)
   --lang LANG       Set message language (default: en)
 
-Targets:
-  devel    Development environment (default)
-  runtime  Minimal runtime
+CMD: Command to run after the container starts; mirrors `docker run <image> [cmd]`:
+  no CMD  → run the Dockerfile CMD (e.g. devel=bash, runtime=auto-run service)
+  with CMD → override the Dockerfile CMD (e.g. ./run.sh -t runtime bash to shell in)
 EOF
       ;;
   esac
@@ -147,6 +155,7 @@ main() {
   local DETACH=false
   local TARGET="devel"
   local INSTANCE=""
+  local -a CMD_ARGS=()
   DRY_RUN=false
 
   while [[ $# -gt 0 ]]; do
@@ -175,13 +184,37 @@ main() {
         _sanitize_lang _LANG "run"
         shift 2
         ;;
+      -t|--target)
+        TARGET="${2:?"-t/--target requires a value (e.g. devel, runtime)"}"
+        shift 2
+        ;;
+      --)
+        shift
+        CMD_ARGS+=("$@")
+        break
+        ;;
       *)
-        TARGET="$1"
+        # Positional from here on is the CMD to run inside the container,
+        # mirroring `docker run <image> [cmd...]` semantics. Empty CMD_ARGS
+        # means "use the Dockerfile CMD".
+        CMD_ARGS+=("$1")
         shift
         ;;
     esac
   done
   export DRY_RUN
+
+  # -d is background `compose up`, which starts the service with its
+  # compose-level command (for devel: tty/stdin_open keep it alive; for
+  # runtime: the Dockerfile CMD runs headless). `up` has no slot for an
+  # override cmd, so -d + CMD is ambiguous — refuse rather than silently
+  # drop the cmd.
+  if [[ "${DETACH}" == true ]] && (( ${#CMD_ARGS[@]} > 0 )); then
+    printf "[run] ERROR: -d/--detach does not accept a CMD (got: %s). " "${CMD_ARGS[*]}" >&2
+    printf "Use './exec.sh -t %s %s' to run a command inside a detached container.\n" \
+      "${TARGET}" "${CMD_ARGS[*]}" >&2
+    exit 2
+  fi
 
   local _setup="${FILE_PATH}/template/script/docker/setup.sh"
   local _tui="${FILE_PATH}/setup_tui.sh"
@@ -272,12 +305,25 @@ main() {
     # Foreground devel: `up -d` + `exec` so a second terminal can join via
     # `./exec.sh`. Trap auto-`down` on exit to preserve the
     # "exit shell = container gone" semantic of the previous `compose run`.
+    # CMD_ARGS passthrough: empty → `bash` (matches Dockerfile CMD for devel);
+    # non-empty → override (e.g. `./run.sh ls /tmp`).
     trap _devel_cleanup EXIT
     _compose_project up -d "${TARGET}"
-    _compose_project exec "${TARGET}" bash
+    if (( ${#CMD_ARGS[@]} > 0 )); then
+      _compose_project exec "${TARGET}" "${CMD_ARGS[@]}"
+    else
+      _compose_project exec "${TARGET}" bash
+    fi
   else
-    # Other one-shot stages (test, runtime, ...): keep `compose run --rm`.
-    _compose_project run --rm "${TARGET}"
+    # Other one-shot stages (runtime, test, ...): `compose run --rm` with
+    # CMD passthrough. Empty CMD_ARGS → service's Dockerfile CMD runs
+    # (e.g. runtime auto-boots parameter_bridge). Non-empty overrides
+    # (e.g. `./run.sh -t runtime bash` to debug interactively).
+    if (( ${#CMD_ARGS[@]} > 0 )); then
+      _compose_project run --rm "${TARGET}" "${CMD_ARGS[@]}"
+    else
+      _compose_project run --rm "${TARGET}"
+    fi
   fi
 }
 

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -693,6 +693,21 @@ generate_compose_yaml() {
     printf '    runtime: %s\n' "${_runtime}"
   }
 
+  # Detect `FROM … AS runtime` in the sibling Dockerfile — if present,
+  # emit a dedicated `runtime` compose service that extends `devel`'s
+  # baseline (same volumes / network / caps / GPU) but with its own
+  # image tag, container_name, and non-interactive tty settings so
+  # `./run.sh -t runtime` auto-runs the Dockerfile CMD (e.g. a
+  # parameter_bridge process). Absent `AS runtime` → skip emission so
+  # repos without a runtime stage don't get a broken service entry.
+  # Issue #108.
+  local _dockerfile _has_runtime=false
+  _dockerfile="$(dirname -- "${_out}")/Dockerfile"
+  if [[ -f "${_dockerfile}" ]] \
+     && grep -qE '^FROM[[:space:]]+[^[:space:]]+[[:space:]]+AS[[:space:]]+runtime[[:space:]]*$' "${_dockerfile}"; then
+    _has_runtime=true
+  fi
+
   # Convert space-separated caps to YAML array form [a, b, c]
   local -a _caps_arr=()
   read -ra _caps_arr <<< "${_gpu_caps}"
@@ -878,6 +893,33 @@ YAML
               capabilities: ${_caps_yaml}
 YAML
     fi
+
+    # runtime service (when Dockerfile has `AS runtime`): extends devel's
+    # baseline (volumes, network, GPU, capabilities), overrides target +
+    # image + container_name, disables tty/stdin_open since runtime is
+    # auto-run headless (Dockerfile CMD drives). profiles: [runtime]
+    # keeps plain `compose up` scoped to devel; `compose run runtime` or
+    # `compose up runtime` still works because explicit-service targeting
+    # bypasses the profile gate.
+    if [[ "${_has_runtime}" == true ]]; then
+      cat <<YAML
+
+  runtime:
+    extends:
+      service: devel
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
+    image: \${DOCKER_HUB_USER:-local}/${_name}:runtime
+    container_name: ${_name}-runtime\${INSTANCE_SUFFIX:-}
+    stdin_open: false
+    tty: false
+    profiles:
+      - runtime
+YAML
+    fi
+
     cat <<YAML
 
   test:

--- a/test/unit/compose_gen_spec.bats
+++ b/test/unit/compose_gen_spec.bats
@@ -502,3 +502,130 @@ teardown() {
   (( _tty_line < _runtime_line ))
   (( _runtime_line < _cap_line ))
 }
+
+# ════════════════════════════════════════════════════════════════════
+# Runtime service auto-emission (issue #108)
+# ════════════════════════════════════════════════════════════════════
+#
+# When the sibling Dockerfile declares `FROM <base> AS runtime`, setup.sh
+# emits a dedicated `runtime` compose service alongside `devel`/`test`.
+# Absent that stage, emission is skipped so plain-dev repos don't get a
+# broken service entry.
+
+@test "generate_compose_yaml emits runtime service when Dockerfile has AS runtime" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'DOCK'
+FROM ubuntu:24.04 AS devel
+CMD ["bash"]
+
+FROM devel AS runtime
+CMD ["/entrypoint.sh"]
+DOCK
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras
+  run grep -E '^  runtime:' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "generate_compose_yaml skips runtime service when Dockerfile lacks AS runtime" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'DOCK'
+FROM ubuntu:24.04 AS devel
+CMD ["bash"]
+DOCK
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras
+  run grep -cE '^  runtime:' "${COMPOSE_OUT}"
+  assert_output "0"
+}
+
+@test "generate_compose_yaml skips runtime service when Dockerfile is absent" {
+  # No Dockerfile in TEMP_DIR at all.
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras
+  run grep -cE '^  runtime:' "${COMPOSE_OUT}"
+  assert_output "0"
+}
+
+@test "runtime service extends devel and overrides target/image/tty/profile" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'DOCK'
+FROM ubuntu:24.04 AS devel
+CMD ["bash"]
+
+FROM devel AS runtime
+CMD ["/app"]
+DOCK
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras
+  # extends → devel (compose merges base volumes, env, caps, etc.)
+  run grep -F 'service: devel' "${COMPOSE_OUT}"
+  assert_success
+  # build target override
+  run grep -F 'target: runtime' "${COMPOSE_OUT}"
+  assert_success
+  # image tag is :runtime (not :devel)
+  run grep -E '^    image:.*:runtime$' "${COMPOSE_OUT}"
+  assert_success
+  # container_name uses -runtime suffix + INSTANCE_SUFFIX support
+  run grep -F 'container_name: myrepo-runtime${INSTANCE_SUFFIX:-}' "${COMPOSE_OUT}"
+  assert_success
+  # non-interactive (runtime is headless auto-run, Dockerfile CMD drives)
+  run grep -E '^    stdin_open: false$' "${COMPOSE_OUT}"
+  assert_success
+  run grep -E '^    tty: false$' "${COMPOSE_OUT}"
+  assert_success
+  # profiles gate prevents plain `compose up` from starting runtime.
+  # `--` guards against grep reading the leading `-` as an option.
+  run grep -F -- '- runtime' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "runtime service appears between devel and test blocks" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'DOCK'
+FROM ubuntu:24.04 AS devel
+CMD ["bash"]
+
+FROM devel AS runtime
+CMD ["/app"]
+DOCK
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras
+  local _devel _runtime _test
+  _devel="$(grep -n '^  devel:'   "${COMPOSE_OUT}" | head -1 | cut -d: -f1)"
+  _runtime="$(grep -n '^  runtime:' "${COMPOSE_OUT}" | head -1 | cut -d: -f1)"
+  _test="$(grep -n '^  test:'    "${COMPOSE_OUT}" | head -1 | cut -d: -f1)"
+  (( _devel < _runtime ))
+  (( _runtime < _test ))
+}
+
+@test "runtime detection is robust against weird whitespace" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'DOCK'
+FROM ubuntu:24.04    AS    devel
+CMD ["bash"]
+
+FROM   devel   AS   runtime
+CMD ["/app"]
+DOCK
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras
+  run grep -E '^  runtime:' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "runtime detection ignores non-runtime stage names" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'DOCK'
+FROM ubuntu:24.04 AS runtime-base
+FROM runtime-base AS devel
+CMD ["bash"]
+DOCK
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras
+  # "runtime-base" doesn't count as the runtime stage (strict match).
+  run grep -cE '^  runtime:' "${COMPOSE_OUT}"
+  assert_output "0"
+}

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -239,10 +239,37 @@ EOS
 }
 
 @test "run.sh non-devel target routes to 'compose run --rm'" {
-  run bash "${SANDBOX}/run.sh" --dry-run test
+  # -t is now the explicit target flag; positional would be treated as CMD.
+  run bash "${SANDBOX}/run.sh" --dry-run -t test
   assert_success
   assert_output --partial "run"
   assert_output --partial "--rm"
+}
+
+@test "run.sh positional args after options become CMD passthrough (devel)" {
+  # New semantics: positionals = cmd, default target = devel.
+  # Expect exec of `ls /tmp` inside the devel service.
+  run bash "${SANDBOX}/run.sh" --dry-run ls /tmp
+  assert_success
+  assert_output --partial "exec"
+  assert_output --partial "ls /tmp"
+}
+
+@test "run.sh -t runtime with CMD overrides Dockerfile runtime CMD" {
+  run bash "${SANDBOX}/run.sh" --dry-run -t runtime bash
+  assert_success
+  assert_output --partial "run"
+  assert_output --partial "--rm"
+  assert_output --partial "runtime"
+  assert_output --partial "bash"
+}
+
+@test "run.sh -d combined with CMD is rejected with exit 2" {
+  run bash "${SANDBOX}/run.sh" --dry-run -d ls /tmp
+  assert_failure
+  [ "$status" -eq 2 ]
+  assert_output --partial "does not accept a CMD"
+  assert_output --partial "./exec.sh"
 }
 
 @test "run.sh --instance is appended to project/container name" {


### PR DESCRIPTION
## Summary

Closes #108 (runtime service missing from auto-generated `compose.yaml`) and #118 (run.sh / exec.sh positional-arg asymmetry). Both are "run phase" UX: one adds the missing service, the other aligns how users target it.

## Changes

### `setup.sh` — auto-emit runtime service
`generate_compose_yaml` detects `FROM <base> AS runtime` in the sibling Dockerfile and emits a paired `runtime` compose service right before `test`:

```yaml
  runtime:
    extends:
      service: devel
    build:
      target: runtime
    image: ${DOCKER_HUB_USER:-local}/<name>:runtime
    container_name: <name>-runtime${INSTANCE_SUFFIX:-}
    stdin_open: false
    tty: false
    profiles:
      - runtime
```

Extends means runtime inherits volumes / env / network / caps / GPU deploy from devel. `profiles: [runtime]` keeps plain `compose up` scoped to devel; explicit `compose run runtime` bypasses the profile gate. Repos without `AS runtime` get no emission — backward-compatible for plain-dev repos.

### `run.sh` — BREAKING arg realignment

- **Target** moves to an explicit `-t/--target` flag (default `devel`).
- **Positional args** become CMD passthrough (mirrors `docker run <image> [cmd]` and `exec.sh`).
- Empty CMD → Dockerfile CMD (devel = bash, runtime = auto-run service).
- Non-empty CMD → override (`./run.sh -t runtime bash` for interactive debug).
- `-d` + CMD → `exit 2` error pointing at `./exec.sh`; `-d` alone unchanged (`compose up -d`).

**Migration:** `./run.sh runtime` → `./run.sh -t runtime`; `./run.sh test` → `./run.sh -t test`. Bare `./run.sh` unchanged (devel bash).

### Tests (+10)

- **run_sh_spec** (+3): positional→CMD passthrough, `-t runtime` + cmd override, `-d` + CMD error.
- **compose_gen_spec** (+7): auto-emit positive / negative (no `AS runtime`) / negative (no Dockerfile) / extends shape / ordering (devel < runtime < test) / whitespace tolerance / strict-match (no `runtime-base` etc.).
- Total: **664 → 674**.

## Test plan

- [x] `make -f Makefile.ci test` local — 674/674 pass
- [ ] Self-test CI green
- [ ] After merge + tag (v0.10.0-rc1): ros1_bridge upgrades, `./run.sh -t runtime` attaches to bridge logs, Ctrl+C stops cleanly; `./run.sh -t runtime bash` drops into runtime shell for debugging.

## Release

Recommend **v0.10.0-rc1** (BREAKING: run.sh migration, run phase unified). Validate on ros1_bridge + at least one GUI-using env repo, promote to v0.10.0 after RC passes.

## Out of scope (future PRs)

- **#49 Phase B** — setup.sh subcommand refactor + `_msg` shadow (#101) fix. Separate "setup phase" PR.
- **#55** — ros1_bridge `entrypoint.sh` timeout guard (downstream bug fix, independent).