### PR TITLE
fix(test-tools): bats unusable in image + APT_MIRROR_DEBIAN plumbing

### DIFF
--- a/.github/workflows/release-test-tools.yaml
+++ b/.github/workflows/release-test-tools.yaml
@@ -71,3 +71,18 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tags.outputs.tags }}
           push: true
+
+      - name: Smoke test pushed image
+        # Regression guard for the v0.12.1 publish (issue #165): the alpine
+        # final stage shipped without bash and without /usr/local/bin/bats,
+        # so the image had bats-* files on disk but `bats` was unrunnable.
+        # Pull the just-pushed amd64 leg and exercise each tool end-to-end
+        # so a similar break never reaches downstream consumers silently.
+        shell: bash
+        run: |
+          set -euo pipefail
+          image="ghcr.io/ycpss91255-docker/test-tools:latest"
+          docker pull "${image}"
+          docker run --rm "${image}" bats --version
+          docker run --rm "${image}" shellcheck --version
+          docker run --rm "${image}" hadolint --version

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,6 +9,7 @@ services:
     environment:
       - HOST_UID=${HOST_UID:-1000}
       - HOST_GID=${HOST_GID:-1000}
+      - APT_MIRROR_DEBIAN=${APT_MIRROR_DEBIAN:-deb.debian.org}
     entrypoint: /bin/bash
     command:
       - -c

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`Dockerfile.test-tools`: bats now runnable in the published image** (#165). The alpine-based final stage was missing `bash` (required by bats's `#!/usr/bin/env bash` entry point) and the `/usr/local/bin/bats` symlink (the upstream `bats/bats:latest` ships it but it lives outside `/opt/bats`, so the existing `COPY --from=bats-src /opt/bats /opt/bats` did not pick it up). `apk add bash` and `ln -s /opt/bats/bin/bats /usr/local/bin/bats` restore both. `release-test-tools.yaml` now runs `bats --version`, `shellcheck --version`, `hadolint --version` against the just-pushed image as a regression guard so a similar break can't ship silently again.
+- **`compose.yaml` / `ci.sh::_install_deps`: `make -f Makefile.ci test` no longer hard-fails on networks where `deb.debian.org` is unreachable** (#164). The kcov/kcov-based `ci` service had no apt-mirror plumbing, so `apt-get update` always pointed at the upstream Debian archive even when the host's TW mirror responded normally. `compose.yaml` now propagates `APT_MIRROR_DEBIAN` (default `deb.debian.org`, no-op when unset) into the container, and `_install_deps` rewrites `/etc/apt/sources.list` (and `sources.list.d/*.list` / `*.sources`) with `sed` before running `apt-get update` whenever the env var differs from the default. Set `APT_MIRROR_DEBIAN=mirror.twds.com.tw` (or any reachable Debian mirror) on the host before invoking `make test` / `make coverage` to opt into the rewrite. The cleaner long-term fix — switching the `ci` service to the published `test-tools` image so the apt-install path is bypassed entirely — is tracked separately and depends on this PR's image rebuild landing first.
+
 ## [v0.12.1] - 2026-04-28
 
 Patch release containing a single bug fix to `upgrade.sh`'s version comparator. No new features, no breaking changes from v0.12.0.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **784 tests** total (740 unit + 44 integration).
+Template self-tests: **787 tests** total (743 unit + 44 integration).
 
 ## Test Files
 
@@ -351,7 +351,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `pip setup.sh sets PIP_BREAK_SYSTEM_PACKAGES=1` | Break system packages |
 | `pip setup.sh fails when pip is not available` | Missing pip error |
 
-### test/unit/ci_spec.bats (8)
+### test/unit/ci_spec.bats (11)
 
 | Test | Description |
 |------|-------------|
@@ -360,6 +360,9 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `_install_deps: dies with clear error when apt-get install fails` | Explicit `apt-get install` error |
 | `_install_deps: dies with clear error when git clone bats-mock fails` | Explicit `git clone` error |
 | `_install_deps: happy path succeeds when bats absent and all deps install cleanly` | Full install path |
+| `_install_deps: rewrites sources.list when APT_MIRROR_DEBIAN differs from default` | TW-mirror sed substitution path |
+| `_install_deps: skips sources.list rewrite when APT_MIRROR_DEBIAN equals default` | Default value short-circuit |
+| `_install_deps: skips sources.list rewrite when APT_MIRROR_DEBIAN unset` | Unset env var short-circuit |
 | `_run_shellcheck: invokes shellcheck against every expected script` | Wired-file regression guard |
 | `_run_shellcheck: picks up every .sh file in script/docker/` | `find` covers new scripts |
 | `_run_shellcheck: exits non-zero when shellcheck fails on any script` | Strict-mode propagation |

--- a/dockerfile/Dockerfile.test-tools
+++ b/dockerfile/Dockerfile.test-tools
@@ -41,9 +41,16 @@ RUN apk add --no-cache curl xz && \
         "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-${hd_arch}" && \
     chmod +x /usr/local/bin/hadolint
 
+# Final stage: bash + bats + shellcheck + hadolint + bats-{support,assert,mock}.
+# bash is required because /opt/bats/bin/bats is a `#!/usr/bin/env bash` script
+# and alpine:latest only ships busybox ash. The /usr/local/bin/bats symlink
+# exposes bats on PATH (the upstream bats/bats:latest puts it there but the
+# symlink is not under /opt/bats so it is not picked up by the COPY above).
 FROM alpine:latest
+RUN apk add --no-cache bash
 COPY --from=bats-src /opt/bats /opt/bats
 COPY --from=bats-src /usr/lib/bats /usr/lib/bats
 COPY --from=bats-extensions /bats /usr/lib/bats
 COPY --from=lint-tools /usr/local/bin/shellcheck /usr/local/bin/
 COPY --from=lint-tools /usr/local/bin/hadolint /usr/local/bin/
+RUN ln -s /opt/bats/bin/bats /usr/local/bin/bats

--- a/script/ci/ci.sh
+++ b/script/ci/ci.sh
@@ -58,6 +58,23 @@ _die() { printf "[ci] ERROR: %s\n" "$*" >&2; exit 1; }
 _install_deps() {
   command -v bats >/dev/null 2>&1 && return 0
 
+  # Rewrite sources.list to use APT_MIRROR_DEBIAN before apt-get update.
+  # Default deb.debian.org is unreachable on some networks (regional outage,
+  # ISP routing, captive portals) while the configured mirror responds. The
+  # env var is plumbed through by compose.yaml; only rewrite when it actually
+  # differs from the default so unaffected networks keep using the upstream.
+  local _mirror="${APT_MIRROR_DEBIAN:-deb.debian.org}"
+  if [[ "${_mirror}" != "deb.debian.org" ]]; then
+    [[ -f /etc/apt/sources.list ]] \
+      && sed -i "s|deb.debian.org|${_mirror}|g" /etc/apt/sources.list
+    if compgen -G '/etc/apt/sources.list.d/*.list' >/dev/null; then
+      sed -i "s|deb.debian.org|${_mirror}|g" /etc/apt/sources.list.d/*.list
+    fi
+    if compgen -G '/etc/apt/sources.list.d/*.sources' >/dev/null; then
+      sed -i "s|deb.debian.org|${_mirror}|g" /etc/apt/sources.list.d/*.sources
+    fi
+  fi
+
   apt-get update -qq \
     || _die "apt-get update failed. Check network / apt mirror reachability."
 

--- a/test/unit/ci_spec.bats
+++ b/test/unit/ci_spec.bats
@@ -97,6 +97,56 @@ teardown() {
   assert_success
 }
 
+@test "_install_deps: rewrites sources.list when APT_MIRROR_DEBIAN differs from default" {
+  local _log="${BATS_TEST_TMPDIR}/sed.log"
+  mock_cmd "sed" '
+    printf "%s\n" "$*" >> "'"${_log}"'"
+    exit 0'
+  mock_cmd "apt-get" 'exit 0'
+  mock_cmd "git" 'exit 0'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    export APT_MIRROR_DEBIAN="mirror.twds.com.tw"
+    _install_deps
+  '
+  assert_success
+  assert [ -f "${_log}" ]
+  run cat "${_log}"
+  assert_output --partial "s|deb.debian.org|mirror.twds.com.tw|g"
+}
+
+@test "_install_deps: skips sources.list rewrite when APT_MIRROR_DEBIAN equals default" {
+  mock_cmd "sed" 'echo "sed-should-not-be-called"; exit 1'
+  mock_cmd "apt-get" 'exit 0'
+  mock_cmd "git" 'exit 0'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    export APT_MIRROR_DEBIAN="deb.debian.org"
+    _install_deps
+  '
+  assert_success
+  refute_output --partial "sed-should-not-be-called"
+}
+
+@test "_install_deps: skips sources.list rewrite when APT_MIRROR_DEBIAN unset" {
+  mock_cmd "sed" 'echo "sed-should-not-be-called"; exit 1'
+  mock_cmd "apt-get" 'exit 0'
+  mock_cmd "git" 'exit 0'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    unset APT_MIRROR_DEBIAN
+    _install_deps
+  '
+  assert_success
+  refute_output --partial "sed-should-not-be-called"
+}
+
 # ════════════════════════════════════════════════════════════════════
 # _run_shellcheck
 #


### PR DESCRIPTION
## Summary

Two related fixes that unblock local CI on TW networks and restore the
published `ghcr.io/ycpss91255-docker/test-tools:latest` image so
downstream consumers can pull it without `bats: command not found`.

### `Dockerfile.test-tools` — bats now runnable in the image (#165)

Final stage was missing `bash` (bats shebang is `#!/usr/bin/env bash`,
alpine ships only busybox `ash`) and `/usr/local/bin/bats` (upstream
`bats/bats:latest` ships the symlink outside `/opt/bats`, so
`COPY --from=bats-src /opt/bats /opt/bats` doesn't pick it up).

```dockerfile
RUN apk add --no-cache bash
...
RUN ln -s /opt/bats/bin/bats /usr/local/bin/bats
```

`release-test-tools.yaml` now `docker pull`s the just-pushed image and
runs `bats --version`, `shellcheck --version`, `hadolint --version` as a
post-publish smoke test. Catches any similar "image ships but binary is
unrunnable" regression before it leaks into downstream CI.

### `compose.yaml` + `ci.sh::_install_deps` — APT_MIRROR_DEBIAN plumbing (#164, approach `(a)`)

The kcov/kcov-based `ci` service ran `apt-get update` against the
image's stock `/etc/apt/sources.list` (deb.debian.org). On networks
where that's unreachable but the TW mirror responds, `make -f
Makefile.ci test` hard-fails with no usable workaround.

- `compose.yaml`: propagate `APT_MIRROR_DEBIAN` env (default
  `deb.debian.org`, no-op when host env unset).
- `ci.sh::_install_deps`: when `APT_MIRROR_DEBIAN` differs from the
  default, `sed` `/etc/apt/sources.list` + `sources.list.d/*.list` +
  `sources.list.d/*.sources` to swap the host before `apt-get update`.

Usage:

```
APT_MIRROR_DEBIAN=mirror.twds.com.tw make -f Makefile.ci test
```

Default behaviour unchanged for users who can reach `deb.debian.org`
fine — only opt-in when set.

Approach `(b)` from #164 (bake bats into `test-tools` and switch the
`ci` service to it so `_install_deps` becomes a full no-op) is the
cleaner long-term fix but has a chicken-and-egg with the broken
`test-tools:latest` — folded into a follow-up issue once this PR's
image rebuild lands.

### Tests

- 3 new `ci_spec.bats` tests covering the rewrite branches
  (`APT_MIRROR_DEBIAN` differs / equals default / unset).
- TEST.md count synced (8 → 11 in `ci_spec.bats`; 784 → 787 total).

## Test plan

- [x] `APT_MIRROR_DEBIAN=mirror.twds.com.tw make -f Makefile.ci test` —
      743 unit + 44 integration = 787 tests pass; ShellCheck clean
- [ ] After merge + `v0.12.2` tag: verify `release-test-tools.yaml`
      smoke step catches a deliberately-broken Dockerfile (regression
      test of the regression test). Currently boxed in by the same
      image that's broken; once `:latest` is rebuilt clean, repeat the
      drill on a temporary branch to confirm the smoke step actually
      fails on missing `bash`.
- [ ] After image rebuild: open follow-up issue / PR for #164 (b) —
      switch compose `ci` service to the published `test-tools` image,
      drop `_install_deps` apt-install path entirely.

Closes #165
Closes #164
