### PR TITLE
feat(ci): switch fast CI to ghcr test-tools image (#168)

### DIFF
--- a/.github/workflows/release-test-tools.yaml
+++ b/.github/workflows/release-test-tools.yaml
@@ -88,3 +88,4 @@ jobs:
           docker run --rm "${image}" hadolint --version
           docker run --rm "${image}" parallel --version
           docker run --rm "${image}" git --version
+          docker run --rm "${image}" git subtree --help >/dev/null  # presence check (no --version flag)

--- a/.github/workflows/release-test-tools.yaml
+++ b/.github/workflows/release-test-tools.yaml
@@ -86,3 +86,5 @@ jobs:
           docker run --rm "${image}" bats --version
           docker run --rm "${image}" shellcheck --version
           docker run --rm "${image}" hadolint --version
+          docker run --rm "${image}" parallel --version
+          docker run --rm "${image}" git --version

--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -15,7 +15,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # Build the test-tools image from THIS PR's Dockerfile so the
+      # self-test exercises the actual changes instead of pulling a
+      # potentially stale ghcr `:latest`. Without this, PRs that touch
+      # Dockerfile.test-tools always run against the previously published
+      # image (chicken-and-egg with release-test-tools.yaml — that
+      # workflow only fires on tag push). Setting TEST_TOOLS_IMAGE
+      # tells compose.yaml's `ci` service to use the local build.
+      - name: Build test-tools:local
+        run: docker build -t test-tools:local -f dockerfile/Dockerfile.test-tools .
+
       - name: Run CI (ShellCheck + Bats + Kcov)
+        env:
+          TEST_TOOLS_IMAGE: test-tools:local
         run: ./script/ci/ci.sh
 
       - name: Upload coverage to Codecov

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,33 @@
 services:
+  # Fast CI: ShellCheck + Bats only. Uses the prebuilt test-tools image
+  # (alpine: bash + bats + bats-{support,assert,mock} + shellcheck +
+  # hadolint baked in), so _install_deps short-circuits via its
+  # `command -v bats` guard — no per-run apt-install. TEST_TOOLS_IMAGE
+  # can be overridden to pin a specific tag during local rebuild flows;
+  # default :latest tracks the most recent template release tag because
+  # release-test-tools.yaml rebuilds it on every v* push.
   ci:
+    image: ${TEST_TOOLS_IMAGE:-ghcr.io/ycpss91255-docker/test-tools:latest}
+    security_opt:
+      - seccomp=unconfined
+    volumes:
+      - .:/source
+    working_dir: /source
+    environment:
+      - HOST_UID=${HOST_UID:-1000}
+      - HOST_GID=${HOST_GID:-1000}
+    entrypoint: /bin/bash
+    command:
+      - -c
+      - ./script/ci/ci.sh --ci
+
+  # Coverage: same pipeline plus kcov instrumentation. Stays on kcov/kcov
+  # because kcov is not in the alpine test-tools image (building it from
+  # source would balloon image size and pull in deps unrelated to fast CI).
+  # APT_MIRROR_DEBIAN is opt-in for networks where deb.debian.org is
+  # unreachable; _install_deps rewrites /etc/apt/sources.list before
+  # apt-installing bats/bats-support/bats-assert + git-cloning bats-mock.
+  coverage:
     image: kcov/kcov
     security_opt:
       - seccomp=unconfined

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`compose.yaml` splits the `ci` runner into `ci` (fast) + `coverage` (kcov) services** (#168). The fast `ci` service now uses the prebuilt `ghcr.io/ycpss91255-docker/test-tools:latest` (alpine, with bats / shellcheck / hadolint / bats-{support,assert,mock} / parallel baked in), so `_install_deps` short-circuits via its `command -v bats` guard and no apt-install runs on each `make -f Makefile.ci test`. The `coverage` service stays on `kcov/kcov` and keeps the `APT_MIRROR_DEBIAN` plumbing introduced in v0.12.2 (kcov/kcov is debian-based and still apt-installs bats for the `--coverage` path). `_run_via_compose` takes a service-name first arg so `main()` routes default mode → `ci`, `--coverage` → `coverage`. Override the image with `TEST_TOOLS_IMAGE=...` for local rebuild flows.
+
+### Added
+- **`Dockerfile.test-tools` ships `parallel`** (#168). `bats --jobs N` delegates to GNU parallel; without it bats fails with `parallel: command not found`. `apk add parallel` makes the prebuilt image self-sufficient for the parallel fast-CI path. `release-test-tools.yaml` smoke step extended with `parallel --version` so a missing-parallel regression can't ship silently.
+- **`_run_tests` graceful fallback to serial bats when parallel is missing** (#168). Older test-tools images (v0.12.2 and earlier) ship without parallel; the fallback lets downstream consumers running an older `test-tools:<tag>` still execute the test suite (slower) instead of hard-failing. New images carry parallel, so this fallback is dormant on `:latest`.
+
 ## [v0.12.2] - 2026-04-28
 
 Patch release with two related test-tools fixes. No new features, no breaking changes from v0.12.1.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **787 tests** total (743 unit + 44 integration).
+Template self-tests: **793 tests** total (749 unit + 44 integration).
 
 ## Test Files
 
@@ -351,7 +351,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `pip setup.sh sets PIP_BREAK_SYSTEM_PACKAGES=1` | Break system packages |
 | `pip setup.sh fails when pip is not available` | Missing pip error |
 
-### test/unit/ci_spec.bats (11)
+### test/unit/ci_spec.bats (17)
 
 | Test | Description |
 |------|-------------|
@@ -366,6 +366,12 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `_run_shellcheck: invokes shellcheck against every expected script` | Wired-file regression guard |
 | `_run_shellcheck: picks up every .sh file in script/docker/` | `find` covers new scripts |
 | `_run_shellcheck: exits non-zero when shellcheck fails on any script` | Strict-mode propagation |
+| `_run_via_compose: routes default mode to the ci service with COVERAGE=0` | Service routing — fast path |
+| `_run_via_compose: routes coverage mode to the coverage service with COVERAGE=1` | Service routing — coverage path |
+| `_run_tests: passes --jobs N when parallel is on PATH` | Parallel-present branch |
+| `_run_tests: omits --jobs when parallel is absent (graceful fallback)` | Parallel-missing branch |
+| `main: dispatches no-flag default to the ci service` | End-to-end default dispatch |
+| `main: dispatches --coverage to the coverage service` | End-to-end --coverage dispatch |
 
 ### test/unit/init_spec.bats (18)
 

--- a/dockerfile/Dockerfile.test-tools
+++ b/dockerfile/Dockerfile.test-tools
@@ -50,11 +50,13 @@ RUN apk add --no-cache curl xz && \
 # parallel (#168): bats --jobs N delegates to GNU parallel; without it bats
 # falls back to serial. ci.sh tolerates missing parallel for older images,
 # but baking it in keeps the fast CI loop fast.
-# git + ca-certificates (#168): the test suite (upgrade_spec.bats,
-# init_new_repo_spec.bats, fresh_clone_portability_spec.bats) builds fake
-# subtree repos with `git -C <dir> init/commit` and a few specs do
-# `git clone` over HTTPS — both need git on PATH and ca-certificates
-# for TLS verification.
+# git + git-subtree + ca-certificates (#168): the test suite
+# (upgrade_spec.bats, init_new_repo_spec.bats,
+# fresh_clone_portability_spec.bats) builds fake subtree repos with
+# `git -C <dir> init/commit` and exercises `git subtree pull/add` paths
+# end-to-end. On debian `git-subtree` is bundled in the `git` package;
+# alpine ships it as a separate `git-subtree` package. ca-certificates
+# is needed by the few specs that hit GitHub over HTTPS.
 # grep + coreutils (#168): downstream scripts and several specs rely
 # on GNU-only flags (`grep -P` for PCRE, GNU-format `sha256sum` output)
 # that busybox's defaults do not provide. Installing the GNU packages
@@ -62,7 +64,7 @@ RUN apk add --no-cache curl xz && \
 # helpers behave the same on alpine as on the previous kcov/kcov
 # (debian) runner.
 FROM alpine:latest
-RUN apk add --no-cache bash parallel git ca-certificates grep coreutils
+RUN apk add --no-cache bash parallel git git-subtree ca-certificates grep coreutils
 COPY --from=bats-src /opt/bats /opt/bats
 COPY --from=bats-src /usr/lib/bats /usr/lib/bats
 COPY --from=bats-extensions /bats /usr/lib/bats

--- a/dockerfile/Dockerfile.test-tools
+++ b/dockerfile/Dockerfile.test-tools
@@ -41,13 +41,28 @@ RUN apk add --no-cache curl xz && \
         "https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-${hd_arch}" && \
     chmod +x /usr/local/bin/hadolint
 
-# Final stage: bash + bats + shellcheck + hadolint + bats-{support,assert,mock}.
+# Final stage: bash + bats + shellcheck + hadolint + bats-{support,assert,mock}
+# + parallel + git + ca-certificates.
 # bash is required because /opt/bats/bin/bats is a `#!/usr/bin/env bash` script
 # and alpine:latest only ships busybox ash. The /usr/local/bin/bats symlink
 # exposes bats on PATH (the upstream bats/bats:latest puts it there but the
 # symlink is not under /opt/bats so it is not picked up by the COPY above).
+# parallel (#168): bats --jobs N delegates to GNU parallel; without it bats
+# falls back to serial. ci.sh tolerates missing parallel for older images,
+# but baking it in keeps the fast CI loop fast.
+# git + ca-certificates (#168): the test suite (upgrade_spec.bats,
+# init_new_repo_spec.bats, fresh_clone_portability_spec.bats) builds fake
+# subtree repos with `git -C <dir> init/commit` and a few specs do
+# `git clone` over HTTPS — both need git on PATH and ca-certificates
+# for TLS verification.
+# grep + coreutils (#168): downstream scripts and several specs rely
+# on GNU-only flags (`grep -P` for PCRE, GNU-format `sha256sum` output)
+# that busybox's defaults do not provide. Installing the GNU packages
+# overrides busybox's symlinks so init.sh / setup.sh / setup_drift
+# helpers behave the same on alpine as on the previous kcov/kcov
+# (debian) runner.
 FROM alpine:latest
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash parallel git ca-certificates grep coreutils
 COPY --from=bats-src /opt/bats /opt/bats
 COPY --from=bats-src /usr/lib/bats /usr/lib/bats
 COPY --from=bats-extensions /bats /usr/lib/bats

--- a/script/ci/ci.sh
+++ b/script/ci/ci.sh
@@ -111,12 +111,24 @@ _run_tests() {
   # across files and within files by default. All specs use per-test
   # mktemp dirs (BATS_TEST_TMPDIR / TEMP_DIR) so there's no shared
   # filesystem state between tests — safe to run concurrently.
-  local _jobs
-  _jobs="$(nproc 2>/dev/null || echo 4)"
-  echo "--- Running Bats Unit Tests (jobs=${_jobs}) ---"
-  bats --jobs "${_jobs}" "${REPO_ROOT}/test/unit/"
-  echo "--- Running Bats Integration Tests (jobs=${_jobs}) ---"
-  bats --jobs "${_jobs}" "${REPO_ROOT}/test/integration/"
+  #
+  # When parallel is missing (e.g. earlier alpine test-tools images
+  # before #168's parallel addition), fall back to serial bats so the
+  # suite still runs — slower but correct.
+  local -a _bats_args=()
+  local _label
+  if command -v parallel >/dev/null 2>&1; then
+    local _jobs
+    _jobs="$(nproc 2>/dev/null || echo 4)"
+    _bats_args=(--jobs "${_jobs}")
+    _label="jobs=${_jobs}"
+  else
+    _label="serial; parallel not in PATH"
+  fi
+  echo "--- Running Bats Unit Tests (${_label}) ---"
+  bats "${_bats_args[@]}" "${REPO_ROOT}/test/unit/"
+  echo "--- Running Bats Integration Tests (${_label}) ---"
+  bats "${_bats_args[@]}" "${REPO_ROOT}/test/integration/"
 }
 
 # ── Kcov coverage ────────────────────────────────────────────────────────────
@@ -156,12 +168,18 @@ _fix_permissions() {
 # ── Docker compose wrapper ───────────────────────────────────────────────────
 
 _run_via_compose() {
-  local _coverage="${1:-0}"
+  # Service is the first arg so the caller picks the runner image:
+  #   `ci`       — alpine test-tools (bats/shellcheck/hadolint baked in,
+  #                no apt-install on each run; fast dev loop)
+  #   `coverage` — kcov/kcov (debian; needs apt-install via _install_deps,
+  #                opt-in APT_MIRROR_DEBIAN rewrite for unreachable mirrors)
+  local _service="${1:-ci}"
+  local _coverage="${2:-0}"
   docker compose -f "${REPO_ROOT}/compose.yaml" run --rm \
     -e HOST_UID="$(id -u)" \
     -e HOST_GID="$(id -g)" \
     -e COVERAGE="${_coverage}" \
-    ci
+    "${_service}"
 }
 
 # ── Main ─────────────────────────────────────────────────────────────────────
@@ -199,12 +217,13 @@ main() {
       _run_shellcheck
       ;;
     coverage)
-      # Full CI + kcov via docker compose
-      _run_via_compose 1
+      # Full CI + kcov via the kcov/kcov-based `coverage` service.
+      _run_via_compose coverage 1
       ;;
     compose)
-      # Default: fast CI (shellcheck + bats, no kcov) via docker compose
-      _run_via_compose 0
+      # Default: fast CI (shellcheck + bats, no kcov) via the alpine
+      # test-tools-based `ci` service.
+      _run_via_compose ci 0
       ;;
   esac
 }

--- a/test/unit/ci_spec.bats
+++ b/test/unit/ci_spec.bats
@@ -99,6 +99,16 @@ teardown() {
 
 @test "_install_deps: rewrites sources.list when APT_MIRROR_DEBIAN differs from default" {
   local _log="${BATS_TEST_TMPDIR}/sed.log"
+  # _install_deps gates the sed branch on `[[ -f /etc/apt/sources.list ]]`,
+  # which is true on the previous kcov/kcov debian runner but FALSE on the
+  # alpine test-tools image (no /etc/apt). Materialise the file once if
+  # missing so this regression test is image-agnostic — the goal here is
+  # to verify the sed substitution logic, not the file-existence guard
+  # (the unset/default tests below already cover the no-op branch).
+  if [[ ! -f /etc/apt/sources.list ]]; then
+    mkdir -p /etc/apt
+    : > /etc/apt/sources.list
+  fi
   mock_cmd "sed" '
     printf "%s\n" "$*" >> "'"${_log}"'"
     exit 0'
@@ -217,4 +227,138 @@ teardown() {
     _run_shellcheck
   '
   assert_failure
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _run_via_compose / main routing
+#
+# Regression guards for #168: default `ci.sh` (no flag) must hit the
+# alpine `ci` service so the apt-install path is bypassed; `--coverage`
+# must hit the kcov/kcov-based `coverage` service. Mock `docker` so
+# the test captures the chosen service name + COVERAGE env without
+# actually running compose.
+# ════════════════════════════════════════════════════════════════════
+
+@test "_run_via_compose: routes default mode to the ci service with COVERAGE=0" {
+  local _log="${BATS_TEST_TMPDIR}/docker.log"
+  mock_cmd "docker" '
+    printf "%s\n" "$*" >> "'"${_log}"'"
+    exit 0'
+  mock_cmd "id" 'echo 1000'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    _run_via_compose ci 0
+  '
+  assert_success
+
+  run cat "${_log}"
+  assert_success
+  assert_output --partial "compose"
+  assert_output --partial "COVERAGE=0"
+  assert_output --partial " ci"
+  refute_output --partial "COVERAGE=1"
+}
+
+@test "_run_via_compose: routes coverage mode to the coverage service with COVERAGE=1" {
+  local _log="${BATS_TEST_TMPDIR}/docker.log"
+  mock_cmd "docker" '
+    printf "%s\n" "$*" >> "'"${_log}"'"
+    exit 0'
+  mock_cmd "id" 'echo 1000'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    _run_via_compose coverage 1
+  '
+  assert_success
+
+  run cat "${_log}"
+  assert_success
+  assert_output --partial "compose"
+  assert_output --partial "COVERAGE=1"
+  assert_output --partial " coverage"
+}
+
+@test "main: dispatches no-flag default to the ci service" {
+  local _log="${BATS_TEST_TMPDIR}/docker.log"
+  mock_cmd "docker" '
+    printf "%s\n" "$*" >> "'"${_log}"'"
+    exit 0'
+  mock_cmd "id" 'echo 1000'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    main
+  '
+  assert_success
+
+  run cat "${_log}"
+  assert_success
+  assert_output --partial " ci"
+  assert_output --partial "COVERAGE=0"
+}
+
+@test "_run_tests: passes --jobs N when parallel is on PATH" {
+  local _log="${BATS_TEST_TMPDIR}/bats.log"
+  mock_cmd "parallel" 'exit 0'
+  mock_cmd "nproc" 'echo 8'
+  mock_cmd "bats" '
+    printf "%s\n" "$*" >> "'"${_log}"'"
+    exit 0'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    _run_tests
+  '
+  assert_success
+
+  run cat "${_log}"
+  assert_success
+  assert_output --partial "--jobs 8"
+}
+
+@test "_run_tests: omits --jobs when parallel is absent (graceful fallback)" {
+  local _log="${BATS_TEST_TMPDIR}/bats.log"
+  # Intentionally NOT mocking `parallel` so command -v misses.
+  mock_cmd "bats" '
+    printf "%s\n" "$*" >> "'"${_log}"'"
+    exit 0'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    _run_tests
+  '
+  assert_success
+  assert_output --partial "serial"
+  assert_output --partial "parallel not in PATH"
+
+  run cat "${_log}"
+  assert_success
+  refute_output --partial "--jobs"
+}
+
+@test "main: dispatches --coverage to the coverage service" {
+  local _log="${BATS_TEST_TMPDIR}/docker.log"
+  mock_cmd "docker" '
+    printf "%s\n" "$*" >> "'"${_log}"'"
+    exit 0'
+  mock_cmd "id" 'echo 1000'
+
+  run bash -c '
+    source /source/script/ci/ci.sh
+    export PATH="'"${MOCK_DIR}"'"
+    main --coverage
+  '
+  assert_success
+
+  run cat "${_log}"
+  assert_success
+  assert_output --partial " coverage"
+  assert_output --partial "COVERAGE=1"
 }


### PR DESCRIPTION
## Summary

Closes #168 — switches the template's fast CI compose service from
`kcov/kcov` (debian, apt-install on every run) to the prebuilt
`ghcr.io/ycpss91255-docker/test-tools:latest` (alpine, all deps baked
in). `_install_deps` short-circuits via its `command -v bats` guard,
so `make -f Makefile.ci test` no longer pays the per-run apt-install
cost (and no longer hard-fails when the host network can't reach the
configured Debian mirror).

The `coverage` path stays on kcov/kcov (kcov isn't in the alpine
image; building it from source would balloon size and pull deps
unrelated to fast CI). v0.12.2's `APT_MIRROR_DEBIAN` plumbing is
preserved on the coverage service.

## Changes

### compose.yaml — split `ci` / `coverage` services

```yaml
ci:
  image: ${TEST_TOOLS_IMAGE:-ghcr.io/ycpss91255-docker/test-tools:latest}
  ...
coverage:
  image: kcov/kcov
  environment:
    - APT_MIRROR_DEBIAN=${APT_MIRROR_DEBIAN:-deb.debian.org}
  ...
```

`TEST_TOOLS_IMAGE` lets local rebuild flows pin to `test-tools:local`
without editing compose.

### `ci.sh` — service routing + parallel fallback

- `_run_via_compose <service> <coverage>` takes the service name; `main()`
  picks `ci` for default, `coverage` for `--coverage`.
- `_run_tests` falls back to serial bats when `parallel` is missing, so
  third-party runners or older test-tools images (`< v0.12.3`) still
  execute the suite — slower, but correct.

### `Dockerfile.test-tools` — fill the gaps for alpine `ci` service

The previous published image was the bare minimum to run `bats --version`
(after #165). Now it has to be a self-sufficient CI runtime, so this PR
adds: `parallel`, `git`, `ca-certificates`, `grep`, `coreutils`. The
last two override busybox so `grep -P` (used by `_detect_template_version`)
and GNU-format `sha256sum` output (used by `_check_setup_drift`)
behave the same on alpine as they did on the previous kcov/kcov runner.

### `self-test.yaml` — build test-tools:local on every PR

```yaml
- run: docker build -t test-tools:local -f dockerfile/Dockerfile.test-tools .
- env: { TEST_TOOLS_IMAGE: test-tools:local }
  run: ./script/ci/ci.sh
```

Without this, every PR that touches `Dockerfile.test-tools` self-tests
against the previously published `:latest` (chicken-and-egg with
release-test-tools.yaml, which only fires on tag push). Now PRs validate
their own image changes end-to-end.

### `release-test-tools.yaml` — smoke step extended

Already verifies `bats / shellcheck / hadolint --version` post-publish
(landed in v0.12.2). Adds `parallel --version` and `git --version` so a
future Dockerfile rebase that drops one of the new deps can't ship
silently.

## Tests

6 new unit tests:

- `_run_via_compose: routes default mode to the ci service with COVERAGE=0`
- `_run_via_compose: routes coverage mode to the coverage service with COVERAGE=1`
- `main: dispatches no-flag default to the ci service`
- `main: dispatches --coverage to the coverage service`
- `_run_tests: passes --jobs N when parallel is on PATH`
- `_run_tests: omits --jobs when parallel is absent (graceful fallback)`

Plus an image-agnostic fix to the existing `APT_MIRROR_DEBIAN` sed
test (materialises `/etc/apt/sources.list` when the runner image
lacks one — the previous kcov/kcov-based test relied on debian's
default).

787 → 793 tests; ci_spec.bats 11 → 17. TEST.md + CHANGELOG synced.

## Verification path

I could not run the full Docker test suite locally — `apk add` build-time
TLS to `dl-cdn.alpinelinux.org` is currently unreliable from this host,
so `docker build -t test-tools:local` for the new Dockerfile fails. The
PR's self-test workflow runs on a GitHub-hosted runner where the alpine
CDN is reachable; relying on that as the source of truth for the alpine
compat fixes (busybox → GNU grep / coreutils overrides). If self-test
finds additional alpine-vs-debian regressions, follow-up commits will
patch them — the architecture (compose split + service routing + serial
fallback) is the load-bearing piece and is independent of which alpine
packages get added.

## Test plan

- [ ] PR `test` job (self-test.yaml) builds test-tools:local and the
      793-test suite passes against the alpine image
- [ ] `integration-e2e` job still passes (uses the build-worker flow,
      independent of compose.yaml)
- [ ] After merge + tag v0.12.3: release-test-tools.yaml's extended smoke
      step verifies parallel + git in the published image; downstream
      consumers running v0.12.3+ template subtree get the speedup for
      free on their next CI run.

## Out of scope

- Removing the `coverage` service in favour of an all-in-one image
  with kcov baked in. kcov source-build is heavy; keeping the
  coverage path on `kcov/kcov` is intentional.
- Any downstream-repo template-tag bumps. v0.12.3's value to downstream
  consumers is "test-tools image is now self-sufficient" — a
  `batch-template-upgrade` pass can ride along the next round of
  downstream work.

