### PR TITLE
fix(make): correct upgrade.sh path in downstream Makefile

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`make upgrade` / `make upgrade-check` no longer fails with `No such file or directory`** in fresh consumer repos. The downstream-facing `template/script/docker/Makefile` (symlinked into every repo's root) was calling `./template/script/upgrade.sh`, but `upgrade.sh` lives at template root (`./template/upgrade.sh`). The wrong path slipped in around v0.10.x and went undetected because no test asserted the target's recipe. Path corrected and a regression test added.
+
 ## [v0.11.0] - 2026-04-27
 
 Stable promotion of [v0.11.0-rc1](https://github.com/ycpss91255-docker/template/releases/tag/v0.11.0-rc1). Closes Phase B of #49 — `setup.sh` is now a git-style CLI backend (`apply` / `check-drift` / `set` / `show` / `list` / `add` / `remove` / `reset`). **BREAKING** for any caller invoking `setup.sh` without a subcommand.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **757 tests** total (713 unit + 44 integration).
+Template self-tests: **758 tests** total (714 unit + 44 integration).
 
 ## Test Files
 
@@ -193,7 +193,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `runtime detection is robust against weird whitespace` | regex tolerance |
 | `runtime detection ignores non-runtime stage names` | strict match |
 
-### test/unit/template_spec.bats (127)
+### test/unit/template_spec.bats (128)
 
 | Test | Description |
 |------|-------------|
@@ -209,6 +209,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `Makefile.ci exists (template CI)` | File check |
 | `Makefile.ci has test target` | Makefile target |
 | `Makefile.ci has lint target` | Makefile target |
+| `Makefile upgrade target uses ./template/upgrade.sh (not ./template/script/upgrade.sh)` | Regression: bad path in script/docker/Makefile |
 | `test/smoke/test_helper.bash exists` | Directory structure |
 | `test/smoke/script_help.bats exists` | Directory structure |
 | `test/smoke/display_env.bats exists` | Directory structure |

--- a/script/docker/Makefile
+++ b/script/docker/Makefile
@@ -22,10 +22,10 @@ stop: ## Stop and remove containers
 	./stop.sh
 
 upgrade: ## Upgrade template subtree
-	./template/script/upgrade.sh
+	./template/upgrade.sh
 
 upgrade-check: ## Check for template updates
-	./template/script/upgrade.sh --check
+	./template/upgrade.sh --check
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -56,6 +56,17 @@ setup() {
   assert_success
 }
 
+@test "Makefile upgrade target uses ./template/upgrade.sh (not ./template/script/upgrade.sh)" {
+  # Regression: the Makefile symlinked into every downstream repo has
+  # called `./template/script/upgrade.sh` since v0.10.x, but upgrade.sh
+  # actually lives at template root (`./template/upgrade.sh`). The
+  # broken target produced "No such file or directory" on `make upgrade`
+  # / `make upgrade-check` for fresh consumer repos.
+  run grep -E '^[[:space:]]+\./template/upgrade\.sh' /source/script/docker/Makefile
+  assert_success
+  refute_output --partial "./template/script/upgrade.sh"
+}
+
 @test "Makefile.ci exists (template CI)" {
   assert [ -f /source/Makefile.ci ]
 }


### PR DESCRIPTION
## Symptom

`make upgrade` and `make upgrade-check` fail in fresh consumer repos:

```
$ make upgrade-check
./template/script/upgrade.sh --check
make: ./template/script/upgrade.sh: No such file or directory
make: *** [Makefile:28: upgrade-check] Error 127
```

## Root cause

`template/script/docker/Makefile` (symlinked into every consumer repo's root) calls `./template/script/upgrade.sh`, but `upgrade.sh` actually lives at the template root: `./template/upgrade.sh`. The wrong path slipped in around v0.10.x and went undetected because no test asserted the target's recipe.

## Fix

- Correct both `upgrade` and `upgrade-check` recipes to point at `./template/upgrade.sh`.
- Add a regression test in `template_spec.bats` that greps the Makefile for the correct path AND explicitly refutes the broken one (so a future reintroduction lights up red).

## Test plan

- [x] Logic verified: pre-fix grep finds no match → red; post-fix grep finds both lines → green; refute_output check ensures the wrong path doesn't sneak back.
- [x] CHANGELOG `[Unreleased] Fixed` entry.
- [x] TEST.md: template_spec 127 → 128, total 757 → 758.
- [x] No-emoji + no AI attribution per repo style.

## Related

- Independent of #152 / #153 (also touch `[Unreleased]`); whichever lands second of the three needs a small CHANGELOG / TEST.md rebase.