### PR TITLE
feat(setup): promote template-default fallback notice to WARN (closes #186)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Template-default fallback notice promoted from INFO to WARN** (#186). `_announce_template_default_fallback` in `script/docker/setup.sh` now emits `[setup] WARN:` instead of `[setup] INFO:` when the per-repo `setup.conf.local` is missing or has no `[section]` headers. INFO scrolled past in normal `build.sh` / `run.sh` output and users missed the heads-up that template defaults were silently in effect; WARN matches the semantics (this is an unusual configuration state worth flagging, not a routine status line). The two i18n keys also rename `info_no_repo_conf` → `warn_no_repo_conf` and `info_empty_repo_conf` → `warn_empty_repo_conf` across all four languages so the message table stays self-describing.
+
 ## [v0.13.0] - 2026-04-29
 
 Minor release introducing the `setup.conf.local` user-override file.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -65,8 +65,8 @@ writeback (first-time bootstrap / user-edit respect / opt-out).
 | `_msg` / `_detect_lang` i18n | 6 |
 | `[build]` apt_mirror (empty fallback, override) | 2 |
 | Workspace writeback (first-time, respect user edit, opt-out) | 3 |
-| Per-repo setup.conf missing / empty INFO (#150: missing → INFO, empty → INFO, partial → silent, zh-TW lang) | 4 |
-| Per-repo setup.conf INFO on check-drift path (#157: missing → INFO, empty → INFO, partial → silent, zh-TW lang) | 4 |
+| Per-repo setup.conf missing / empty WARN (#150 / #186: missing → WARN, empty → WARN, partial → silent, zh-TW lang) | 4 |
+| Per-repo setup.conf WARN on check-drift path (#157 / #186: missing → WARN, empty → WARN, partial → silent, zh-TW lang) | 4 |
 
 ### test/unit/tui_spec.bats (87)
 

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -56,8 +56,8 @@ _setup_msg() {
         reset_aborted)    echo "已取消，未變更任何檔案" ;;
         reset_done)       echo "setup.conf 已重設為模板預設值（先前內容備份於 .bak）" ;;
         reset_needs_yes)  echo "非互動模式：請加 --yes 才會執行 reset（避免誤刪）" ;;
-        info_no_repo_conf) echo "未找到 repo 自有的 setup.conf — 全部 section 將使用模板預設值" ;;
-        info_empty_repo_conf) echo "repo 的 setup.conf 沒有任何 section 覆寫 — 全部 section 將使用模板預設值" ;;
+        warn_no_repo_conf) echo "未找到 repo 自有的 setup.conf — 全部 section 將使用模板預設值" ;;
+        warn_empty_repo_conf) echo "repo 的 setup.conf 沒有任何 section 覆寫 — 全部 section 將使用模板預設值" ;;
       esac ;;
     zh-CN)
       case "${_key}" in
@@ -78,8 +78,8 @@ _setup_msg() {
         reset_aborted)    echo "已取消，未更改任何文件" ;;
         reset_done)       echo "setup.conf 已重置为模板默认值（之前内容备份至 .bak）" ;;
         reset_needs_yes)  echo "非交互模式：请加 --yes 才会执行 reset（避免误删）" ;;
-        info_no_repo_conf) echo "未找到 repo 自有的 setup.conf — 全部 section 将使用模板默认值" ;;
-        info_empty_repo_conf) echo "repo 的 setup.conf 没有任何 section 覆写 — 全部 section 将使用模板默认值" ;;
+        warn_no_repo_conf) echo "未找到 repo 自有的 setup.conf — 全部 section 将使用模板默认值" ;;
+        warn_empty_repo_conf) echo "repo 的 setup.conf 没有任何 section 覆写 — 全部 section 将使用模板默认值" ;;
       esac ;;
     ja)
       case "${_key}" in
@@ -100,8 +100,8 @@ _setup_msg() {
         reset_aborted)    echo "中断されました。ファイルは変更されていません" ;;
         reset_done)       echo "setup.conf をテンプレートのデフォルトにリセットしました（旧内容は .bak に保存）" ;;
         reset_needs_yes)  echo "非対話モード: --yes を指定しないと reset は実行されません（誤削除防止）" ;;
-        info_no_repo_conf) echo "repo 固有の setup.conf が見つかりません — 全ての section でテンプレートのデフォルト値を使用します" ;;
-        info_empty_repo_conf) echo "repo の setup.conf にセクション上書きがありません — 全ての section でテンプレートのデフォルト値を使用します" ;;
+        warn_no_repo_conf) echo "repo 固有の setup.conf が見つかりません — 全ての section でテンプレートのデフォルト値を使用します" ;;
+        warn_empty_repo_conf) echo "repo の setup.conf にセクション上書きがありません — 全ての section でテンプレートのデフォルト値を使用します" ;;
       esac ;;
     *)
       case "${_key}" in
@@ -122,8 +122,8 @@ _setup_msg() {
         reset_aborted)    echo "Aborted; no files changed" ;;
         reset_done)       echo "setup.conf reset to template default (prior contents saved to .bak)" ;;
         reset_needs_yes)  echo "Non-interactive: pass --yes to confirm reset (prevents accidental destruction)" ;;
-        info_no_repo_conf) echo "no per-repo setup.conf — using template defaults for all sections" ;;
-        info_empty_repo_conf) echo "per-repo setup.conf has no section overrides — using template defaults for all sections" ;;
+        warn_no_repo_conf) echo "no per-repo setup.conf — using template defaults for all sections" ;;
+        warn_empty_repo_conf) echo "per-repo setup.conf has no section overrides — using template defaults for all sections" ;;
       esac ;;
   esac
 }
@@ -1378,12 +1378,14 @@ _setup_check_drift() {
 # ════════════════════════════════════════════════════════════════════
 # _announce_template_default_fallback <base_path>
 #
-# Surface a one-shot INFO when the per-repo setup.conf provides no
+# Surface a one-shot WARN when the per-repo setup.conf provides no
 # overrides — either missing entirely or present but containing no
 # [section] headers. Called from both `_setup_apply` and
 # `_setup_check_drift` so build.sh / run.sh's drift-check rebuild path
 # also surfaces the heads-up (closes #157, follow-up to #150 / #153).
-# Emitted to stderr to keep stdout machine-parseable.
+# Emitted to stderr to keep stdout machine-parseable. #186 promoted
+# the level from INFO to WARN so the notice doesn't scroll past
+# unnoticed in normal build.sh / run.sh output.
 # ════════════════════════════════════════════════════════════════════
 _announce_template_default_fallback() {
   local _base="${1:?"${FUNCNAME[0]}: missing base_path"}"
@@ -1391,9 +1393,9 @@ _announce_template_default_fallback() {
   # not the derived snapshot.
   local _repo_local="${_base}/setup.conf.local"
   if [[ ! -f "${_repo_local}" ]]; then
-    printf "[setup] INFO: %s\n" "$(_setup_msg info_no_repo_conf)" >&2
+    printf "[setup] WARN: %s\n" "$(_setup_msg warn_no_repo_conf)" >&2
   elif ! grep -qE '^[[:space:]]*\[[^]]+\]' "${_repo_local}"; then
-    printf "[setup] INFO: %s\n" "$(_setup_msg info_empty_repo_conf)" >&2
+    printf "[setup] WARN: %s\n" "$(_setup_msg warn_empty_repo_conf)" >&2
   fi
 }
 

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -891,22 +891,25 @@ EOF
 # ── Per-repo setup.conf missing / empty INFO (issue #150) ────────────────
 # When the per-repo setup.conf is absent, or present but has no section
 # headers, every _load_setup_conf call falls back to the template default.
-# That fallback used to be silent — surfacing one INFO line at apply()
+# That fallback used to be silent — surfacing one WARN line at apply()
 # entry tells the user the entire run is template-default driven, without
-# spamming an INFO per section (11 sections would be noisy).
+# spamming a notice per section (11 sections would be noisy). #186
+# promoted this from INFO to WARN so the heads-up doesn't scroll past.
 
-@test "apply prints INFO when per-repo setup.conf is missing" {
+@test "apply prints WARN when per-repo setup.conf is missing (#186)" {
   # No TEMP_DIR/setup.conf created — apply should fall back to template
-  # default and announce it once on stderr.
+  # default and announce it once on stderr at WARN level.
   run bash -c "
     source /source/script/docker/setup.sh
     main apply --base-path '${TEMP_DIR}' 2>&1
   "
   assert_success
+  assert_output --partial "[setup] WARN:"
   assert_output --partial "no per-repo setup.conf"
+  refute_output --partial "[setup] INFO:"
 }
 
-@test "apply prints INFO when per-repo setup.conf has no section headers" {
+@test "apply prints WARN when per-repo setup.conf has no section headers (#186)" {
   # Comments-only file counts as effectively empty: nothing to override.
   cat > "${TEMP_DIR}/setup.conf.local" <<'EOF'
 # only comments, no [section] headers
@@ -917,6 +920,7 @@ EOF
     main apply --base-path '${TEMP_DIR}' 2>&1
   "
   assert_success
+  assert_output --partial "[setup] WARN:"
   assert_output --partial "per-repo setup.conf has no section"
 }
 
@@ -936,12 +940,13 @@ EOF
   refute_output --partial "per-repo setup.conf has no section"
 }
 
-@test "apply --lang zh-TW prints INFO in Traditional Chinese when setup.conf missing" {
+@test "apply --lang zh-TW prints WARN in Traditional Chinese when setup.conf missing (#186)" {
   run bash -c "
     source /source/script/docker/setup.sh
     main apply --base-path '${TEMP_DIR}' --lang zh-TW 2>&1
   "
   assert_success
+  assert_output --partial "[setup] WARN:"
   assert_output --partial "未找到"
 }
 
@@ -1052,7 +1057,7 @@ EOF
   assert_output --partial "drift detected"
 }
 
-@test "check-drift prints INFO when per-repo setup.conf is missing" {
+@test "check-drift prints WARN when per-repo setup.conf is missing (#186)" {
   # No TEMP_DIR/setup.conf created — check-drift should announce the
   # template-default fallback the same way `apply` does, so users
   # running the build.sh drift-check path see the heads-up too.
@@ -1060,10 +1065,11 @@ EOF
     source /source/script/docker/setup.sh
     main check-drift --base-path '${TEMP_DIR}' 2>&1
   "
+  assert_output --partial "[setup] WARN:"
   assert_output --partial "no per-repo setup.conf"
 }
 
-@test "check-drift prints INFO when per-repo setup.conf has no section headers" {
+@test "check-drift prints WARN when per-repo setup.conf has no section headers (#186)" {
   cat > "${TEMP_DIR}/setup.conf.local" <<'EOF'
 # only comments, no [section] headers
 EOF
@@ -1071,6 +1077,7 @@ EOF
     source /source/script/docker/setup.sh
     main check-drift --base-path '${TEMP_DIR}' 2>&1
   "
+  assert_output --partial "[setup] WARN:"
   assert_output --partial "per-repo setup.conf has no section"
 }
 
@@ -1087,11 +1094,12 @@ EOF
   refute_output --partial "per-repo setup.conf has no section"
 }
 
-@test "check-drift --lang zh-TW prints INFO in Traditional Chinese when setup.conf missing" {
+@test "check-drift --lang zh-TW prints WARN in Traditional Chinese when setup.conf missing (#186)" {
   run bash -c "
     source /source/script/docker/setup.sh
     main check-drift --base-path '${TEMP_DIR}' --lang zh-TW 2>&1
   "
+  assert_output --partial "[setup] WARN:"
   assert_output --partial "未找到"
 }
 


### PR DESCRIPTION
## Summary

Promotes `_announce_template_default_fallback`'s log level from `INFO` to `WARN` so the heads-up that the run is using template defaults doesn't scroll past in normal `build.sh` / `run.sh` output.

Closes #186.

### What changed

- `script/docker/setup.sh::_announce_template_default_fallback`: both `printf` calls now emit `[setup] WARN:` instead of `[setup] INFO:`.
- i18n key rename so the message table stays self-describing:
  - `info_no_repo_conf` → `warn_no_repo_conf`
  - `info_empty_repo_conf` → `warn_empty_repo_conf`
  - All four languages updated (en / zh-TW / zh-CN / ja).
- `test/unit/setup_spec.bats`: existing 6 tests on the apply / check-drift fallback paths now also `assert_output --partial "[setup] WARN:"` (and one negative `refute_output --partial "[setup] INFO:"`) so the prefix can't regress silently.
- `doc/test/TEST.md`: section summary text updated to match the new WARN semantics (test count unchanged: 175 in setup_spec.bats).
- `doc/changelog/CHANGELOG.md`: `[Unreleased]` `### Changed` entry added.

### Why WARN (not delete the notice)

Deleting hides a legitimate runtime state ("running on template defaults"). Promoting to WARN keeps users informed and makes the notice hard to miss in CI / interactive output.

### Independence from #174

This is logically independent of the #174 setup.conf split — #174 changes the lifecycle of the file; this issue only changes the log level of the existing notice. The rebase race that previously declined #186 in `/issue-fix` is gone now that #174 (PR #188) has merged, and the fix applies cleanly on top of the post-#174 layout (`_announce_template_default_fallback` already inspects `setup.conf.local` after #174).

## Test plan

- [ ] `make -f Makefile.ci test` green on this PR (already green locally — full Bats unit + integration suite passed, including the 6 updated assertions).
- [ ] Reviewer eyeballs the 4 i18n locale strings — only the `case` keys flipped, message text unchanged.
