### PR TITLE
docs: audit fixup — TEST.md per-spec counts + README parity + missing inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ is copied to the repo and the detected workspace is written to
 ./template/init.sh --gen-conf # plain copy of template/setup.conf to repo root
 ```
 
+### Interactive TUI
+
+`./setup_tui.sh` opens the main menu and lets you edit values across all sections; the backend is `dialog` or `whiptail` (when both are missing it prints a `sudo apt install dialog` hint and exits). Cancel / Esc leaves without saving; saving auto-invokes `setup.sh` to regenerate `.env` + `compose.yaml`.
+
 ### When setup.sh runs
 
 `setup.sh` runs only when explicitly triggered — it is not re-run on
@@ -381,6 +385,8 @@ jobs:
 | `image_name` | string | yes | - | Container image name |
 | `build_args` | string | no | `""` | Multi-line KEY=VALUE build args |
 | `build_runtime` | boolean | no | `true` | Whether to build runtime stage |
+| `platforms` | string | no | `"linux/amd64"` | Comma-separated target platforms; each runs as a parallel native-runner shard (`linux/amd64` → ubuntu-latest, `linux/arm64` → ubuntu-24.04-arm) |
+| `test_tools_version` | string | no | `"latest"` | Tag for `ghcr.io/ycpss91255-docker/test-tools:<tag>` build-arg; pin to the template release you upgraded from for reproducibility |
 
 ### release-worker.yaml inputs
 

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -373,6 +373,8 @@ jobs:
 | `image_name` | string | はい | - | コンテナイメージ名 |
 | `build_args` | string | いいえ | `""` | 複数行 KEY=VALUE ビルド引数 |
 | `build_runtime` | boolean | いいえ | `true` | runtime stage をビルドするか |
+| `platforms` | string | いいえ | `"linux/amd64"` | カンマ区切りのターゲットプラットフォーム；各プラットフォームがネイティブ runner 上で並列実行（`linux/amd64` → ubuntu-latest、`linux/arm64` → ubuntu-24.04-arm） |
+| `test_tools_version` | string | いいえ | `"latest"` | `ghcr.io/ycpss91255-docker/test-tools:<tag>` のタグ。下流側は採用した template release にピン留めすると再現性が確保できる |
 
 ### release-worker.yaml パラメータ
 

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -363,6 +363,8 @@ jobs:
 | `image_name` | string | 是 | - | 容器镜像名称 |
 | `build_args` | string | 否 | `""` | 多行 KEY=VALUE 构建参数 |
 | `build_runtime` | boolean | 否 | `true` | 是否构建 runtime stage |
+| `platforms` | string | 否 | `"linux/amd64"` | 逗号分隔的目标平台；每个在原生 runner 上并行运行（`linux/amd64` → ubuntu-latest、`linux/arm64` → ubuntu-24.04-arm） |
+| `test_tools_version` | string | 否 | `"latest"` | `ghcr.io/ycpss91255-docker/test-tools:<tag>` 的 tag，下游可固定到所升级的 template release 以保证可复现 |
 
 ### release-worker.yaml 参数
 

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -363,6 +363,8 @@ jobs:
 | `image_name` | string | 是 | - | 容器映像名稱 |
 | `build_args` | string | 否 | `""` | 多行 KEY=VALUE 建置參數 |
 | `build_runtime` | boolean | 否 | `true` | 是否建置 runtime stage |
+| `platforms` | string | 否 | `"linux/amd64"` | 逗號分隔的目標平台；每個會在原生 runner 上平行跑（`linux/amd64` → ubuntu-latest、`linux/arm64` → ubuntu-24.04-arm） |
+| `test_tools_version` | string | 否 | `"latest"` | `ghcr.io/ycpss91255-docker/test-tools:<tag>` 的 tag，下游可釘到所升級的 template release 以保證可重現 |
 
 ### release-worker.yaml 參數
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -318,7 +318,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `setup.sh default _base_path uses /..` | Path resolution |
 | `setup.sh default _base_path uses double parent traversal` | Repo root traversal |
 
-### test/unit/bashrc_spec.bats (14)
+### test/unit/bashrc_spec.bats (18)
 
 | Test | Description |
 |------|-------------|
@@ -472,7 +472,7 @@ Exercises the runtime assertion helpers shipped in
 | `main copies tmux.conf to config directory` | Config copy |
 | `script runs entry_point when executed directly` | Direct-run guard |
 
-### test/unit/upgrade_spec.bats (20)
+### test/unit/upgrade_spec.bats (18)
 
 Unit tests for `upgrade.sh` helpers. Uses the sed-range pattern to extract
 one function at a time into a minimal harness (with `_log` / `_error`


### PR DESCRIPTION
## Summary

Full audit sweep found 3 drift points slipping past prior PRs:

### 1. TEST.md per-spec sub-counts stale

- `bashrc_spec.bats`: TEST.md said 14, actual is 18 (4 new tests merged without bumping the per-spec header)
- `upgrade_spec.bats`: TEST.md said 20, actual is 18 (2 tests removed, header not updated)

Total `Template self-tests: 757` was already correct — only the per-spec sub-headers drifted.

### 2. README 4-language parity broken

English README was missing the `### Interactive TUI` heading + paragraph that zh-TW / zh-CN / ja all carried (showed 9 top-level + **15** sub-sections vs 9 + **16** in translations). Added the matching English block.

### 3. README `build-worker.yaml inputs` table incomplete

Missing two inputs that landed in v0.10.x:
- `platforms` (multi-arch matrix, default `"linux/amd64"`) — added in v0.10.0-rc1
- `test_tools_version` (GHCR pin, default `"latest"`) — added in v0.10.1 / PR #131

Added rows in all 4 README files.

## Test plan

- [x] `make -f Makefile.ci test` — 757 / 0
- [x] `make -f Makefile.ci lint` — clean (no shell change)
- [x] All 4 README files: 9 top-level + 16 sub-sections each (parity verified)
- [x] All TEST.md per-spec headers match actual `^@test` counts (re-verified after fix)

No code change.