### PR TITLE
feat(make): forward optional VERSION to upgrade.sh

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -19,8 +19,8 @@ clean: ## Remove coverage reports
 init: ## Initialize repo (new or existing)
 	./init.sh
 
-upgrade: ## Upgrade template subtree to latest version
-	./upgrade.sh
+upgrade: ## Upgrade template subtree (optional VERSION=vX.Y.Z; defaults to latest)
+	./upgrade.sh $(VERSION)
 
 upgrade-check: ## Check if a newer template version is available
 	./upgrade.sh --check

--- a/README.md
+++ b/README.md
@@ -325,7 +325,10 @@ make upgrade-check
 # Upgrade to latest (subtree pull + version file + workflow tag)
 make upgrade
 
-# Or specify a version
+# Or pin a specific version
+make upgrade VERSION=v0.3.0
+
+# Fallback if make is unavailable
 ./template/upgrade.sh v0.3.0
 ```
 
@@ -351,7 +354,7 @@ updates:
 
 Dependabot notices the `uses: ycpss91255-docker/template/...@vX.Y.Z` refs in
 `main.yaml`, compares against the template's latest tag, and files a PR. You
-still run `./template/upgrade.sh vX.Y.Z` locally to sync the subtree itself —
+still run `make upgrade VERSION=vX.Y.Z` locally to sync the subtree itself —
 Dependabot only bumps the workflow refs.
 
 ## CI Reusable Workflows

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`make -f Makefile.ci upgrade` now accepts an optional `VERSION` variable**. `make -f Makefile.ci upgrade VERSION=vX.Y.Z` pins the subtree pull to a specific tag; `make -f Makefile.ci upgrade` (no `VERSION`) keeps resolving the latest tag. The recipe forwards `$(VERSION)` to `./upgrade.sh`, so empty expands to the no-arg form. This makes `make` the documented entry point for both latest and pinned upgrades; `./template/upgrade.sh` remains as a fallback when `make` is unavailable.
+
 ### Fixed
 - **`make upgrade` / `make upgrade-check` no longer fails with `No such file or directory`** in fresh consumer repos. The downstream-facing `template/script/docker/Makefile` (symlinked into every repo's root) was calling `./template/script/upgrade.sh`, but `upgrade.sh` lives at template root (`./template/upgrade.sh`). The wrong path slipped in around v0.10.x and went undetected because no test asserted the target's recipe. Path corrected and a regression test added.
 

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -322,6 +322,9 @@ make upgrade-check
 make upgrade
 
 # バージョン指定
+make upgrade VERSION=v0.3.0
+
+# make が使えない場合のフォールバック
 ./template/upgrade.sh v0.3.0
 ```
 
@@ -340,7 +343,7 @@ updates:
       interval: "weekly"
 ```
 
-Dependabot は `main.yaml` 内の `uses: ycpss91255-docker/template/...@vX.Y.Z` ref を見て、template の最新 tag と照合して PR を出します。subtree 自体は引き続きローカルで `./template/upgrade.sh vX.Y.Z` を実行する必要があります — Dependabot が扱うのは workflow ref のみです。
+Dependabot は `main.yaml` 内の `uses: ycpss91255-docker/template/...@vX.Y.Z` ref を見て、template の最新 tag と照合して PR を出します。subtree 自体は引き続きローカルで `make upgrade VERSION=vX.Y.Z` を実行する必要があります — Dependabot が扱うのは workflow ref のみです。
 
 ## CI Reusable Workflows
 

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -312,6 +312,9 @@ make upgrade-check
 make upgrade
 
 # 或指定版本
+make upgrade VERSION=v0.3.0
+
+# 没有 make 时的 fallback
 ./template/upgrade.sh v0.3.0
 ```
 
@@ -330,7 +333,7 @@ updates:
       interval: "weekly"
 ```
 
-Dependabot 会读 `main.yaml` 里的 `uses: ycpss91255-docker/template/...@vX.Y.Z` ref，比对 template 最新 tag 后开 PR。subtree 本身仍需在本地跑 `./template/upgrade.sh vX.Y.Z` — Dependabot 只负责 workflow ref。
+Dependabot 会读 `main.yaml` 里的 `uses: ycpss91255-docker/template/...@vX.Y.Z` ref，比对 template 最新 tag 后开 PR。subtree 本身仍需在本地跑 `make upgrade VERSION=vX.Y.Z` — Dependabot 只负责 workflow ref。
 
 ## CI Reusable Workflows
 

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -312,6 +312,9 @@ make upgrade-check
 make upgrade
 
 # 或指定版本
+make upgrade VERSION=v0.3.0
+
+# 沒有 make 時的 fallback
 ./template/upgrade.sh v0.3.0
 ```
 
@@ -330,7 +333,7 @@ updates:
       interval: "weekly"
 ```
 
-Dependabot 會讀 `main.yaml` 裡的 `uses: ycpss91255-docker/template/...@vX.Y.Z` ref，比對 template 最新 tag 後開 PR。subtree 本身仍需在本地跑 `./template/upgrade.sh vX.Y.Z` — Dependabot 只負責 workflow ref。
+Dependabot 會讀 `main.yaml` 裡的 `uses: ycpss91255-docker/template/...@vX.Y.Z` ref，比對 template 最新 tag 後開 PR。subtree 本身仍需在本地跑 `make upgrade VERSION=vX.Y.Z` — Dependabot 只負責 workflow ref。
 
 ## CI Reusable Workflows
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **758 tests** total (714 unit + 44 integration).
+Template self-tests: **760 tests** total (716 unit + 44 integration).
 
 ## Test Files
 
@@ -193,7 +193,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `runtime detection is robust against weird whitespace` | regex tolerance |
 | `runtime detection ignores non-runtime stage names` | strict match |
 
-### test/unit/template_spec.bats (128)
+### test/unit/template_spec.bats (130)
 
 | Test | Description |
 |------|-------------|
@@ -209,6 +209,8 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `Makefile.ci exists (template CI)` | File check |
 | `Makefile.ci has test target` | Makefile target |
 | `Makefile.ci has lint target` | Makefile target |
+| `Makefile.ci has upgrade target` | Makefile target |
+| `Makefile.ci upgrade target forwards optional VERSION variable` | VERSION arg passthrough |
 | `Makefile upgrade target uses ./template/upgrade.sh (not ./template/script/upgrade.sh)` | Regression: bad path in script/docker/Makefile |
 | `test/smoke/test_helper.bash exists` | Directory structure |
 | `test/smoke/script_help.bats exists` | Directory structure |

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -81,6 +81,19 @@ setup() {
   assert_success
 }
 
+@test "Makefile.ci has upgrade target" {
+  run grep -E '^upgrade:' /source/Makefile.ci
+  assert_success
+}
+
+@test "Makefile.ci upgrade target forwards optional VERSION variable" {
+  # `make -f Makefile.ci upgrade [VERSION=vX.Y.Z]` is the documented entry
+  # point. The recipe must pass $(VERSION) to ./upgrade.sh so an empty
+  # VERSION resolves to "latest" and a set VERSION pins a specific tag.
+  run grep -E '^[[:space:]]+\./upgrade\.sh \$\(VERSION\)' /source/Makefile.ci
+  assert_success
+}
+
 # ════════════════════════════════════════════════════════════════════
 # Structure: test directory layout
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- `make -f Makefile.ci upgrade VERSION=vX.Y.Z` now pins the subtree pull to a specific tag; `make -f Makefile.ci upgrade` (no `VERSION`) keeps resolving the latest tag.
- The recipe forwards `$(VERSION)` to `./upgrade.sh`, so empty expands to the no-arg form.
- Aligns with CLAUDE.md's "make first, upgrade.sh as fallback" rule.

## Why

Previously `./template/upgrade.sh vX.Y.Z` was the only way to pin a version, even though `make` is the documented entry point. This made the pinned-upgrade flow inconsistent with the latest-upgrade flow (which already had `make upgrade`).

## Test plan

- [x] `make -f Makefile.ci test` — 759 ok / 0 failures (was 757 / 0 before)
- [x] ShellCheck clean
- [x] 4-language READMEs updated
- [x] CHANGELOG `[Unreleased] Added` entry
- [x] TEST.md: template_spec 127 → 129, total 757 → 759
- [x] New unit tests:
  - `Makefile.ci has upgrade target`
  - `Makefile.ci upgrade target forwards optional VERSION variable`