### PR TITLE
fix(upgrade): semver-aware --check + refuse implicit downgrade (#156)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`upgrade.sh --check` (and `make upgrade-check`) no longer reports a downgrade when the local pin is a prerelease ahead of the latest stable tag** (#156). Previously the comparator used plain string equality (`==`) — so a downstream pinned to `v0.12.0-rc1` while the org's latest stable was still `v0.11.0` would print `Update available: v0.12.0-rc1 → v0.11.0` and exit 1, telling the user to roll back. The new `_semver_cmp` helper applies SemVer §11 (pre-release < associated final), so `_check` now correctly classifies the three real-world cases: equal (exit 0, "Already up to date"), behind (exit 1, "Update available"), and ahead (exit 0, "Local is ahead of latest stable"). `_upgrade <older>` from a newer local version is also now refused with an explicit "Refusing implicit downgrade" error before any subtree pull, so a typo'd `make upgrade VERSION=v0.11.0` on a v0.12.0-rc1 working tree no longer silently rolls back the prerelease pin.
+
+### Added
+- **`_semver_cmp <a> <b>`** in `upgrade.sh` — pure-bash SemVer §11 comparator. Returns 0 / 1 / 2 for equal / a<b / a>b. Handles only the shape this project ships (`vMAJOR.MINOR.PATCH[-PRERELEASE]`) but applies §11 correctly: `sort -V` puts pre-releases AFTER finals (treats `-` as "less than empty"), which is wrong for our use case once a stable tag exists alongside its earlier `-rc` tags.
+
 ## [v0.12.0] - 2026-04-28
 
 Stable promotion of [v0.12.0-rc2](https://github.com/ycpss91255-docker/template/releases/tag/v0.12.0-rc2). Two small developer-experience features and one consumer-facing bug fix; no breaking changes from v0.11.0.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **769 tests** total (725 unit + 44 integration).
+Template self-tests: **784 tests** total (740 unit + 44 integration).
 
 ## Test Files
 
@@ -478,7 +478,7 @@ Exercises the runtime assertion helpers shipped in
 | `main copies tmux.conf to config directory` | Config copy |
 | `script runs entry_point when executed directly` | Direct-run guard |
 
-### test/unit/upgrade_spec.bats (18)
+### test/unit/upgrade_spec.bats (33)
 
 Unit tests for `upgrade.sh` helpers. Uses the sed-range pattern to extract
 one function at a time into a minimal harness (with `_log` / `_error`
@@ -489,10 +489,12 @@ source the full `upgrade.sh` (which would trigger its top-level
 Covers: `_warn_config_drift` (silent / fires on drift / diff hint),
 the three safety guards added after the v0.9.7 Jetson incident
 (`_require_git_identity`, `_require_clean_merge_state`,
-`_verify_subtree_intact` with rollback), and structural invariants that
+`_verify_subtree_intact` with rollback), structural invariants that
 pin call-ordering in `_upgrade` (identity check runs before subtree
 pull, integrity verification runs after, pre-pull HEAD is snapshotted
-for rollback).
+for rollback), and the SemVer §11-aware `_semver_cmp` + `_check`
+behavior added for issue #156 (prerelease ahead of latest stable
+must not be reported as "needing downgrade").
 
 | Test | Description |
 |------|-------------|
@@ -514,6 +516,21 @@ for rollback).
 | `upgrade.sh calls _require_git_identity before subtree pull` | Pre-flight ordering |
 | `upgrade.sh calls _verify_subtree_intact after subtree pull` | Post-flight ordering |
 | `upgrade.sh snapshots pre-pull HEAD for rollback` | Rollback anchor |
+| `_semver_cmp: equal versions return 0` | Equality |
+| `_semver_cmp: lower core returns 1` | Behind core |
+| `_semver_cmp: higher core returns 2` | Ahead core |
+| `_semver_cmp: pre-release < final at same core (rc1 < 0.12.0)` | SemVer §11 a |
+| `_semver_cmp: final > pre-release at same core (0.12.0 > rc1)` | SemVer §11 b |
+| `_semver_cmp: rc1 < rc2 (lex pre-release ordering)` | Pre-release order |
+| `_semver_cmp: rc2 > rc1` | Pre-release order |
+| `_semver_cmp: pre-release of newer beats older final (0.12.0-rc1 > 0.11.0)` | Cross-core |
+| `_semver_cmp: older final < pre-release of newer (0.11.0 < 0.12.0-rc1)` | Cross-core |
+| `_check: equal versions report up-to-date and exit 0` | Happy equal |
+| `_check: behind latest reports update available and exits 1` | Behind |
+| `_check: prerelease ahead of latest stable exits 0 (issue #156 case)` | Regression #156 |
+| `_check: stable later than latest stable exits 0 (defensive)` | Local-only tag |
+| `_check: prerelease behind latest stable proposes upgrade (rc1 → 0.12.0)` | Leave prerelease |
+| `_upgrade refuses to downgrade from a newer local version` | Implicit-downgrade guard |
 
 ### test/integration/init_new_repo_spec.bats (36)
 

--- a/test/unit/upgrade_spec.bats
+++ b/test/unit/upgrade_spec.bats
@@ -25,6 +25,8 @@ EOS
   sed -n '/^_require_git_identity() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
   sed -n '/^_require_clean_merge_state() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
   sed -n '/^_verify_subtree_intact() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
+  sed -n '/^_semver_cmp() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
+  sed -n '/^_check() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
 }
 
 teardown() {
@@ -270,4 +272,174 @@ _mk_subtree_repo() {
 @test "upgrade.sh snapshots pre-pull HEAD for rollback" {
   run grep -F 'git rev-parse HEAD' "${UPGRADE}"
   assert_success
+}
+
+# ── _semver_cmp (SemVer §11 ordering) ───────────────────────────────────────
+#
+# SemVer §11 says a pre-release version has LOWER precedence than the
+# associated normal version (rc1 < final). GNU `sort -V` sorts the
+# other way (final < rc1, treating `-` as "less than empty"), which is
+# why upgrade.sh needs its own comparator: the wrong ordering causes
+# `make upgrade-check` to mis-classify v0.12.0-rc1 vs released v0.12.0
+# once the stable tag exists.
+#
+# Returns: 0 = equal, 1 = a < b, 2 = a > b.
+
+@test "_semver_cmp: equal versions return 0" {
+  run bash -c "source '${HARNESS}'; _semver_cmp v0.11.0 v0.11.0; echo \$?"
+  assert_success
+  assert_output "0"
+}
+
+@test "_semver_cmp: lower core returns 1" {
+  run bash -c "source '${HARNESS}'; _semver_cmp v0.11.0 v0.12.0; echo \$?"
+  assert_success
+  assert_output "1"
+}
+
+@test "_semver_cmp: higher core returns 2" {
+  run bash -c "source '${HARNESS}'; _semver_cmp v0.12.0 v0.11.0; echo \$?"
+  assert_success
+  assert_output "2"
+}
+
+@test "_semver_cmp: pre-release < final at same core (rc1 < 0.12.0)" {
+  run bash -c "source '${HARNESS}'; _semver_cmp v0.12.0-rc1 v0.12.0; echo \$?"
+  assert_success
+  assert_output "1"
+}
+
+@test "_semver_cmp: final > pre-release at same core (0.12.0 > rc1)" {
+  run bash -c "source '${HARNESS}'; _semver_cmp v0.12.0 v0.12.0-rc1; echo \$?"
+  assert_success
+  assert_output "2"
+}
+
+@test "_semver_cmp: rc1 < rc2 (lex pre-release ordering)" {
+  run bash -c "source '${HARNESS}'; _semver_cmp v0.12.0-rc1 v0.12.0-rc2; echo \$?"
+  assert_success
+  assert_output "1"
+}
+
+@test "_semver_cmp: rc2 > rc1" {
+  run bash -c "source '${HARNESS}'; _semver_cmp v0.12.0-rc2 v0.12.0-rc1; echo \$?"
+  assert_success
+  assert_output "2"
+}
+
+@test "_semver_cmp: pre-release of newer beats older final (0.12.0-rc1 > 0.11.0)" {
+  run bash -c "source '${HARNESS}'; _semver_cmp v0.12.0-rc1 v0.11.0; echo \$?"
+  assert_success
+  assert_output "2"
+}
+
+@test "_semver_cmp: older final < pre-release of newer (0.11.0 < 0.12.0-rc1)" {
+  run bash -c "source '${HARNESS}'; _semver_cmp v0.11.0 v0.12.0-rc1; echo \$?"
+  assert_success
+  assert_output "1"
+}
+
+# ── _check (semver-aware) ────────────────────────────────────────────────────
+#
+# _check exits 0 when there's nothing to do (already current, or local
+# is ahead of latest stable — typical for prerelease testers) and 1
+# only when a real upgrade is available. This is the regression at the
+# heart of issue #156: previously _check used `==` and reported any
+# mismatch (including "running rc1, latest stable is older v0.11.0")
+# as "needing downgrade" with exit 1.
+
+@test "_check: equal versions report up-to-date and exit 0" {
+  run bash -c "
+    source '${HARNESS}'
+    _get_local_version()  { echo v0.12.0; }
+    _get_latest_version() { echo v0.12.0; }
+    _check
+  "
+  assert_success
+  assert_output --partial "Local:  v0.12.0"
+  assert_output --partial "Latest: v0.12.0"
+  assert_output --partial "Already up to date"
+}
+
+@test "_check: behind latest reports update available and exits 1" {
+  run bash -c "
+    source '${HARNESS}'
+    _get_local_version()  { echo v0.11.0; }
+    _get_latest_version() { echo v0.12.0; }
+    _check
+  "
+  assert_failure
+  assert_output --partial "Update available: v0.11.0 →v0.12.0"
+}
+
+@test "_check: prerelease ahead of latest stable exits 0 (issue #156 case)" {
+  # Scenario from issue #156: user's downstream pinned to v0.12.0-rc1
+  # while the org's latest stable tag is still v0.11.0. _check should
+  # NOT advise a downgrade — it should say the local is ahead.
+  run bash -c "
+    source '${HARNESS}'
+    _get_local_version()  { echo v0.12.0-rc1; }
+    _get_latest_version() { echo v0.11.0; }
+    _check
+  "
+  assert_success
+  assert_output --partial "Local:  v0.12.0-rc1"
+  assert_output --partial "Latest: v0.11.0"
+  assert_output --partial "ahead"
+  refute_output --partial "Update available"
+}
+
+@test "_check: stable later than latest stable exits 0 (defensive)" {
+  # If local was hand-tagged to a future version not yet on the remote
+  # (e.g. local-only release, or stale ls-remote), don't propose a
+  # downgrade.
+  run bash -c "
+    source '${HARNESS}'
+    _get_local_version()  { echo v0.13.0; }
+    _get_latest_version() { echo v0.12.0; }
+    _check
+  "
+  assert_success
+  assert_output --partial "ahead"
+}
+
+@test "_check: prerelease behind latest stable proposes upgrade (rc1 →0.12.0)" {
+  # Once v0.12.0 is published, a downstream still on v0.12.0-rc1
+  # should be told to leave the prerelease and move to stable.
+  run bash -c "
+    source '${HARNESS}'
+    _get_local_version()  { echo v0.12.0-rc1; }
+    _get_latest_version() { echo v0.12.0; }
+    _check
+  "
+  assert_failure
+  assert_output --partial "Update available: v0.12.0-rc1 →v0.12.0"
+}
+
+# ── _upgrade refuses implicit downgrade ─────────────────────────────────────
+#
+# Calling `./template/upgrade.sh v0.11.0` from a v0.12.0-rc1 working
+# tree should refuse and exit non-zero before touching the working
+# tree. The user can still recover deliberately (e.g., set the version
+# file by hand or rerun with a clear --force flag if we ever add one).
+
+@test "_upgrade refuses to downgrade from a newer local version" {
+  # Extract a minimal _upgrade by hand (the full body sources too many
+  # external deps); we only need the entry-point downgrade guard. The
+  # guard MUST fire before any subtree pull.
+  run bash -c "
+    source '${HARNESS}'
+    sed -n '/^_upgrade() {\$/,/^}\$/p' '${UPGRADE}' > '${TEMP_DIR}/upgrade_fn.sh'
+    source '${TEMP_DIR}/upgrade_fn.sh'
+
+    _get_local_version()      { echo v0.12.0-rc1; }
+    _require_git_identity()   { :; }
+    _require_clean_merge_state(){ :; }
+    git()                     { echo 'FATAL: git should not be called' >&2; exit 99; }
+
+    _upgrade v0.11.0
+  "
+  assert_failure
+  assert_output --partial "downgrade"
+  refute_output --partial "FATAL"
 }

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -109,6 +109,47 @@ _get_latest_version() {
     | sed 's|refs/tags/||'
 }
 
+# ── Semver comparison ────────────────────────────────────────────────────────
+#
+# SemVer §11 says a pre-release version has LOWER precedence than the
+# associated normal version (rc1 < final). GNU `sort -V` orders them
+# the OTHER way (final < rc1, treats `-` as "less than empty"), so we
+# can't just delegate. The wrong ordering caused issue #156: once
+# v0.12.0 was published, downstreams still pinned to v0.12.0-rc1
+# would have been told they were "ahead" of stable, hiding the upgrade.
+#
+# This comparator handles the only semver shape we ship —
+# v<MAJOR>.<MINOR>.<PATCH>[-<PRERELEASE>] — and applies §11 explicitly:
+#   - core compared via `sort -V` (purely numeric, no `-` involved)
+#   - same-core final beats same-core pre-release
+#   - same-core pre-releases compared lexicographically (rc1 < rc2 etc.)
+#
+# Returns: 0 = equal, 1 = a < b, 2 = a > b.
+_semver_cmp() {
+  local _a="${1#v}"
+  local _b="${2#v}"
+  local _a_core="${_a%%-*}"
+  local _b_core="${_b%%-*}"
+  local _a_pre=""
+  local _b_pre=""
+  [[ "${_a}" == *"-"* ]] && _a_pre="${_a#*-}"
+  [[ "${_b}" == *"-"* ]] && _b_pre="${_b#*-}"
+
+  if [[ "${_a_core}" != "${_b_core}" ]]; then
+    local _newer
+    _newer="$(printf '%s\n%s\n' "${_a_core}" "${_b_core}" | sort -V | tail -1)"
+    [[ "${_newer}" == "${_a_core}" ]] && return 2 || return 1
+  fi
+
+  if [[ -z "${_a_pre}" && -z "${_b_pre}" ]]; then return 0; fi
+  [[ -z "${_a_pre}" ]] && return 2
+  [[ -z "${_b_pre}" ]] && return 1
+
+  if [[ "${_a_pre}" < "${_b_pre}" ]]; then return 1; fi
+  if [[ "${_a_pre}" > "${_b_pre}" ]]; then return 2; fi
+  return 0
+}
+
 # ── Check mode ───────────────────────────────────────────────────────────────
 
 _check() {
@@ -123,13 +164,18 @@ _check() {
   _log "Local:  ${local_ver}"
   _log "Latest: ${latest_ver}"
 
-  if [[ "${local_ver}" == "${latest_ver}" ]]; then
-    _log "Already up to date."
-    return 0
-  else
-    _log "Update available: ${local_ver} → ${latest_ver}"
+  if [[ "${local_ver}" == "unknown" ]]; then
+    _log "Update available: ${local_ver} →${latest_ver}"
     return 1
   fi
+
+  local _cmp=0
+  _semver_cmp "${local_ver}" "${latest_ver}" || _cmp=$?
+  case "${_cmp}" in
+    0) _log "Already up to date."; return 0 ;;
+    1) _log "Update available: ${local_ver} →${latest_ver}"; return 1 ;;
+    2) _log "Local is ahead of latest stable (prerelease or local-only tag)."; return 0 ;;
+  esac
 }
 
 # ── Upgrade ──────────────────────────────────────────────────────────────────
@@ -142,6 +188,20 @@ _upgrade() {
   if [[ "${local_ver}" == "${target_ver}" ]]; then
     _log "Already at ${target_ver}. Nothing to do."
     return 0
+  fi
+
+  # Refuse implicit downgrade. Without this guard the user can ratchet
+  # back from v0.12.0-rc1 to an older v0.11.0 without realising it,
+  # which silently undoes prerelease testing and re-introduces fixed
+  # bugs. _semver_cmp returns 2 when local > target per SemVer §11.
+  if [[ "${local_ver}" != "unknown" ]]; then
+    local _cmp=0
+    _semver_cmp "${local_ver}" "${target_ver}" || _cmp=$?
+    if (( _cmp == 2 )); then
+      _error "Refusing implicit downgrade from ${local_ver} to ${target_ver}.
+  If this is intentional (rolling back a bad release), edit
+  template/.version manually and re-run the upgrade."
+    fi
   fi
 
   # Pre-flight safety checks. Any failure exits non-zero without


### PR DESCRIPTION
Closes #156.

## Problem

`upgrade.sh --check` (and `make upgrade-check`) used plain string equality, so any mismatch was reported as `Update available: <local> → <latest>` with exit 1. After publishing `v0.12.0-rc1` while the latest stable was still `v0.11.0`, downstream repos saw:

```
[upgrade] Local:  v0.12.0-rc1
[upgrade] Latest: v0.11.0
[upgrade] Update available: v0.12.0-rc1 → v0.11.0
```

— advising users to downgrade a prerelease they were intentionally testing.

A symmetric problem existed in `_upgrade`: `make upgrade VERSION=v0.11.0` on a `v0.12.0-rc1` working tree would silently roll back the prerelease pin without warning.

## Fix

Add `_semver_cmp` (pure-bash, SemVer §11). Cannot delegate to `sort -V` — it treats `-` as "less than empty" and orders `v0.12.0` BEFORE `v0.12.0-rc1`, which is wrong once a stable tag exists alongside its earlier `-rc` tags (a downstream still on `v0.12.0-rc1` would be classified as "ahead" of stable and never told to upgrade).

`_check` now reports three states:
- equal → `Already up to date` (exit 0)
- behind → `Update available` (exit 1)
- ahead → `Local is ahead of latest stable (prerelease or local-only tag)` (exit 0)

`_upgrade <older>` from a newer local version is refused with an explicit `Refusing implicit downgrade` error before any git operation, with a hint at the deliberate-rollback path (edit `template/.version` manually).

## Tests

15 new unit tests in `test/unit/upgrade_spec.bats`, covering:
- `_semver_cmp`: equal / lower core / higher core / rc1<final / final>rc1 / rc1<rc2 / cross-core prerelease
- `_check`: each of the three branches, plus the regression case from #156 (rc1 ahead of older stable) and the symmetric "rc1 behind newly-released stable" case
- `_upgrade`: implicit-downgrade guard fires before any git call

Total: **784 tests** (740 unit + 44 integration), all green inside the kcov compose runner. ShellCheck clean.

## Notes

- Behavior change is backwards-compatible from the user's POV: `--check` still exits 0 when nothing to do and 1 when an upgrade is available; the new "ahead" branch only fires for the previously-broken case.
- `_upgrade <same>` early-return is unchanged.
- The deliberate-downgrade escape hatch is documented in the new error message (edit `template/.version`).