### PR TITLE
fix(upgrade.sh): main.yaml sed regex handles semver pre-release tags

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`upgrade.sh` main.yaml sed regex now handles semver pre-release tags** (closes #61). The prior `[0-9.]*` character class stopped at the first `-`, so upgrading from an existing RC tag (e.g. `v0.10.0-rc1` → `-rc2`) left the old `-rcN` suffix in place and produced `@v0.10.0-rc2-rc1`. First surfaced when ros1_bridge ran `./template/upgrade.sh v0.10.0-rc2` from `@v0.9.13`. Regex now anchored on full semver shape (`\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?`). Two regression tests added covering RC → RC and RC → stable transitions.
+
 ## [v0.10.0-rc2] - 2026-04-24
 
 Second release candidate. Ships the arm64 test-tools hotfix that v0.10.0-rc1 / v0.9.13 both missed — **strongly recommended** over rc1 for any downstream repo enabling the arm64 build matrix.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **675 tests** total (632 unit + 43 integration).
+Template self-tests: **677 tests** total (634 unit + 43 integration).
 
 ## Test Files
 
@@ -188,7 +188,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `runtime detection is robust against weird whitespace` | regex tolerance |
 | `runtime detection ignores non-runtime stage names` | strict match |
 
-### test/unit/template_spec.bats (116)
+### test/unit/template_spec.bats (118)
 
 | Test | Description |
 |------|-------------|
@@ -288,6 +288,8 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `upgrade.sh --gen-conf delegates to init.sh --gen-conf` | Delegation |
 | `upgrade.sh --help mentions --gen-conf` | Help text |
 | `upgrade.sh updates main.yaml @tag without clobbering release-worker.yaml` | sed regression |
+| `upgrade.sh main.yaml sed handles semver pre-release tags (RC → RC)` | `-rcN-rcN` regression |
+| `upgrade.sh main.yaml sed handles stable → stable + RC → stable transitions` | RC → stable cleanup |
 | `build-worker.yaml: no legacy in-job test-tools build step` | v0.9.13 GHCR migration |
 | `build-worker.yaml: resolves template version from GITHUB_WORKFLOW_REF` | GHCR tag resolution |
 | `build-worker.yaml: test build passes TEST_TOOLS_IMAGE build-arg` | build-arg wiring |

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -719,6 +719,73 @@ EOF
   rm -rf "${_tmp}"
 }
 
+@test "upgrade.sh main.yaml sed handles semver pre-release tags (RC → RC)" {
+  # Regression: the previous `[0-9.]*` character class stopped at the
+  # first `-`, so upgrading from an existing RC tag left the old
+  # `-rcN` suffix in place and the new version got appended after it
+  # (e.g. @v0.10.0-rc1 → -rc2 produced `@v0.10.0-rc2-rc1`).
+  local _tmp _yaml
+  _tmp="$(mktemp -d)"
+  _yaml="${_tmp}/main.yaml"
+  cat > "${_yaml}" <<'EOF'
+jobs:
+  call-docker-build:
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v0.10.0-rc1
+  call-release:
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@v0.10.0-rc1
+EOF
+  local _seds
+  _seds="$(grep -E "^[[:space:]]*sed -i" /source/upgrade.sh)"
+  while IFS= read -r _line; do
+    # shellcheck disable=SC2001
+    _line="$(echo "${_line}" | sed "s|\${main_yaml}|${_yaml}|g; s|\${target_ver}|v0.10.0-rc2|g")"
+    eval "${_line}"
+  done <<< "${_seds}"
+
+  # Must produce the clean new tag — no leftover `-rc1` suffix.
+  run grep -c 'build-worker.yaml@v0.10.0-rc2$' "${_yaml}"
+  assert_output "1"
+  run grep -c 'release-worker.yaml@v0.10.0-rc2$' "${_yaml}"
+  assert_output "1"
+  # And no double suffix anywhere.
+  run grep -c '@v0.10.0-rc2-rc' "${_yaml}"
+  assert_output "0"
+
+  rm -rf "${_tmp}"
+}
+
+@test "upgrade.sh main.yaml sed handles stable → stable + RC → stable transitions" {
+  # Edge cases around the pre-release group: from plain semver to plain,
+  # and from RC back to plain stable (e.g. v0.10.0-rc2 → v0.10.0).
+  local _tmp _yaml
+  _tmp="$(mktemp -d)"
+  _yaml="${_tmp}/main.yaml"
+  cat > "${_yaml}" <<'EOF'
+jobs:
+  call-docker-build:
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v0.10.0-rc2
+  call-release:
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@v0.9.9
+EOF
+  local _seds
+  _seds="$(grep -E "^[[:space:]]*sed -i" /source/upgrade.sh)"
+  while IFS= read -r _line; do
+    # shellcheck disable=SC2001
+    _line="$(echo "${_line}" | sed "s|\${main_yaml}|${_yaml}|g; s|\${target_ver}|v0.10.0|g")"
+    eval "${_line}"
+  done <<< "${_seds}"
+
+  run grep -c 'build-worker.yaml@v0.10.0$' "${_yaml}"
+  assert_output "1"
+  run grep -c 'release-worker.yaml@v0.10.0$' "${_yaml}"
+  assert_output "1"
+  # Must not leave stale -rc2 anywhere in the file.
+  run grep -c 'rc2' "${_yaml}"
+  assert_output "0"
+
+  rm -rf "${_tmp}"
+}
+
 # ════════════════════════════════════════════════════════════════════
 # build-worker.yaml: GHCR test-tools migration (D plan)
 # ════════════════════════════════════════════════════════════════════

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -186,10 +186,14 @@ _upgrade() {
   _log "Step 4/4: update workflow @tag references"
   local main_yaml="${REPO_ROOT}/.github/workflows/main.yaml"
   if [[ -f "${main_yaml}" ]]; then
-    # Replace @vX.Y.Z with new version in reusable workflow references.
-    # Match each worker file by name to avoid greedy patterns clobbering siblings.
-    sed -i "s|build-worker\.yaml@v[0-9.]*|build-worker.yaml@${target_ver}|g" "${main_yaml}"
-    sed -i "s|release-worker\.yaml@v[0-9.]*|release-worker.yaml@${target_ver}|g" "${main_yaml}"
+    # Replace @vX.Y.Z(-prerelease)? with new version in reusable workflow
+    # references. Match each worker file by name to avoid greedy patterns
+    # clobbering siblings. The `-E` regex anchors on a full semver shape
+    # (optional pre-release per §9) — the prior `[0-9.]*` stopped at the
+    # first `-`, so upgrading from an RC tag (e.g. v0.10.0-rc1 → -rc2)
+    # left the old suffix in place and produced `@v0.10.0-rc2-rc1`.
+    sed -i -E "s|build-worker\.yaml@v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?|build-worker.yaml@${target_ver}|g" "${main_yaml}"
+    sed -i -E "s|release-worker\.yaml@v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?|release-worker.yaml@${target_ver}|g" "${main_yaml}"
     git add "${main_yaml}"
   fi
 


### PR DESCRIPTION
## Summary

Closes #61.

`upgrade.sh` line 191-192 used `[0-9.]*` character class to match the existing `@vX.Y.Z` reference, which stops at the first non-`[0-9.]` character. Upgrading from an existing RC tag therefore left the old `-rcN` suffix in place and appended the new version after it:

```yaml
# before: @v0.10.0-rc1
# after  ./template/upgrade.sh v0.10.0-rc2
#        @v0.10.0-rc2-rc1   (broken)
```

ros1_bridge surfaced this when running `./template/upgrade.sh v0.10.0-rc2` from `@v0.9.13` — the RC bump produced `@v0.10.0-rc2-rc2` and the PR had to manually unglue it before CI could go green.

## Fix

Regex anchored on full semver shape per §9:

```diff
-sed -i    "s|build-worker\.yaml@v[0-9.]*|build-worker.yaml@${target_ver}|g"
+sed -i -E "s|build-worker\.yaml@v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?|build-worker.yaml@${target_ver}|g"
```

Same change for release-worker.

## Tests

Two regression tests in `template_spec.bats`:
- `upgrade.sh main.yaml sed handles semver pre-release tags (RC → RC)` — `@v0.10.0-rc1` → `@v0.10.0-rc2`, asserts no `-rc2-rc` double suffix remains.
- `upgrade.sh main.yaml sed handles stable → stable + RC → stable transitions` — mixed `@v0.10.0-rc2` + `@v0.9.9` → `@v0.10.0`, asserts `rc2` is gone everywhere.

675 → 677 total.

## Test plan

- [x] `make -f Makefile.ci test` local — 677/677 pass
- [ ] CI template self-test green
- [ ] After merge: include in v0.10.0 stable release so future upgrades from any RC-pinned repo are safe.