### PR TITLE
fix(dockerfile): drop dead COPY compose.yaml from Dockerfile.example

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`Dockerfile.example`: drop dead `COPY compose.yaml /lint/compose.yaml`**. The /lint stage shellcheck'd `.sh` and hadolint'd `Dockerfile` but never read `/lint/compose.yaml` — the COPY was leftover scaffolding from earlier iterations. After v0.12.4 (#172) made `compose.yaml` a derived artifact (gitignored + `git rm --cached`), fresh CI checkouts no longer have the file and `docker/build-push-action`'s COPY step started failing on the build context for new repos generated from this template. The same dead-code line was patched out of the 10 affected v0.12.4 batch-upgrade PRs to unblock the rollout.
+
 ## [v0.12.4] - 2026-04-29
 
 Patch release bundling two Makefile / setup-tui fixes plus the

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -141,7 +141,6 @@ COPY --from=test-tools-stage /usr/local/bin/hadolint /usr/local/bin/hadolint
 # Lint: ShellCheck (.sh) + Hadolint (Dockerfile)
 COPY .hadolint.yaml /lint/.hadolint.yaml
 COPY Dockerfile /lint/Dockerfile
-COPY compose.yaml /lint/compose.yaml
 COPY *.sh /lint/
 # Helpers sourced by the root-level scripts. Must sit next to them so
 # build.sh / run.sh / exec.sh / stop.sh / setup.sh can source _lib.sh


### PR DESCRIPTION
## Summary

Drop dead `COPY compose.yaml /lint/compose.yaml` line in `dockerfile/Dockerfile.example`. The /lint stage shellcheck'd `.sh` and hadolint'd `Dockerfile` but never read `/lint/compose.yaml` — the COPY was leftover scaffolding from earlier iterations.

## Why now

After v0.12.4 (#172) made `compose.yaml` a derived artifact (gitignored + `git rm --cached`), fresh CI checkouts no longer have the file and `docker/build-push-action`'s COPY step starts failing on the build context for **new repos generated from this template** (`./template/init.sh` copies Dockerfile.example).

Existing repos in the v0.12.4 batch upgrade hit the same regression. They were patched out-of-band by `.claude/scripts/fix-compose-copy-line.sh` (10 affected — `env/{ros_kinetic, ros2_humble, osrf_*}`, `app/{realsense_*, sick_*, urg_node_noetic}`); the 7 that already lacked the COPY (`agent/*`, `ros1_bridge`, `ros_noetic`, `urg_node_humble`) were unaffected.

## Test plan

- [ ] `Self Test / test` green (existing 824 tests; this PR adds none — Dockerfile change is dead-code removal, smoke covered by Dockerfile build itself in `Self Test / integration-e2e`)
- [ ] `Self Test / integration-e2e` green (the e2e job creates a fresh repo via `init.sh` + builds `./build.sh test` + `./build.sh` end-to-end, which exercises Dockerfile.example's test stage; this is the regression that would catch a new-repo bug)
- [ ] After merge: future `/new-repo` runs produce Dockerfiles that don't reference compose.yaml in the lint stage
