### PR TITLE
fix(ci): build-worker.yaml test-tools version via input, not WORKFLOW_REF

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -17,6 +17,23 @@ on:
         type: boolean
         default: true
         description: "Whether to build runtime stage"
+      test_tools_version:
+        required: false
+        type: string
+        default: "latest"
+        description: |
+          Tag for the `ghcr.io/ycpss91255-docker/test-tools:<tag>` image
+          consumed as a build-arg by the downstream Dockerfile's test
+          stage. Caller should pin this to the template release they
+          upgraded from (e.g. `test_tools_version: v0.10.1`) for
+          reproducibility; default `latest` works but loses
+          determinism against an in-flight template release.
+
+          Replaces the earlier GITHUB_WORKFLOW_REF parsing, which was
+          read the caller's own tag ref (e.g. a downstream repo's
+          `v1.5.0`) rather than the template's pinned @tag, so
+          downstream tag pushes would try to pull
+          `ghcr.io/.../test-tools:<downstream-tag>` which never exists.
       platforms:
         required: false
         type: string
@@ -133,23 +150,6 @@ jobs:
           EOF
           mkdir -p /tmp/workspace
 
-      - name: Resolve template version for test-tools image
-        # The downstream repo's main.yaml pins this workflow via
-        #   uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@vX.Y.Z
-        # GITHUB_WORKFLOW_REF exposes that full ref at runtime. Parse
-        # out the tag so we can pin the test-tools GHCR image to the
-        # matching template release (prevents version skew between the
-        # workflow logic and the test-tools contract it assumes).
-        id: tplver
-        shell: bash
-        run: |
-          ref="${GITHUB_WORKFLOW_REF##*@}"
-          case "${ref}" in
-            refs/tags/v*) ver="${ref##refs/tags/}" ;;
-            *)            ver="latest" ;;
-          esac
-          printf 'image=ghcr.io/ycpss91255-docker/test-tools:%s\n' "${ver}" >> "${GITHUB_OUTPUT}"
-
       - name: Build test stage (includes smoke tests)
         # The downstream Dockerfile consumes TEST_TOOLS_IMAGE as the
         # source of `COPY --from=${TEST_TOOLS_IMAGE}`; buildx auto-pulls
@@ -157,6 +157,15 @@ jobs:
         # is not present locally, so no explicit docker-pull step is
         # needed here. Public visibility of the GHCR package means
         # anonymous pull works, keeping the build-args simple.
+        #
+        # `inputs.test_tools_version` lets the caller pin the
+        # test-tools image tag to whichever template release they
+        # upgraded from (e.g. `test_tools_version: v0.10.1`). Default
+        # `latest` tracks whatever the most recent template release
+        # published — fine for non-tagged CI, but downstream repos
+        # cutting their own release should pin explicitly for
+        # reproducibility (the earlier GITHUB_WORKFLOW_REF auto-parse
+        # was wrong: that ref is the caller's own tag, not template's).
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -169,7 +178,7 @@ jobs:
             UID=1000
             GID=1000
             HARDWARE=${{ matrix.hardware }}
-            TEST_TOOLS_IMAGE=${{ steps.tplver.outputs.image }}
+            TEST_TOOLS_IMAGE=ghcr.io/ycpss91255-docker/test-tools:${{ inputs.test_tools_version }}
             ${{ inputs.build_args }}
 
       - name: Build devel stage

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING for callers pinned to `@v0.10.0`**: `build-worker.yaml` gains a new input `test_tools_version` (default `"latest"`). Downstream `main.yaml` should pin it to the template release they upgraded from (e.g. `test_tools_version: v0.10.1`) for reproducibility. Repos on `@v0.10.0` or below that never cut a release tag keep working on unpinned `:latest` (unchanged from v0.10.0's silent GHCR fallback during branch / PR pushes).
+
+### Fixed
+- **`build-worker.yaml` auto-parse bug on tagged downstream releases.** v0.10.0's `GITHUB_WORKFLOW_REF` parsing read the **caller's** ref — when a downstream repo pushed its own release tag (e.g. `v1.5.0`), the workflow tried to pull `ghcr.io/.../test-tools:v1.5.0` (doesn't exist) instead of template's pinned `:v0.10.0`. Surfaced first by ros1_bridge's v1.5.0 release attempt. Fix: drop the `GITHUB_WORKFLOW_REF` parse entirely, require caller to pass `test_tools_version` explicitly (defaults to `latest`). Regression test added to `template_spec.bats`.
+
 ## [v0.10.0] - 2026-04-24
 
 First stable minor bump post-v0.9.x. Cuts the rc2 feature work + two fixes. **Recommended upgrade path** for all downstream repos (rc1 / rc2 supersede everything earlier, see rc1/rc2 notes below for the full run-phase UX realignment + arm64 test-tools hotfix).

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **685 tests** total (642 unit + 43 integration).
+Template self-tests: **686 tests** total (643 unit + 43 integration).
 
 ## Test Files
 
@@ -188,7 +188,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `runtime detection is robust against weird whitespace` | regex tolerance |
 | `runtime detection ignores non-runtime stage names` | strict match |
 
-### test/unit/template_spec.bats (118)
+### test/unit/template_spec.bats (119)
 
 | Test | Description |
 |------|-------------|
@@ -291,8 +291,9 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `upgrade.sh main.yaml sed handles semver pre-release tags (RC → RC)` | `-rcN-rcN` regression |
 | `upgrade.sh main.yaml sed handles stable → stable + RC → stable transitions` | RC → stable cleanup |
 | `build-worker.yaml: no legacy in-job test-tools build step` | v0.9.13 GHCR migration |
-| `build-worker.yaml: resolves template version from GITHUB_WORKFLOW_REF` | GHCR tag resolution |
-| `build-worker.yaml: test build passes TEST_TOOLS_IMAGE build-arg` | build-arg wiring |
+| `build-worker.yaml: declares test_tools_version input` | v0.10.1 input replaces GITHUB_WORKFLOW_REF parse |
+| `build-worker.yaml: does not resurrect the GITHUB_WORKFLOW_REF parse step` | regression guard |
+| `build-worker.yaml: test build passes TEST_TOOLS_IMAGE from inputs` | build-arg wiring |
 | `Dockerfile.example has ARG TEST_TOOLS_IMAGE with test-tools:local default` | ARG default |
 | `Dockerfile.example FROM ${TEST_TOOLS_IMAGE} AS test-tools-stage` | named stage alias |
 | `Dockerfile.example test stage copies from test-tools-stage, not test-tools:local` | stage rename migration |

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -800,29 +800,44 @@ EOF
   assert_output "0"
 }
 
-@test "build-worker.yaml: resolves template version from GITHUB_WORKFLOW_REF" {
+@test "build-worker.yaml: declares test_tools_version input" {
+  # Replaces the v0.10.0 GITHUB_WORKFLOW_REF auto-parse, which read the
+  # caller's own tag ref (e.g. a downstream repo's v1.5.0) rather than
+  # template's pinned @tag, so downstream tag pushes tried to pull
+  # `ghcr.io/.../test-tools:<downstream-tag>` and failed 404.
   local _yaml="/source/.github/workflows/build-worker.yaml"
   [[ -f "${_yaml}" ]] || skip "build-worker.yaml not present in /source"
-  run grep -F 'GITHUB_WORKFLOW_REF' "${_yaml}"
+  run grep -F 'test_tools_version:' "${_yaml}"
   assert_success
-  # outputs var must carry the ghcr.io tag for downstream build-arg pass-through
-  run grep -F 'ghcr.io/ycpss91255-docker/test-tools' "${_yaml}"
+  # Default must be `latest` so unpinned callers still work.
+  run awk '
+    /test_tools_version:/ { inside = 1 }
+    inside && /^[[:space:]]+default:/ { print; exit }
+  ' "${_yaml}"
   assert_success
+  assert_output --partial '"latest"'
 }
 
-@test "build-worker.yaml: test build passes TEST_TOOLS_IMAGE build-arg" {
+@test "build-worker.yaml: does not resurrect the GITHUB_WORKFLOW_REF parse step" {
+  # Regression guard: the legacy auto-parse step must not come back.
+  # Comments referencing it are fine (they explain the deprecation).
   local _yaml="/source/.github/workflows/build-worker.yaml"
   [[ -f "${_yaml}" ]] || skip "build-worker.yaml not present in /source"
-  # The test-stage build step must include TEST_TOOLS_IMAGE so the
-  # downstream Dockerfile's `FROM ${TEST_TOOLS_IMAGE}` stage resolves
-  # to the GHCR image (not the local fallback tag).
+  run grep -Fc 'Resolve template version for test-tools image' "${_yaml}"
+  assert_output "0"
+}
+
+@test "build-worker.yaml: test build passes TEST_TOOLS_IMAGE from inputs" {
+  local _yaml="/source/.github/workflows/build-worker.yaml"
+  [[ -f "${_yaml}" ]] || skip "build-worker.yaml not present in /source"
   run awk '
     /- name: Build test stage/ { inside = 1 }
     inside && /^[[:space:]]*- name:/ && !/Build test stage/ { inside = 0 }
     inside { print }
   ' "${_yaml}"
   assert_success
-  assert_output --partial 'TEST_TOOLS_IMAGE='
+  # build-arg must wire inputs.test_tools_version into the ghcr tag
+  assert_output --partial 'TEST_TOOLS_IMAGE=ghcr.io/ycpss91255-docker/test-tools:${{ inputs.test_tools_version }}'
 }
 
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Critical hotfix for v0.10.0. Downstream repos cutting their own release tag (`v*`) hit a hard 404 in the `test` stage; `call-release` then skips and no GitHub Release is produced. ros1_bridge v1.5.0 release was the first victim.

## Root cause

`build-worker.yaml` derives the `ghcr.io/.../test-tools:<tag>` image from `GITHUB_WORKFLOW_REF`, under the assumption that env var is the reusable workflow's own `@vX.Y.Z` pin. It isn't — per GitHub docs it's the **caller's** top-level workflow ref. For a downstream tag push like ros1_bridge `v1.5.0`:

```
GITHUB_WORKFLOW_REF=".../ros1_bridge/.github/workflows/main.yaml@refs/tags/v1.5.0"
→ parsed as ver=v1.5.0
→ TEST_TOOLS_IMAGE=ghcr.io/ycpss91255-docker/test-tools:v1.5.0
→ 404
```

Branch / PR pushes masked this because the case statement fell through to `latest`.

## Fix

- Drop the auto-parse step entirely.
- Add `inputs.test_tools_version` (string, default `"latest"`).
- Caller pins it explicitly in their `main.yaml`:
  ```yaml
  uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v0.10.1
  with:
    test_tools_version: v0.10.1
  ```

## BREAKING for downstream repos

Repos on `@v0.10.0` that upgrade to `@v0.10.1` must add `test_tools_version` (explicit pin is the reproducible choice; skipping = `latest`). Repos that never tag a release were never broken by the underlying bug, so the upgrade is optional for them.

## Tests (+1 net)

- `build-worker.yaml: declares test_tools_version input` (default `"latest"`)
- `build-worker.yaml: does not resurrect the GITHUB_WORKFLOW_REF parse step` (regression guard)
- `build-worker.yaml: test build passes TEST_TOOLS_IMAGE from inputs`

Replaced the two legacy assertions (`resolves template version from GITHUB_WORKFLOW_REF`, `test build passes TEST_TOOLS_IMAGE build-arg`).

685 → 686 total.

## Test plan

- [x] `make -f Makefile.ci test` — 686/686 pass
- [ ] CI self-test green on this PR
- [ ] After tag + ros1_bridge @v0.10.1 retry: `v1.5.0` tag push lands `call-release` green and GitHub Release gets created.