### PR TITLE
feat(init/upgrade): sync canonical .gitignore + untrack tracked-but-derived files

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`.gitignore` is now template-managed** (#172). Two new helpers in `template/script/docker/lib/gitignore.sh` — `_sync_gitignore <path>` (append-missing strategy: idempotent, preserves user-defined lines, leaves a `# managed by template (do not remove)` marker on first sync) and `_untrack_canonical_in_repo <repo>` (`git rm --cached` for any canonical entry that's still git-tracked) — wire into both `init.sh` paths and propagate through `upgrade.sh`. Canonical set: `.env`, `.env.bak`, `compose.yaml`, `setup.conf.bak`, `coverage/`, `.Dockerfile.generated`. Future derived artifacts get appended to the lib in a later release and downstream repos pick them up automatically on the next `make upgrade`. The wiring also heals the v0.9.0+ drift where 15/17 downstream repos still git-tracked `compose.yaml` despite it being a derived artifact: the next batch-upgrade emits the `git rm --cached` in the same commit as the workflow `@tag` rewrite, with no separate sweep PR.
+
 ## [v0.12.3] - 2026-04-28
 
 Patch release that completes the test-tools migration started in v0.12.2 (#165 + #164) and fixes a bash 5.3 silent-exit bug in `upgrade.sh --check` exposed by the alpine runner. No breaking changes from v0.12.2.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **795 tests** total (751 unit + 44 integration).
+Template self-tests: **818 tests** total (767 unit + 51 integration).
 
 ## Test Files
 
@@ -543,6 +543,30 @@ must not be reported as "needing downgrade").
 | `_get_latest_version: empty result feeds _check's 'Could not fetch' guard` | Empty result still surfaces real fetch failures |
 | `_upgrade refuses to downgrade from a newer local version` | Implicit-downgrade guard |
 
+### test/unit/gitignore_spec.bats (16)
+
+Unit tests for `template/script/docker/lib/gitignore.sh` — the canonical
+`.gitignore` set + sync/untrack helpers introduced for issue #172.
+
+| Test | Description |
+|------|-------------|
+| `_canonical_gitignore_entries: emits exactly the 6 canonical lines` | Single source of truth |
+| `_canonical_gitignore_entries: list is stable order` | Deterministic output |
+| `_sync_gitignore: creates the file when missing, with marker block + all entries` | Greenfield |
+| `_sync_gitignore: empty file gets marker block + all entries appended` | Empty file |
+| `_sync_gitignore: file with all entries already present is a no-op` | Already-synced |
+| `_sync_gitignore: appends only missing entries when subset already present` | Drift fill-in |
+| `_sync_gitignore: preserves user-defined lines (bridge.yaml, .env.gpg, .claude/)` | User-line preservation |
+| `_sync_gitignore: idempotent — second invocation produces no further changes` | Idempotency |
+| `_sync_gitignore: no duplicate canonical lines after re-run` | No-dup invariant |
+| `_sync_gitignore: ends with newline so future appends start on their own line` | Trailing-newline guarantee |
+| `_untrack_canonical_in_repo: git rm --cached for tracked compose.yaml` | 15-repo drift fix |
+| `_untrack_canonical_in_repo: leaves untracked files alone` | Scope guard |
+| `_untrack_canonical_in_repo: no-op when no canonical files tracked` | Healthy-repo no-op |
+| `_untrack_canonical_in_repo: handles tracked coverage/ directory` | Directory entry |
+| `_untrack_canonical_in_repo: idempotent — second run succeeds without error` | Re-run safety |
+| `_untrack_canonical_in_repo: untracks all canonical entries that match` | Multi-entry sweep |
+
 ### test/integration/init_new_repo_spec.bats (36)
 
 End-to-end verification that `init.sh` produces a complete repo skeleton in
@@ -614,3 +638,21 @@ after the Jetson v0.9.7 incident (stubs `git-subtree pull` via
 | `upgrade.sh fails fast when git identity is missing` | Pre-flight identity guard |
 | `upgrade.sh fails fast when MERGE_HEAD is present` | Pre-flight merge-state guard |
 | `upgrade.sh rolls back when git-subtree does a destructive fast-forward` | Destructive-FF rollback |
+
+### test/integration/gitignore_sync_spec.bats (7)
+
+End-to-end coverage that wires `lib/gitignore.sh` through `init.sh`'s
+new-repo + existing-repo paths and `upgrade.sh`'s commit step. Standalone
+fixture (independent of `upgrade_spec.bats`'s stub-init fixture) because
+gitignore sync requires the **real** `init.sh` to run during Step 3 of
+`upgrade.sh`. Issue #172.
+
+| Test | Description |
+|------|-------------|
+| `init.sh new-repo: .gitignore contains all 6 canonical entries` | New-repo path uses lib |
+| `init.sh new-repo: .gitignore has the 'managed by template' marker` | Marker comment present |
+| `init.sh existing-repo: appends missing canonical entries to user .gitignore` | Drift fill-in |
+| `init.sh existing-repo: untracks compose.yaml that was committed` | 15-repo drift heal |
+| `init.sh existing-repo: idempotent — second run produces no .gitignore changes` | Re-run no-op |
+| `upgrade.sh end-to-end: synced .gitignore + untracked compose.yaml in single commit` | One-shot upgrade |
+| `upgrade.sh end-to-end: idempotent on a second run — no extra commits` | Re-upgrade clean |

--- a/init.sh
+++ b/init.sh
@@ -28,6 +28,9 @@ readonly REPO_ROOT
 TEMPLATE_REL="template"
 readonly TEMPLATE_REL
 
+# shellcheck disable=SC1091
+source "${TEMPLATE_DIR}/script/docker/lib/gitignore.sh"
+
 _log() { printf "[init] %s\n" "$*"; }
 
 # ── Symlink helper ──────────────────────────────────────────────────────────
@@ -210,17 +213,10 @@ jobs:
 YAML
   _log "  Created .github/workflows/main.yaml"
 
-  # .gitignore (compose.yaml + .env are setup.sh-generated artifacts;
-  # *.bak siblings are written by `./template/init.sh --gen-conf --force`
-  # on a reset-conf, see #124 / issue #60 — keep them local-only.)
-  cat > .gitignore <<'GIT'
-.env
-.env.bak
-compose.yaml
-setup.conf.bak
-coverage/
-.Dockerfile.generated
-GIT
+  # .gitignore: source canonical set from lib/gitignore.sh so future
+  # template-added derived artifacts propagate via the existing-repo
+  # sync path on next upgrade (#172).
+  _sync_gitignore "${REPO_ROOT}/.gitignore"
   _log "  Created .gitignore"
 
   # doc/
@@ -279,6 +275,17 @@ MD
 _init_existing_repo() {
   _log "Existing repo detected (Dockerfile found)"
   _create_symlinks
+  _sync_existing_gitignore
+}
+
+# _sync_existing_gitignore
+#   On existing-repo init / upgrade, append any canonical entries the
+#   user's .gitignore is missing AND `git rm --cached` any tracked
+#   files that have since become derived artifacts. Heals the 15-repo
+#   drift documented in #172 in one shot — no separate sweep PR needed.
+_sync_existing_gitignore() {
+  _sync_gitignore "${REPO_ROOT}/.gitignore"
+  _untrack_canonical_in_repo "${REPO_ROOT}"
 }
 
 # ── Generate per-repo setup.conf ────────────────────────────────────────────

--- a/script/docker/lib/gitignore.sh
+++ b/script/docker/lib/gitignore.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# lib/gitignore.sh - Canonical .gitignore entries + sync/untrack helpers.
+#
+# Issue #172: every release cycle adds new derived artifacts (compose.yaml,
+# .env.bak, coverage/, ...). Without sync, downstream repos accumulate
+# drift and end up tracking files they shouldn't. This lib is the single
+# source of truth, sourced by init.sh (new-repo + existing-repo paths)
+# and consumed indirectly by upgrade.sh through init.sh.
+
+# _canonical_gitignore_entries
+#   Print the canonical .gitignore set, one entry per line. Order is
+#   stable so consumers can diff outputs across versions.
+#
+#   Add new entries here when the template introduces another derived
+#   artifact, then bump the next release. Downstreams pick it up via
+#   `make upgrade` -> ./template/upgrade.sh -> init.sh resync chain.
+_canonical_gitignore_entries() {
+  cat <<'EOF'
+.env
+.env.bak
+compose.yaml
+setup.conf.bak
+coverage/
+.Dockerfile.generated
+EOF
+}
+
+# _sync_gitignore <path>
+#   Append canonical entries that are missing from <path>, preserving
+#   user-defined lines and any pre-existing canonical lines (no
+#   duplicates, no reordering, no removals).
+#
+#   On first sync of a fresh repo the appended block is preceded by a
+#   `# managed by template (do not remove)` comment so future readers
+#   know not to delete the entries. The comment is only added once;
+#   subsequent syncs that need to add a new entry append it without a
+#   second comment.
+#
+#   Idempotent: running twice in a row never modifies the file the
+#   second time.
+_sync_gitignore() {
+  local _path="$1"
+  local -a _missing=()
+  local _entry
+
+  while IFS= read -r _entry; do
+    [[ -z "${_entry}" ]] && continue
+    if [[ ! -f "${_path}" ]] || ! grep -qxF "${_entry}" "${_path}"; then
+      _missing+=("${_entry}")
+    fi
+  done < <(_canonical_gitignore_entries)
+
+  if (( ${#_missing[@]} == 0 )); then
+    return 0
+  fi
+
+  if [[ ! -f "${_path}" ]]; then
+    : > "${_path}"
+  fi
+
+  # Ensure file ends with newline so the appended entries don't get
+  # concatenated onto the user's last line. Skip on empty file (nothing
+  # to terminate).
+  if [[ -s "${_path}" ]]; then
+    local _last
+    _last="$(tail -c 1 -- "${_path}")"
+    if [[ "${_last}" != $'\n' ]]; then
+      printf '\n' >> "${_path}"
+    fi
+  fi
+
+  # Marker comment added only if absent — keeps re-syncs from stacking
+  # comments on every release.
+  if ! grep -q '^# managed by template' "${_path}"; then
+    printf '# managed by template (do not remove)\n' >> "${_path}"
+  fi
+
+  printf '%s\n' "${_missing[@]}" >> "${_path}"
+}
+
+# _untrack_canonical_in_repo <repo_root>
+#   For each canonical entry that's still git-tracked under <repo_root>,
+#   run `git rm --cached`. Working tree is preserved — the file just
+#   stops being tracked, so the next commit drops it from history's
+#   active set and `setup.sh`'s regen no longer pollutes `git status`.
+#
+#   Heals the 15-repo drift documented in #172 (compose.yaml tracked
+#   despite being a v0.9.0+ derived artifact) without requiring a
+#   separate per-repo PR.
+#
+#   No-op when:
+#     - <repo_root> is not a git repo
+#     - no canonical entry matches a tracked path
+#   Idempotent: re-running after the entries are gone is silent.
+_untrack_canonical_in_repo() {
+  local _repo="$1"
+  if ! git -C "${_repo}" rev-parse --git-dir >/dev/null 2>&1; then
+    return 0
+  fi
+  local _entry _path
+  while IFS= read -r _entry; do
+    [[ -z "${_entry}" ]] && continue
+    _path="${_entry%/}"
+    # ls-files emits matching tracked paths; empty output means nothing
+    # to untrack. -z guard avoids running `git rm` on empty pathspec.
+    if [[ -n "$(git -C "${_repo}" ls-files -- "${_path}" 2>/dev/null)" ]]; then
+      git -C "${_repo}" rm --cached -r --quiet -- "${_path}" >/dev/null 2>&1 || true
+    fi
+  done < <(_canonical_gitignore_entries)
+}

--- a/test/integration/gitignore_sync_spec.bats
+++ b/test/integration/gitignore_sync_spec.bats
@@ -1,0 +1,239 @@
+#!/usr/bin/env bats
+#
+# Integration: .gitignore sync via init.sh (new + existing) and upgrade.sh.
+#
+# Issue #172. The lib functions are unit-tested in test/unit/gitignore_spec.bats;
+# this spec wires them through the user-facing entry points and proves
+# the v0.12.x → v0.12.4 batch upgrade will heal the 15-repo
+# tracked-compose.yaml drift in one shot, no separate sweep required.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/../unit/test_helper"
+
+  TMP_ROOT="$(mktemp -d)"
+  REPO_DIR="${TMP_ROOT}/myrepo"
+  mkdir -p "${REPO_DIR}/template"
+  cp -a /source/. "${REPO_DIR}/template/"
+  cd "${REPO_DIR}"
+}
+
+teardown() {
+  rm -rf "${TMP_ROOT}"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# init.sh new-repo path: .gitignore is created via lib (single source)
+# ════════════════════════════════════════════════════════════════════
+
+@test "init.sh new-repo: .gitignore contains all 6 canonical entries" {
+  bash template/init.sh
+  local _entry
+  for _entry in .env .env.bak compose.yaml setup.conf.bak coverage/ .Dockerfile.generated; do
+    run grep -xF "${_entry}" "${REPO_DIR}/.gitignore"
+    assert_success
+  done
+}
+
+@test "init.sh new-repo: .gitignore has the 'managed by template' marker" {
+  bash template/init.sh
+  run grep -F 'managed by template' "${REPO_DIR}/.gitignore"
+  assert_success
+}
+
+# ════════════════════════════════════════════════════════════════════
+# init.sh existing-repo path: sync + untrack the 15-repo drift case
+# ════════════════════════════════════════════════════════════════════
+
+_seed_existing_repo() {
+  # Mirror the v0.12.1-era 15-repo state: Dockerfile present (so init.sh
+  # takes the existing-repo path), partial canonical .gitignore (`.env`
+  # only) plus a user-defined entry, compose.yaml committed.
+  echo "FROM alpine" > "${REPO_DIR}/Dockerfile"
+  git -C "${REPO_DIR}" init -q -b main
+  git -C "${REPO_DIR}" config user.email t@t
+  git -C "${REPO_DIR}" config user.name t
+  cat > "${REPO_DIR}/.gitignore" <<'EOF'
+.env
+.claude/
+EOF
+  echo "services: {}" > "${REPO_DIR}/compose.yaml"
+  git -C "${REPO_DIR}" add -A
+  git -C "${REPO_DIR}" commit -q -m "init"
+}
+
+@test "init.sh existing-repo: appends missing canonical entries to user .gitignore" {
+  _seed_existing_repo
+  bash template/init.sh
+
+  # User entry preserved verbatim
+  run grep -xF '.claude/' "${REPO_DIR}/.gitignore"
+  assert_success
+  # Pre-existing canonical entry preserved (no duplicate)
+  run grep -c '^\.env$' "${REPO_DIR}/.gitignore"
+  assert_output "1"
+  # All previously-missing canonical entries now present
+  run grep -xF 'compose.yaml' "${REPO_DIR}/.gitignore"
+  assert_success
+  run grep -xF '.env.bak' "${REPO_DIR}/.gitignore"
+  assert_success
+  run grep -xF 'setup.conf.bak' "${REPO_DIR}/.gitignore"
+  assert_success
+  run grep -xF 'coverage/' "${REPO_DIR}/.gitignore"
+  assert_success
+  run grep -xF '.Dockerfile.generated' "${REPO_DIR}/.gitignore"
+  assert_success
+}
+
+@test "init.sh existing-repo: untracks compose.yaml that was committed" {
+  _seed_existing_repo
+  # Sanity: compose.yaml is tracked before init.sh runs
+  run git -C "${REPO_DIR}" ls-files compose.yaml
+  assert_output "compose.yaml"
+
+  bash template/init.sh
+
+  # No longer in index
+  run git -C "${REPO_DIR}" ls-files compose.yaml
+  assert_output ""
+  # Still on disk — user's working copy untouched
+  [[ -f "${REPO_DIR}/compose.yaml" ]]
+}
+
+@test "init.sh existing-repo: idempotent — second run produces no .gitignore changes" {
+  _seed_existing_repo
+  bash template/init.sh
+  local _first
+  _first="$(cat "${REPO_DIR}/.gitignore")"
+
+  bash template/init.sh
+  local _second
+  _second="$(cat "${REPO_DIR}/.gitignore")"
+
+  assert_equal "${_second}" "${_first}"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# upgrade.sh end-to-end: subtree pull → init.sh sync → single commit
+# ════════════════════════════════════════════════════════════════════
+#
+# Standalone fixture (independent of upgrade_spec.bats's stub-init fixture)
+# because gitignore sync requires the REAL init.sh to run during Step 3.
+
+_seed_upgrade_fixture() {
+  TMPL_WORK="${BATS_TEST_TMPDIR}/template_work"
+  TMPL_BARE="${BATS_TEST_TMPDIR}/template.git"
+  DOWN_DIR="${BATS_TEST_TMPDIR}/downstream"
+
+  # Build a "template" snapshot containing the real init.sh + lib + a
+  # passthrough setup.sh stub.
+  mkdir -p "${TMPL_WORK}/script/docker/lib"
+  echo "v9.0.0" > "${TMPL_WORK}/.version"
+  cp /source/init.sh "${TMPL_WORK}/init.sh"
+  cp /source/upgrade.sh "${TMPL_WORK}/upgrade.sh"
+  cp /source/script/docker/lib/gitignore.sh "${TMPL_WORK}/script/docker/lib/gitignore.sh"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "${TMPL_WORK}/script/docker/setup.sh"
+  # _create_symlinks references these paths; empty stubs keep ln -sf happy.
+  for _f in build.sh run.sh exec.sh stop.sh setup_tui.sh Makefile; do
+    : > "${TMPL_WORK}/script/docker/${_f}"
+  done
+  : > "${TMPL_WORK}/.hadolint.yaml"
+  chmod +x "${TMPL_WORK}/init.sh" "${TMPL_WORK}/upgrade.sh" \
+           "${TMPL_WORK}/script/docker/setup.sh"
+
+  git -C "${TMPL_WORK}" init -q -b main
+  git -C "${TMPL_WORK}" config user.email t@t
+  git -C "${TMPL_WORK}" config user.name t
+  git -C "${TMPL_WORK}" add -A
+  git -C "${TMPL_WORK}" commit -q -m "v9.0.0"
+  git -C "${TMPL_WORK}" tag v9.0.0
+
+  # Bump to v9.0.1 (no real change beyond the version file — sufficient
+  # to drive an upgrade run).
+  echo "v9.0.1" > "${TMPL_WORK}/.version"
+  git -C "${TMPL_WORK}" add -A
+  git -C "${TMPL_WORK}" commit -q -m "v9.0.1"
+  git -C "${TMPL_WORK}" tag v9.0.1
+
+  git init --bare -q "${TMPL_BARE}"
+  git -C "${TMPL_WORK}" push -q "${TMPL_BARE}" v9.0.0 v9.0.1 main
+
+  # Downstream consumer: Dockerfile (so init.sh existing-repo path
+  # fires), partial .gitignore, tracked compose.yaml, main.yaml with
+  # @v9.0.0 references for the @tag rewrite step.
+  mkdir -p "${DOWN_DIR}/.github/workflows"
+  git -C "${DOWN_DIR}" init -q -b main
+  git -C "${DOWN_DIR}" config user.email t@t
+  git -C "${DOWN_DIR}" config user.name t
+  echo "FROM alpine" > "${DOWN_DIR}/Dockerfile"
+  echo "services: {}" > "${DOWN_DIR}/compose.yaml"
+  cat > "${DOWN_DIR}/.gitignore" <<'EOF'
+.env
+.claude/
+EOF
+  cat > "${DOWN_DIR}/.github/workflows/main.yaml" <<'YAML'
+jobs:
+  build:
+    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v9.0.0
+  release:
+    uses: ycpss91255-docker/template/.github/workflows/release-worker.yaml@v9.0.0
+YAML
+  git -C "${DOWN_DIR}" add -A
+  git -C "${DOWN_DIR}" commit -q -m "initial"
+
+  git -C "${DOWN_DIR}" subtree add -q --prefix=template \
+    "file://${TMPL_BARE}" v9.0.0 --squash
+}
+
+@test "upgrade.sh end-to-end: synced .gitignore + untracked compose.yaml in single commit" {
+  _seed_upgrade_fixture
+  cd "${DOWN_DIR}"
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" \
+      ./template/upgrade.sh v9.0.1
+  assert_success
+  assert_output --partial "Done! Upgraded to v9.0.1"
+
+  # .gitignore now contains all canonical entries
+  run grep -xF 'compose.yaml' "${DOWN_DIR}/.gitignore"
+  assert_success
+  run grep -xF '.env.bak' "${DOWN_DIR}/.gitignore"
+  assert_success
+  run grep -xF 'coverage/' "${DOWN_DIR}/.gitignore"
+  assert_success
+  # User .claude/ line preserved
+  run grep -xF '.claude/' "${DOWN_DIR}/.gitignore"
+  assert_success
+  # compose.yaml untracked from index, file still on disk
+  run git -C "${DOWN_DIR}" ls-files compose.yaml
+  assert_output ""
+  [[ -f "${DOWN_DIR}/compose.yaml" ]]
+
+  # The .gitignore + index removal landed in the workflow @tag commit,
+  # not as a stray uncommitted change. We only assert tracked-side
+  # cleanliness — the first init.sh on this fixture also creates new
+  # symlinks (build.sh, run.sh, ...) that show up as untracked, which
+  # is expected and orthogonal to #172.
+  run git -C "${DOWN_DIR}" diff --quiet HEAD
+  assert_success
+}
+
+@test "upgrade.sh end-to-end: idempotent on a second run — no extra commits" {
+  _seed_upgrade_fixture
+  cd "${DOWN_DIR}"
+
+  env TEMPLATE_REMOTE="file://${TMPL_BARE}" \
+      ./template/upgrade.sh v9.0.1 >/dev/null
+  local _post_first
+  _post_first="$(git -C "${DOWN_DIR}" rev-parse HEAD)"
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" \
+      ./template/upgrade.sh v9.0.1
+  assert_success
+  assert_output --partial "Already at v9.0.1"
+
+  local _post_second
+  _post_second="$(git -C "${DOWN_DIR}" rev-parse HEAD)"
+  assert_equal "${_post_second}" "${_post_first}"
+}

--- a/test/unit/gitignore_spec.bats
+++ b/test/unit/gitignore_spec.bats
@@ -1,0 +1,255 @@
+#!/usr/bin/env bats
+#
+# Unit tests for template/script/docker/lib/gitignore.sh.
+#
+# Issue #172: init.sh / upgrade.sh need to sync a canonical .gitignore set
+# (.env, .env.bak, compose.yaml, setup.conf.bak, coverage/,
+# .Dockerfile.generated). The lib has three responsibilities:
+#   1. Emit the canonical list (single source of truth).
+#   2. Append-missing into a target .gitignore, idempotent, preserving
+#      user-defined lines.
+#   3. `git rm --cached` any canonical entry that's still tracked in the
+#      repo (so 15 downstream repos that mis-track compose.yaml get
+#      healed by the next batch-upgrade).
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  # shellcheck disable=SC1091
+  source /source/script/docker/lib/gitignore.sh
+
+  TMP_DIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "${TMP_DIR}"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _canonical_gitignore_entries
+# ════════════════════════════════════════════════════════════════════
+
+@test "_canonical_gitignore_entries: emits exactly the 6 canonical lines" {
+  run _canonical_gitignore_entries
+  assert_success
+  assert_output - <<'EXPECTED'
+.env
+.env.bak
+compose.yaml
+setup.conf.bak
+coverage/
+.Dockerfile.generated
+EXPECTED
+}
+
+@test "_canonical_gitignore_entries: list is stable order" {
+  # Two calls must produce byte-identical output (consumers may diff).
+  local _a _b
+  _a="$(_canonical_gitignore_entries)"
+  _b="$(_canonical_gitignore_entries)"
+  assert_equal "${_a}" "${_b}"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _sync_gitignore
+# ════════════════════════════════════════════════════════════════════
+
+@test "_sync_gitignore: creates the file when missing, with marker block + all entries" {
+  local _f="${TMP_DIR}/.gitignore"
+  run _sync_gitignore "${_f}"
+  assert_success
+  [[ -f "${_f}" ]]
+  run cat "${_f}"
+  assert_line --partial "managed by template"
+  assert_line ".env"
+  assert_line ".env.bak"
+  assert_line "compose.yaml"
+  assert_line "setup.conf.bak"
+  assert_line "coverage/"
+  assert_line ".Dockerfile.generated"
+}
+
+@test "_sync_gitignore: empty file gets marker block + all entries appended" {
+  local _f="${TMP_DIR}/.gitignore"
+  : > "${_f}"
+  run _sync_gitignore "${_f}"
+  assert_success
+  run cat "${_f}"
+  assert_line --partial "managed by template"
+  assert_line ".env"
+  assert_line "compose.yaml"
+}
+
+@test "_sync_gitignore: file with all entries already present is a no-op" {
+  local _f="${TMP_DIR}/.gitignore"
+  cat > "${_f}" <<'EOF'
+.env
+.env.bak
+compose.yaml
+setup.conf.bak
+coverage/
+.Dockerfile.generated
+EOF
+  local _before
+  _before="$(cat "${_f}")"
+  run _sync_gitignore "${_f}"
+  assert_success
+  local _after
+  _after="$(cat "${_f}")"
+  assert_equal "${_after}" "${_before}"
+}
+
+@test "_sync_gitignore: appends only missing entries when subset already present" {
+  local _f="${TMP_DIR}/.gitignore"
+  # Pre-existing partial set (the 15-repo state at the time #172 was filed)
+  cat > "${_f}" <<'EOF'
+.env
+.claude/
+EOF
+  run _sync_gitignore "${_f}"
+  assert_success
+  # User entry preserved
+  run grep -c '^\.claude/$' "${_f}"
+  assert_output "1"
+  # Existing canonical preserved (no duplicate)
+  run grep -c '^\.env$' "${_f}"
+  assert_output "1"
+  # Missing canonical appended
+  run grep -c '^compose\.yaml$' "${_f}"
+  assert_output "1"
+  run grep -c '^\.env\.bak$' "${_f}"
+  assert_output "1"
+  run grep -c '^coverage/$' "${_f}"
+  assert_output "1"
+}
+
+@test "_sync_gitignore: preserves user-defined lines (bridge.yaml, .env.gpg, .claude/)" {
+  local _f="${TMP_DIR}/.gitignore"
+  cat > "${_f}" <<'EOF'
+.env
+.env.gpg
+data/
+bridge.yaml
+.claude/
+EOF
+  run _sync_gitignore "${_f}"
+  assert_success
+  run cat "${_f}"
+  assert_line ".env.gpg"
+  assert_line "data/"
+  assert_line "bridge.yaml"
+  assert_line ".claude/"
+}
+
+@test "_sync_gitignore: idempotent — second invocation produces no further changes" {
+  local _f="${TMP_DIR}/.gitignore"
+  cat > "${_f}" <<'EOF'
+.env
+EOF
+  _sync_gitignore "${_f}"
+  local _after_first
+  _after_first="$(cat "${_f}")"
+  _sync_gitignore "${_f}"
+  local _after_second
+  _after_second="$(cat "${_f}")"
+  assert_equal "${_after_second}" "${_after_first}"
+}
+
+@test "_sync_gitignore: no duplicate canonical lines after re-run" {
+  local _f="${TMP_DIR}/.gitignore"
+  cat > "${_f}" <<'EOF'
+compose.yaml
+EOF
+  _sync_gitignore "${_f}"
+  _sync_gitignore "${_f}"
+  run grep -c '^compose\.yaml$' "${_f}"
+  assert_output "1"
+}
+
+@test "_sync_gitignore: ends with newline so future appends start on their own line" {
+  local _f="${TMP_DIR}/.gitignore"
+  printf 'something' > "${_f}"   # NO trailing newline
+  _sync_gitignore "${_f}"
+  # Last byte must be a newline
+  local _last
+  _last="$(tail -c 1 "${_f}" | od -An -c | tr -d ' ')"
+  assert_equal "${_last}" '\n'
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _untrack_canonical_in_repo
+# ════════════════════════════════════════════════════════════════════
+
+_init_repo_with_tracked() {
+  local _repo="$1"; shift
+  git -C "${_repo}" init -q -b main
+  git -C "${_repo}" config user.email t@t
+  git -C "${_repo}" config user.name t
+  local _f
+  for _f in "$@"; do
+    case "${_f}" in
+      */) mkdir -p "${_repo}/${_f}"; : > "${_repo}/${_f}placeholder" ;;
+      *)  : > "${_repo}/${_f}" ;;
+    esac
+  done
+  git -C "${_repo}" add -A
+  git -C "${_repo}" commit -q -m "init" || true
+}
+
+@test "_untrack_canonical_in_repo: git rm --cached for tracked compose.yaml" {
+  _init_repo_with_tracked "${TMP_DIR}" compose.yaml
+  run _untrack_canonical_in_repo "${TMP_DIR}"
+  assert_success
+  # File still on disk
+  [[ -f "${TMP_DIR}/compose.yaml" ]]
+  # No longer in index
+  run git -C "${TMP_DIR}" ls-files compose.yaml
+  assert_output ""
+}
+
+@test "_untrack_canonical_in_repo: leaves untracked files alone" {
+  git -C "${TMP_DIR}" init -q -b main
+  git -C "${TMP_DIR}" config user.email t@t
+  git -C "${TMP_DIR}" config user.name t
+  : > "${TMP_DIR}/README"
+  git -C "${TMP_DIR}" add -A
+  git -C "${TMP_DIR}" commit -q -m "init"
+  : > "${TMP_DIR}/compose.yaml"   # exists but never committed
+  run _untrack_canonical_in_repo "${TMP_DIR}"
+  assert_success
+  [[ -f "${TMP_DIR}/compose.yaml" ]]
+}
+
+@test "_untrack_canonical_in_repo: no-op when no canonical files tracked" {
+  _init_repo_with_tracked "${TMP_DIR}" README.md
+  run _untrack_canonical_in_repo "${TMP_DIR}"
+  assert_success
+  # README still tracked
+  run git -C "${TMP_DIR}" ls-files README.md
+  assert_output "README.md"
+}
+
+@test "_untrack_canonical_in_repo: handles tracked coverage/ directory" {
+  _init_repo_with_tracked "${TMP_DIR}" coverage/
+  run _untrack_canonical_in_repo "${TMP_DIR}"
+  assert_success
+  [[ -d "${TMP_DIR}/coverage" ]]
+  run git -C "${TMP_DIR}" ls-files coverage/
+  assert_output ""
+}
+
+@test "_untrack_canonical_in_repo: idempotent — second run succeeds without error" {
+  _init_repo_with_tracked "${TMP_DIR}" compose.yaml .env
+  _untrack_canonical_in_repo "${TMP_DIR}"
+  run _untrack_canonical_in_repo "${TMP_DIR}"
+  assert_success
+}
+
+@test "_untrack_canonical_in_repo: untracks all canonical entries that match" {
+  _init_repo_with_tracked "${TMP_DIR}" compose.yaml .env .env.bak setup.conf.bak
+  run _untrack_canonical_in_repo "${TMP_DIR}"
+  assert_success
+  run git -C "${TMP_DIR}" ls-files compose.yaml .env .env.bak setup.conf.bak
+  assert_output ""
+}

--- a/test/unit/init_spec.bats
+++ b/test/unit/init_spec.bats
@@ -17,8 +17,12 @@ setup() {
   TMP_REPO="$(mktemp -d)"
   mkdir -p "${TMP_REPO}/template/dockerfile" \
            "${TMP_REPO}/template/config" \
-           "${TMP_REPO}/template/script/docker"
+           "${TMP_REPO}/template/script/docker/lib"
   ln -s /source/init.sh "${TMP_REPO}/template/init.sh"
+  # init.sh sources lib/gitignore.sh on load (#172). Symlink the real
+  # lib so its functions are available to tests that hit _create_new_repo.
+  ln -s /source/script/docker/lib/gitignore.sh \
+        "${TMP_REPO}/template/script/docker/lib/gitignore.sh"
 
   # Minimal Dockerfile.example stub for _create_new_repo's `cp` step.
   cat > "${TMP_REPO}/template/dockerfile/Dockerfile.example" <<'EOF'

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -269,11 +269,21 @@ _upgrade() {
     git add "${main_yaml}"
   fi
 
-  # Commit workflow updates
+  # Step 3 ran init.sh which (re-)synced .gitignore via lib/gitignore.sh
+  # and `git rm --cached`-ed any tracked-but-now-derived artifacts
+  # (#172). The .gitignore mutation is unstaged; the rm is index-staged.
+  # Stage .gitignore so both land in the same commit.
+  if [[ -f "${REPO_ROOT}/.gitignore" ]]; then
+    git add "${REPO_ROOT}/.gitignore"
+  fi
+
+  # Commit workflow + .gitignore + index removals together
   git commit -m "$(cat <<COMMIT
 chore: update template references to ${target_ver}
 
 - main.yaml: workflow @tag updated to ${target_ver}
+- .gitignore: synced canonical entries (template lib/gitignore.sh)
+- untracked any derived artifacts now covered by .gitignore
 COMMIT
 )" || _log "No additional changes to commit"
 


### PR DESCRIPTION
## Summary

Closes #172. Treats `.gitignore` as a template-managed canonical set,
sourced once and applied consistently from `init.sh` and `upgrade.sh`.

The audit in #172 found 15/17 downstream repos still git-track
`compose.yaml` despite v0.9.0 making it a derived artifact. The proposed
phase-1 (template-side sync) was paired with a phase-2 sweep that would
have opened a second PR per repo to `git rm --cached compose.yaml`.
This PR folds phase-2 into `upgrade.sh` itself: the next
`/batch-template-upgrade` will sync `.gitignore` AND untrack the stale
compose.yaml in the same commit, no sweep PR needed.

## Lib

`template/script/docker/lib/gitignore.sh`:

- `_canonical_gitignore_entries` — single source of truth (`.env`,
  `.env.bak`, `compose.yaml`, `setup.conf.bak`, `coverage/`,
  `.Dockerfile.generated`). Future derived artifacts get added here and
  propagate via the existing-repo sync path on next upgrade.
- `_sync_gitignore <path>` — append-missing, idempotent. Preserves
  user-defined lines (`.claude/`, `bridge.yaml`, `.env.gpg`, ...).
  First sync drops a `# managed by template (do not remove)` marker;
  subsequent syncs skip the marker if already present.
- `_untrack_canonical_in_repo <repo>` — `git rm --cached` for any
  canonical entry still tracked. Working tree preserved. No-op outside
  a git repo. Idempotent.

## Wiring

- `init.sh` new-repo path (`_create_new_repo`): replaces the inline
  6-line heredoc with `_sync_gitignore`.
- `init.sh` existing-repo path (`_init_existing_repo`): new
  `_sync_existing_gitignore` step that combines sync + untrack.
- `upgrade.sh` Step 4: stages `.gitignore` alongside `main.yaml` so the
  sync + the index removals land in the same commit as the workflow
  `@tag` rewrite. The commit message lists all three changes.

## Tests

23 new tests, suite total 795 → 818 (767 unit + 51 integration), all green.

- `test/unit/gitignore_spec.bats` (16): canonical list, sync on
  missing / empty / subset / full, preserves user lines, idempotency,
  trailing-newline, untrack on file / directory / multi-entry, no-op
  cases.
- `test/integration/gitignore_sync_spec.bats` (7): `init.sh` new +
  existing paths produce the canonical set, untrack a tracked
  compose.yaml, idempotent re-run, end-to-end `upgrade.sh` with a real
  init.sh in the fixture (not the stub-init from `upgrade_spec.bats`)
  asserting the synced .gitignore + index removals all land cleanly in
  a single commit.

## Test plan

- [x] `make -f Makefile.ci test` (Docker, full suite + ShellCheck +
      Hadolint) — green
- [x] Behavior validated manually against the audit case: existing repo
      with partial `.gitignore` + tracked `compose.yaml` ends up with
      synced .gitignore + untracked compose.yaml after `init.sh`
- [ ] After merge + tag: `/batch-template-upgrade vX.Y.Z` against the
      15 downstream repos heals the drift in one batch
