### PR TITLE
chore(deps): bump docker/setup-qemu-action + login-action v3 → v4

### DIFF
--- a/.github/workflows/release-test-tools.yaml
+++ b/.github/workflows/release-test-tools.yaml
@@ -46,13 +46,13 @@ jobs:
         # Needed for the arm64 leg; amd64 alone could skip it, but the
         # QEMU setup is a no-op on native arch so we keep the workflow
         # simple with a single builder.
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `softprops/action-gh-release` v2 → v3 (#113)
   - `docker/setup-buildx-action` v3 → v4 (#114) — also drops deprecated `install` input (we never used it)
   - `docker/build-push-action` v6 → v7 (#115) — also drops `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs (we never set them)
+  - `docker/setup-qemu-action` v3 → v4 — manual bump (dependabot's batch hit `open-pull-requests-limit: 5`; picked up here so v0.11.0's Node 24 coverage is complete)
+  - `docker/login-action` v3 → v4 — same reason as above
 
   Requires Actions Runner ≥ v2.327.1, which GitHub-hosted runners have shipped since 2025-09. Self-hosted fleets must update before pinning to `@v0.11.0`+.
 


### PR DESCRIPTION
## Summary

Manual bump for two dockerfile-helper actions that dependabot's earlier batch (#111–#115) skipped because `open-pull-requests-limit: 5` capped out. Both are Node 20 → Node 24, identical to the rest of the Node 24 wave landed via the dependabot batch:

- `docker/setup-qemu-action` v3 → v4 (Node 24 default runtime)
- `docker/login-action` v3 → v4 (Node 24 default runtime)

Both used only in `release-test-tools.yaml` (multi-arch GHCR test-tools build).

## Why now (not next dependabot cycle)

`v0.11.0-rc1` already shipped \"GitHub Actions runtime bumped to Node 24\" as a `Changed` entry. Leaving these two on Node 20 means downstream repos pinning to `@v0.11.0` still hit two Node 20 actions. Closing the gap before stable.

## Test plan

- [x] `make -f Makefile.ci test` — 757 tests, 0 failures
- [x] `make -f Makefile.ci lint` — clean
- [x] `CHANGELOG.md` `[Unreleased] Changed` extended with these two bullets under the existing Node 24 batch entry
- [ ] Post-merge: `release-test-tools.yaml` will pick up the new versions on next tag push (e.g. `v0.11.0` stable)

## Note

Going forward, dependabot's next weekly cycle would have caught these on its own. Doing it manually only because they're conceptually part of the v0.11.0-rc1 Node 24 release theme.