### PR TITLE
fix(workflows): smoke step uses git --exec-path instead of git subtree --help

### DIFF
--- a/.github/workflows/release-test-tools.yaml
+++ b/.github/workflows/release-test-tools.yaml
@@ -88,4 +88,9 @@ jobs:
           docker run --rm "${image}" hadolint --version
           docker run --rm "${image}" parallel --version
           docker run --rm "${image}" git --version
-          docker run --rm "${image}" git subtree --help >/dev/null  # presence check (no --version flag)
+          # `git subtree --help` would invoke `man git-subtree`, but alpine
+          # ships no man viewer in the test-tools image (and we don't want
+          # to install one just for this smoke check). Confirm the binary
+          # exists at git's exec-path instead — same regression-detection
+          # value, no man dependency.
+          docker run --rm "${image}" sh -c 'test -f "$(git --exec-path)/git-subtree"'


### PR DESCRIPTION
## Summary

Tag `v0.12.3`'s release-test-tools workflow build-and-pushed the
test-tools image successfully (so `ghcr.io/.../test-tools:latest` and
`:v0.12.3` are live and usable for downstream consumers), but the
post-publish smoke step exited 128 with:

```
warning: failed to exec 'man': No such file or directory
fatal: no man viewer handled the request
```

`git subtree --help` invokes `man git-subtree`. Alpine test-tools
ships no man viewer (and shouldn't — installing one just for this
smoke check would bloat the image with no other gain).

## Fix

Replace the man-dependent invocation with a file-presence check at
git's exec-path:

```yaml
docker run --rm "${image}" sh -c 'test -f "$(git --exec-path)/git-subtree"'
```

Same regression value (catches any future rebase that drops
`git-subtree` package), no man dependency.

## Verification

- The image build + push step is BEFORE the smoke step in
  release-test-tools.yaml, so v0.12.3's image is already on ghcr and
  unaffected by this patch.
- This workflow only fires on `v*` tag push, so the integration test
  for the smoke step itself is necessarily tag-deferred. The next
  patch tag (v0.12.4 or later) will exercise the new logic naturally.

## Test plan

- [x] Static review: `git --exec-path` exits 0 in the test-tools image;
      `test -f "$(...)/git-subtree"` is busybox-`test` compatible
- [ ] Next tag's release-test-tools workflow run shows the smoke step
      green
