### PR TITLE
fix(setup,lib): extend empty-setup.conf INFO to check-drift + build summary

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Empty setup.conf no longer silent on `build.sh` / `run.sh` rebuild path** (#157). When the per-repo `setup.conf` is missing or contains no `[section]` headers, the INFO line added in v0.12.0-rc1 (#150 / #153) only fired on the `setup.sh apply` path. Rebuilds where `.env` / `setup.conf` / `compose.yaml` already exist took the `setup.sh check-drift` path instead, which had no INFO. Two-part fix: (1) extracted `_announce_template_default_fallback` helper in `setup.sh` and now call it from both `_setup_apply` and `_setup_check_drift` entries; (2) `_print_config_summary` (in `_lib.sh`) now emits `(setup.conf has no section overrides — using template defaults; …)` inside the file-exists branch, mirroring the existing `conf_missing` hint. New `_lib_msg conf_empty` translated in 4 languages.
+
 ## [v0.12.0-rc1] - 2026-04-28
 
 Release candidate for v0.12.0. Two small developer-experience features (`make -f Makefile.ci upgrade VERSION=...`, `setup.sh apply` template-default INFO) plus a bug fix to the downstream `make upgrade` recipe. No breaking changes; downstream repos can `make -f Makefile.ci upgrade VERSION=v0.12.0-rc1` and verify before promoting to stable.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **764 tests** total (720 unit + 44 integration).
+Template self-tests: **769 tests** total (725 unit + 44 integration).
 
 ## Test Files
 
-### test/unit/lib_spec.bats (38)
+### test/unit/lib_spec.bats (39)
 
 | Test | Description |
 |------|-------------|
@@ -33,8 +33,9 @@ Template self-tests: **764 tests** total (720 unit + 44 integration).
 | `_print_config_summary prints files, identity, all populated sections, resolved` | Full config dump |
 | `_print_config_summary hides sections that are empty in setup.conf` | Empty-section skip |
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
+| `_print_config_summary warns when setup.conf exists but has no [section] headers` | #157 empty-conf hint on build/run summary |
 
-### test/unit/setup_spec.bats (170)
+### test/unit/setup_spec.bats (174)
 
 Covers core detection (user/hardware/docker/GPU/GUI), the INI parser
 (`_parse_ini_section`), setup.conf section merging (`_load_setup_conf`
@@ -65,6 +66,7 @@ writeback (first-time bootstrap / user-edit respect / opt-out).
 | `[build]` apt_mirror (empty fallback, override) | 2 |
 | Workspace writeback (first-time, respect user edit, opt-out) | 3 |
 | Per-repo setup.conf missing / empty INFO (#150: missing → INFO, empty → INFO, partial → silent, zh-TW lang) | 4 |
+| Per-repo setup.conf INFO on check-drift path (#157: missing → INFO, empty → INFO, partial → silent, zh-TW lang) | 4 |
 
 ### test/unit/tui_spec.bats (82)
 

--- a/script/docker/_lib.sh
+++ b/script/docker/_lib.sh
@@ -170,6 +170,10 @@ _lib_msg() {
     zh-CN:conf_missing)      echo "(找不到 setup.conf — 运行 ./setup_tui.sh 或 ./%s.sh --setup)" ;;
     ja:conf_missing)         echo "(setup.conf が見つかりません — ./setup_tui.sh または ./%s.sh --setup を実行してください)" ;;
     *:conf_missing)          echo "(setup.conf not found — run ./setup_tui.sh or ./%s.sh --setup)" ;;
+    zh-TW:conf_empty)        echo "(setup.conf 沒有 section 覆寫 — 全部使用模板預設值；./setup_tui.sh 或 edit setup.conf)" ;;
+    zh-CN:conf_empty)        echo "(setup.conf 没有 section 覆写 — 全部使用模板默认值；./setup_tui.sh 或 edit setup.conf)" ;;
+    ja:conf_empty)           echo "(setup.conf にセクション上書きがありません — 全てテンプレート既定値を使用；./setup_tui.sh または edit setup.conf)" ;;
+    *:conf_empty)            echo "(setup.conf has no section overrides — using template defaults; run ./setup_tui.sh or edit setup.conf)" ;;
     zh-TW:customize)         echo "自訂" ;;
     zh-CN:customize)         echo "自定义" ;;
     ja:customize)            echo "カスタマイズ" ;;
@@ -222,16 +226,26 @@ _print_config_summary() {
   # the printout and setup_tui.sh layout mirror each other.
   if [[ -f "${_conf}" ]]; then
     printf "[%s] setup.conf\n" "${_tag}"
-    local _sec _content _l
-    for _sec in image build deploy gui network security resources \
-                environment tmpfs devices volumes; do
-      _content="$(_dump_conf_section "${_conf}" "${_sec}")"
-      [[ -z "${_content}" ]] && continue
-      printf "[%s]   [%s]\n" "${_tag}" "${_sec}"
-      while IFS= read -r _l; do
-        printf "[%s]     %s\n" "${_tag}" "${_l}"
-      done <<< "${_content}"
-    done
+    # When the file exists but contains no [section] headers (empty file
+    # / comments-only / whitespace-only), every section silently falls
+    # back to template defaults. Surface a parallel hint to the
+    # missing-conf branch so users on build.sh's drift-check rebuild
+    # path see the heads-up too (closes #157).
+    if ! grep -qE '^[[:space:]]*\[[^]]+\]' "${_conf}"; then
+      # shellcheck disable=SC2059  # format string is intentional (i18n table owns no %s)
+      printf "[%s]   $(_lib_msg conf_empty)\n" "${_tag}"
+    else
+      local _sec _content _l
+      for _sec in image build deploy gui network security resources \
+                  environment tmpfs devices volumes; do
+        _content="$(_dump_conf_section "${_conf}" "${_sec}")"
+        [[ -z "${_content}" ]] && continue
+        printf "[%s]   [%s]\n" "${_tag}" "${_sec}"
+        while IFS= read -r _l; do
+          printf "[%s]     %s\n" "${_tag}" "${_l}"
+        done <<< "${_content}"
+      done
+    fi
   else
     # shellcheck disable=SC2059  # format string is intentional (i18n table owns %s)
     printf "[%s]   $(_lib_msg conf_missing)\n" "${_tag}" "${_tag}"

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -1285,7 +1285,28 @@ _setup_check_drift() {
     _base_path="$(cd -- "${_SETUP_SCRIPT_DIR}/../../.." && pwd -P)"
   fi
 
+  _announce_template_default_fallback "${_base_path}"
   _check_setup_drift "${_base_path}"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _announce_template_default_fallback <base_path>
+#
+# Surface a one-shot INFO when the per-repo setup.conf provides no
+# overrides — either missing entirely or present but containing no
+# [section] headers. Called from both `_setup_apply` and
+# `_setup_check_drift` so build.sh / run.sh's drift-check rebuild path
+# also surfaces the heads-up (closes #157, follow-up to #150 / #153).
+# Emitted to stderr to keep stdout machine-parseable.
+# ════════════════════════════════════════════════════════════════════
+_announce_template_default_fallback() {
+  local _base="${1:?"${FUNCNAME[0]}: missing base_path"}"
+  local _repo_conf="${_base}/setup.conf"
+  if [[ ! -f "${_repo_conf}" ]]; then
+    printf "[setup] INFO: %s\n" "$(_setup_msg info_no_repo_conf)" >&2
+  elif ! grep -qE '^[[:space:]]*\[[^]]+\]' "${_repo_conf}"; then
+    printf "[setup] INFO: %s\n" "$(_setup_msg info_empty_repo_conf)" >&2
+  fi
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -2097,18 +2118,7 @@ _setup_apply() {
     _base_path="$(cd -- "${_SETUP_SCRIPT_DIR}/../../.." && pwd -P)"
   fi
 
-  # Surface a one-shot INFO when the per-repo setup.conf is missing or
-  # contains no section overrides. _load_setup_conf falls back to the
-  # template default silently per call (11 sections per apply run), so
-  # without this announcement first-time users see no signal that they
-  # are running a pure-template configuration. Emitted to stderr to keep
-  # stdout machine-parseable for callers that capture it.
-  local _repo_conf="${_base_path}/setup.conf"
-  if [[ ! -f "${_repo_conf}" ]]; then
-    printf "[setup] INFO: %s\n" "$(_setup_msg info_no_repo_conf)" >&2
-  elif ! grep -qE '^[[:space:]]*\[[^]]+\]' "${_repo_conf}"; then
-    printf "[setup] INFO: %s\n" "$(_setup_msg info_empty_repo_conf)" >&2
-  fi
+  _announce_template_default_fallback "${_base_path}"
 
   local _env_file="${_base_path}/.env"
 

--- a/test/unit/lib_spec.bats
+++ b/test/unit/lib_spec.bats
@@ -359,6 +359,22 @@ EOF
   assert_output --partial "./setup_tui.sh"
 }
 
+@test "_print_config_summary warns when setup.conf exists but has no [section] headers" {
+  # Empty / comments-only setup.conf is the same situation as missing
+  # from a behavior standpoint (every section falls back to template
+  # defaults), but the existing missing-conf branch never fires because
+  # the file does exist. Surface a parallel hint inside the file-exists
+  # branch so downstream `build.sh` users see the warning.
+  local _fp="${BATS_TEST_TMPDIR}/empty_conf"
+  mkdir -p "${_fp}"
+  cat > "${_fp}/setup.conf" <<'EOF'
+# only comments, no [section] headers
+EOF
+  run bash -c "source ${LIB}; FILE_PATH='${_fp}'; _print_config_summary build"
+  assert_success
+  assert_output --partial "no section overrides"
+}
+
 # ── _lib_msg / _print_config_summary i18n ──────────────────────────────────
 
 @test "_lib_msg returns English by default" {

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -1033,6 +1033,49 @@ EOF
   assert_output --partial "drift detected"
 }
 
+@test "check-drift prints INFO when per-repo setup.conf is missing" {
+  # No TEMP_DIR/setup.conf created — check-drift should announce the
+  # template-default fallback the same way `apply` does, so users
+  # running the build.sh drift-check path see the heads-up too.
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main check-drift --base-path '${TEMP_DIR}' 2>&1
+  "
+  assert_output --partial "no per-repo setup.conf"
+}
+
+@test "check-drift prints INFO when per-repo setup.conf has no section headers" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+# only comments, no [section] headers
+EOF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main check-drift --base-path '${TEMP_DIR}' 2>&1
+  "
+  assert_output --partial "per-repo setup.conf has no section"
+}
+
+@test "check-drift stays silent when per-repo setup.conf has at least one section" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[gpu]
+mode = auto
+EOF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main check-drift --base-path '${TEMP_DIR}' 2>&1
+  "
+  refute_output --partial "no per-repo setup.conf"
+  refute_output --partial "per-repo setup.conf has no section"
+}
+
+@test "check-drift --lang zh-TW prints INFO in Traditional Chinese when setup.conf missing" {
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main check-drift --base-path '${TEMP_DIR}' --lang zh-TW 2>&1
+  "
+  assert_output --partial "未找到"
+}
+
 @test "main check-drift rejects unknown flag" {
   run main check-drift --bogus
   assert_failure


### PR DESCRIPTION
## Summary

Closes #157. Follow-up that completes #150 / #153 (which only covered the `apply` path).

## Why

After v0.12.0-rc1 a user reported running `./build.sh` with an empty `setup.conf` and seeing **no warning** in the build summary:

```
$ cat setup.conf       # <EMPTY>
$ ./build.sh
[build] setup.conf
[build] Resolved      <-- empty header, no hint
```

Two gaps:

1. The INFO line in `_setup_apply` doesn't fire on the rebuild path (`build.sh` calls `setup.sh check-drift` when `.env` + `setup.conf` + `compose.yaml` already exist).
2. `_print_config_summary` only handles the file-missing case (`_lib_msg conf_missing`); the file-exists-but-empty case prints `[build] setup.conf\n[build] Resolved` with nothing in between.

## Fix

| Layer | Change |
|---|---|
| `setup.sh` | Extracted `_announce_template_default_fallback <base_path>` helper. `_setup_apply` and `_setup_check_drift` both call it at entry. |
| `_lib.sh` | New `_lib_msg conf_empty` translated in 4 languages. `_print_config_summary` greps for `^[[:space:]]*\[[^]]+\]` inside the `if [[ -f ... ]]` branch and emits the hint when no section headers are found. |

Partial overrides (some sections present) stay silent — that is normal usage.

## Test plan

- [x] **TDD red→green**: 5 new tests written first against the unfixed code (4 in `setup_spec.bats` for `check-drift` parallel to existing `apply` tests, 1 in `lib_spec.bats` for `_print_config_summary` empty-conf hint).
- [x] No emoji / no AI attribution per repo style.
- [x] CHANGELOG `[Unreleased] Fixed` entry.
- [x] TEST.md: lib_spec 38 → 39, setup_spec 170 → 174, total 764 → 769.

Local Docker validation blocked by transient deb.debian.org outage; relying on PR CI to verify.

## Versioning

Per CLAUDE.md「RC 失敗 → 修復後打 rc2」: this completes #150's stated scope which v0.12.0-rc1 left partial. After merge, cut **v0.12.0-rc2** (no promotion of rc1 to stable).