### PR TITLE
chore: gitignore .claude (also covers symlinks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ multi_run/
 
 # Claude Code session state when launched inside this sub-repo.
 # Workspace-level Claude config lives in ycpss91255-docker/claude-workspace.
-.claude/
+.claude


### PR DESCRIPTION
## Why

The docker monorepo creates `<repo>/.claude` as a relative symlink to the workspace `.claude/` so per-repo Claude sessions (e.g. `cd template && claude` or `cd app/ros1_bridge && claude`) share the same hooks / slash commands / scripts as the workspace session, while still getting per-cwd-slug memory separation. Under the existing `.claude/` (trailing-slash) gitignore pattern, this symlink leaks into `git status` as `?? .claude` because the trailing slash matches directories only. Replacing with `.claude` (no slash) matches files, directories, and symlinks — covers the symlink case without losing the directory case.

## What

Replace `.claude/` with `.claude` in `.gitignore` so the pattern matches both directories AND symlinks. The trailing slash form (`.claude/`) only matches a real directory; the docker monorepo creates `<repo>/.claude` as a symlink to the workspace `.claude/`, which leaks into `git status` as `?? .claude` under the old pattern.

No code, Dockerfile, or test impact.

## Test plan

- [x] CI green on this PR
- After merge: confirm `git status` no longer flags `.claude` symlink in this repo