### PR TITLE
chore: ignore .claude/ session state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ multi_run/
 .DS_Store
 .vscode/
 .idea/
+
+# Claude Code session state when launched inside this sub-repo.
+# Workspace-level Claude config lives in ycpss91255-docker/claude-workspace.
+.claude/


### PR DESCRIPTION
## Summary

Add `.claude/` to `.gitignore` so Claude Code session state
(`.claude/projects/`, `.claude/todos/`, `.claude/settings.local.json`
等) does not leak into this repo if Claude Code is ever launched with
this directory as the project root.

Workspace-level Claude config (hooks, slash commands, skills) is
tracked in [ycpss91255-docker/claude-workspace](https://github.com/ycpss91255-docker/claude-workspace);
nothing about that flow changes — this is purely defense in depth.

## Test plan

- [x] `.gitignore`-only change — no functional impact
- [ ] CI green