### PR TITLE
fix: remove ARG TARGETARCH default in Dockerfile.test-tools

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`Dockerfile.test-tools` `ARG TARGETARCH=amd64` default shadowed BuildKit's per-platform auto-inject** ([moby/buildkit#3403](https://github.com/moby/buildkit/issues/3403)). Every multi-arch build published via `release-test-tools.yaml` (v0.9.13, v0.10.0-rc1) therefore fell back to `amd64` and shipped x86_64 `shellcheck` / `hadolint` binaries inside the arm64 image variant. Symptom downstream: `shellcheck: Exec format error` on arm64 CI (ros1_bridge PR #27 first surfaced it). Fix: declare `ARG TARGETARCH` without default so BuildKit's injected value drives the `case` branch. Regression test added: `Dockerfile.test-tools ARG TARGETARCH has no default value`. Requires a new tag + `release-test-tools.yaml` re-run to reissue `:v0.10.0-rc2` + `:latest` on GHCR.
+
 ## [v0.10.0-rc1] - 2026-04-24
 
 Release candidate for v0.10.0. BREAKING: `run.sh` arg semantics realigned.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **674 tests** total (631 unit + 43 integration).
+Template self-tests: **675 tests** total (632 unit + 43 integration).
 
 ## Test Files
 
@@ -188,7 +188,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `runtime detection is robust against weird whitespace` | regex tolerance |
 | `runtime detection ignores non-runtime stage names` | strict match |
 
-### test/unit/template_spec.bats (115)
+### test/unit/template_spec.bats (116)
 
 | Test | Description |
 |------|-------------|
@@ -266,6 +266,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `exec.sh --dry-run skips precheck and prints compose command` | dry-run e2e |
 | `script/docker/i18n.sh exists` | i18n module exists |
 | `Dockerfile.test-tools includes bats-mock` | bats-mock available in test image |
+| `Dockerfile.test-tools ARG TARGETARCH has no default value (must not shadow BuildKit auto-inject)` | multi-arch build regression |
 | `i18n.sh defines _detect_lang function` | _detect_lang in i18n.sh |
 | `build.sh sources _lib.sh` | build.sh uses shared lib |
 | `run.sh sources _lib.sh` | run.sh uses shared lib |

--- a/dockerfile/Dockerfile.test-tools
+++ b/dockerfile/Dockerfile.test-tools
@@ -20,10 +20,13 @@ RUN apk add --no-cache git && \
 
 FROM alpine:latest AS lint-tools
 # TARGETARCH is auto-populated by BuildKit (docker 23+) with "amd64" /
-# "arm64" / etc. The default handles the rare case where a legacy
-# builder doesn't provide it; override via --build-arg TARGETARCH=<arch>
-# if you build outside BuildKit.
-ARG TARGETARCH=amd64
+# "arm64" / etc. Do NOT set a default — a default value shadows
+# BuildKit's auto-inject (moby/buildkit#3403), which caused every
+# multi-arch build of this file to fall back to amd64 and ship
+# x86_64 shellcheck / hadolint inside the arm64 image variant
+# (visible symptom: `shellcheck: Exec format error` on arm64 downstream
+# CI). If invoked outside BuildKit, pass `--build-arg TARGETARCH=<arch>`.
+ARG TARGETARCH
 RUN apk add --no-cache curl xz && \
     case "${TARGETARCH}" in \
       amd64)  sc_arch="x86_64";  hd_arch="x86_64" ;; \

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -470,6 +470,20 @@ EOF
   assert_success
 }
 
+@test "Dockerfile.test-tools ARG TARGETARCH has no default value (must not shadow BuildKit auto-inject)" {
+  # Regression guard: `ARG TARGETARCH=amd64` with a default shadows
+  # BuildKit's per-platform auto-inject (moby/buildkit#3403), which
+  # caused every multi-arch build to fall back to amd64 — arm64 image
+  # variants shipped x86_64 shellcheck / hadolint binaries. Symptom
+  # downstream: `shellcheck: Exec format error` on arm64 CI.
+  run grep -E '^ARG TARGETARCH=' /source/dockerfile/Dockerfile.test-tools
+  assert_failure
+  # But the bare declaration must still be there so the stage can
+  # consume the BuildKit-injected value.
+  run grep -E '^ARG TARGETARCH$' /source/dockerfile/Dockerfile.test-tools
+  assert_success
+}
+
 @test "Dockerfile.test-tools branches case for amd64 and arm64" {
   # Must handle both common arches; amd64 → x86_64 binaries,
   # arm64 → aarch64 (shellcheck) + arm64 (hadolint) binaries.


### PR DESCRIPTION
## Summary

**Critical latent bug** shipped since multi-arch matrix landed (v0.9.10+). The arm64 variant of every GHCR `test-tools:*` image contains **x86_64 shellcheck / hadolint** binaries, silently breaking downstream arm64 CI at first consumption.

### Root cause

`Dockerfile.test-tools` declares `ARG TARGETARCH=amd64` with a default. Per [moby/buildkit#3403](https://github.com/moby/buildkit/issues/3403), a default value **shadows BuildKit's per-platform auto-inject**. Result: multi-arch builds of this file run the `case "${TARGETARCH}" in ...` branch with `TARGETARCH=amd64` regardless of the actual build platform → x86_64 binary URL used for both amd64 and arm64 manifests.

### Confirmation

Anonymous pull of `ghcr.io/ycpss91255-docker/test-tools:v0.9.13` arm64 variant:

```
$ docker create --platform linux/arm64 ghcr.io/.../test-tools:v0.9.13
$ docker cp ...:/usr/local/bin/shellcheck /tmp/sc-arm64
$ file /tmp/sc-arm64
/tmp/sc-arm64: ELF 64-bit LSB executable, x86-64, ...
```

ros1_bridge PR #27 enabled arm64 matrix and hit:
```
shellcheck: Exec format error
```

### Fix

```diff
-ARG TARGETARCH=amd64
+ARG TARGETARCH
```

Regression test in `template_spec.bats` asserts the ARG has **no default** (`^ARG TARGETARCH=` must not match) while the bare declaration (`^ARG TARGETARCH$`) still does. 674 → 675.

## Release plan (post-merge)

1. Tag **v0.10.0-rc2** from main after this PR merges.
2. `release-test-tools.yaml` auto-reissues `ghcr.io/.../test-tools:v0.10.0-rc2` + `:latest` with per-arch-correct binaries.
3. Downstream ros1_bridge PR #27 bumps `main.yaml` `@v0.9.13` → `@v0.10.0-rc2`, arm64 matrix goes green.
4. If validation passes, promote rc2 → v0.10.0.

### Impact on existing tags

`v0.9.13`, `v0.10.0-rc1` GHCR images stay broken on arm64. Repos currently pinned to those tags that **only build amd64** are unaffected. Repos with arm64 matrix enabled must move to `@v0.10.0-rc2+` — or the template bumps its minimum supported tag if we want to deprecate the broken ones.

## Test plan
- [x] `make -f Makefile.ci test` local — 675/675 pass
- [ ] Self-test CI green on this PR
- [ ] Post-tag: inspect arm64 variant of `:v0.10.0-rc2`, confirm shellcheck is aarch64:
  ```
  docker create --platform linux/arm64 ghcr.io/.../test-tools:v0.10.0-rc2
  docker cp ...:/usr/local/bin/shellcheck /tmp/sc-arm64
  file /tmp/sc-arm64   # expect: aarch64
  ```
- [ ] Post-tag: ros1_bridge PR #27 @v0.10.0-rc2, arm64 CI shard green.