### PR TITLE
feat(build-worker): support Dockerfile in subdirectory via context_path / dockerfile_path inputs (closes #195)

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -56,6 +56,35 @@ on:
 
           Supported values: linux/amd64, linux/arm64. Other values are
           rejected by the compute-matrix step.
+      context_path:
+        required: false
+        type: string
+        default: "."
+        description: |
+          Build context passed to docker/build-push-action's `context:`
+          input. Defaults to repo root for backwards compatibility with
+          the standard template layout (Dockerfile + compose.yaml at
+          repo root).
+
+          Set to a subdirectory (e.g. `docker`) when the consumer repo
+          keeps its docker assets nested — typically to keep
+          template-managed files separated from application source. The
+          path is relative to the repo root after `actions/checkout`.
+
+          Pairs with `dockerfile_path`; both inputs are independent so
+          callers can override one without the other.
+      dockerfile_path:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Optional explicit Dockerfile path relative to the repo root.
+          Empty string (default) defers to `<context_path>/Dockerfile`,
+          matching docker/build-push-action's own default.
+
+          Override only when the Dockerfile is named non-standardly or
+          lives outside `<context_path>/` — most consumers should leave
+          this empty and rely on the implicit `<context_path>/Dockerfile`.
 
 jobs:
   # ────────────────────────────────────────────────────────────────
@@ -168,7 +197,8 @@ jobs:
         # was wrong: that ref is the caller's own tag, not template's).
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: ${{ inputs.context_path }}
+          file: ${{ inputs.dockerfile_path || format('{0}/Dockerfile', inputs.context_path) }}
           target: test
           platforms: ${{ matrix.platform }}
           push: false
@@ -184,7 +214,8 @@ jobs:
       - name: Build devel stage
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: ${{ inputs.context_path }}
+          file: ${{ inputs.dockerfile_path || format('{0}/Dockerfile', inputs.context_path) }}
           target: devel
           platforms: ${{ matrix.platform }}
           push: false
@@ -200,7 +231,8 @@ jobs:
         if: ${{ inputs.build_runtime }}
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: ${{ inputs.context_path }}
+          file: ${{ inputs.dockerfile_path || format('{0}/Dockerfile', inputs.context_path) }}
           target: runtime
           platforms: ${{ matrix.platform }}
           push: false

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`build-worker.yaml` accepts `context_path` / `dockerfile_path` inputs** (#195). Lets downstream repos that nest their docker assets in a subdirectory (e.g. `docker/Dockerfile`, `docker/compose.yaml`) call the reusable workflow with `with: context_path: docker` instead of being forced to keep the Dockerfile at repo root. Both inputs default to current behaviour (`context_path: "."`, `dockerfile_path: ""` → falls back to `<context_path>/Dockerfile`), so the 17 existing downstream repos see no CI change. Use case discovered while migrating `ycpss91255-docker/seggpt`, where the docker environment lives under `seggpt/docker/` to keep template-managed files separate from `src/` and `test/`. Three new `test/unit/build_worker_yaml_spec.bats` tests lock the input forwarding so a future refactor can't silently revert one of the 3 build steps.
+
 ## [v0.14.0] - 2026-04-29
 
 Minor release. Two test / quality follow-ups on top of v0.13.0, no

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **872 tests** total (817 unit + 55 integration).
+Template self-tests: **879 tests** total (824 unit + 55 integration).
 
 ## Test Files
 
@@ -126,6 +126,25 @@ target areas the issue body called out.
 | `_edit_section_network` (host+host no shm prompt, bridge prompts name+ports, ipc=private prompts shm, empty network_name allowed) | 4 |
 | `_edit_section_deploy` (off short-circuits — only writes gpu_mode) | 1 |
 | Multi-section dispatch from main menu (network → host → save) | 1 |
+
+### test/unit/build_worker_yaml_spec.bats (7)
+
+Structural assertions for `.github/workflows/build-worker.yaml` (#195).
+Reusable workflows are not exec'd by these tests; instead grep
+patterns lock the YAML invariants — `context_path` / `dockerfile_path`
+inputs declared with the right defaults, all 3 `docker/build-push-action`
+steps forwarding those inputs, and no leftover `context: .` /
+`file: ./Dockerfile` literals.
+
+| Category | Tests |
+|----------|-------|
+| `inputs.context_path` declared with `default: "."` | 1 |
+| `inputs.dockerfile_path` declared with `default: ""` | 1 |
+| 3 build steps reference `inputs.context_path` | 1 |
+| 3 build steps reference `inputs.dockerfile_path` with `format()` fallback | 1 |
+| No leftover `context: .` literals | 1 |
+| No leftover `file: ./Dockerfile` literals | 1 |
+| Default values together preserve repo-root-Dockerfile callers | 1 |
 
 ### test/unit/build_sh_spec.bats (35)
 

--- a/test/unit/build_worker_yaml_spec.bats
+++ b/test/unit/build_worker_yaml_spec.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+#
+# build_worker_yaml_spec.bats — structural assertions for the
+# `.github/workflows/build-worker.yaml` reusable workflow.
+#
+# Reusable workflows can't be unit-tested by exec'ing them, but their
+# structural invariants (which inputs exist, which `with:` keys
+# forward into docker/build-push-action) are still grep-able. These
+# tests lock the #195 changes — `context_path` / `dockerfile_path`
+# inputs and the corresponding `context:` / `file:` lines in the 3
+# build steps — so a future refactor that drops one of them lights up
+# CI red instead of silently breaking nested-Dockerfile downstreams.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  WF="/source/.github/workflows/build-worker.yaml"
+  [[ -f "${WF}" ]] || skip "build-worker.yaml not at expected path"
+}
+
+# ── Inputs declared (#195) ────────────────────────────────────────────
+
+@test "build-worker.yaml: declares context_path input with default '.'" {
+  run grep -A 3 '^      context_path:' "${WF}"
+  assert_success
+  assert_output --partial 'required: false'
+  assert_output --partial 'type: string'
+  assert_output --partial 'default: "."'
+}
+
+@test "build-worker.yaml: declares dockerfile_path input with empty default" {
+  run grep -A 3 '^      dockerfile_path:' "${WF}"
+  assert_success
+  assert_output --partial 'required: false'
+  assert_output --partial 'type: string'
+  assert_output --partial 'default: ""'
+}
+
+# ── Build steps forward both inputs (#195) ────────────────────────────
+
+@test "build-worker.yaml: 3 build steps all reference inputs.context_path" {
+  # Three `docker/build-push-action` calls — test/devel/runtime stages.
+  # Each must read context from the new input; `context: .` would
+  # silently work for repo-root-Dockerfile callers but break the
+  # nested-Dockerfile use case the issue body documented.
+  run grep -c 'context: ${{ inputs.context_path }}' "${WF}"
+  assert_success
+  assert_output "3"
+}
+
+@test "build-worker.yaml: 3 build steps all forward inputs.dockerfile_path with format() fallback" {
+  # The `||` short-circuit means an empty dockerfile_path falls back
+  # to `<context_path>/Dockerfile`, matching docker/build-push-action's
+  # implicit default. Override path lets callers pin a non-standard
+  # filename.
+  run grep -c "file: \${{ inputs.dockerfile_path || format('{0}/Dockerfile', inputs.context_path) }}" "${WF}"
+  assert_success
+  assert_output "3"
+}
+
+@test "build-worker.yaml: no leftover hardcoded 'context: .' lines" {
+  # Catches partial-refactor regressions where one of the 3 stages
+  # gets reverted by accident. The post-#195 file should have ZERO
+  # `context: .` literals — every reference reads from the input.
+  run grep -c '^          context: \.$' "${WF}"
+  [ "${status}" -ne 0 ] || [ "${output}" = "0" ]
+}
+
+@test "build-worker.yaml: no hardcoded Dockerfile path bypassing the input" {
+  # Belt-and-braces against someone hard-coding `file: ./Dockerfile`
+  # in one stage and forgetting that callers expect the input to flow
+  # through.
+  run grep -E '^[[:space:]]+file: \./Dockerfile$' "${WF}"
+  [ "${status}" -ne 0 ] || [ -z "${output}" ]
+}
+
+# ── Backwards compatibility ──────────────────────────────────────────
+
+@test "build-worker.yaml: defaults preserve repo-root-Dockerfile behavior" {
+  # Both inputs default such that an existing caller passing only
+  # `image_name:` still resolves to context=. and file=./Dockerfile —
+  # what every pre-#195 downstream main.yaml expects. Asserts the
+  # combination, not just each default in isolation.
+  local _ctx _df
+  _ctx="$(grep -A 3 '^      context_path:' "${WF}" | grep 'default:' | head -1)"
+  _df="$(grep -A 3 '^      dockerfile_path:' "${WF}" | grep 'default:' | head -1)"
+  [[ "${_ctx}" == *'"."'* ]]
+  [[ "${_df}" == *'""'* ]]
+}


### PR DESCRIPTION
## Summary

Closes #195. Adds `context_path` / `dockerfile_path` inputs to the `build-worker.yaml` reusable workflow so downstream repos can keep their docker assets in a subdirectory.

### What changed

`.github/workflows/build-worker.yaml`:

- New `context_path` input (default `"."`) — forwarded to `docker/build-push-action`'s `context:`.
- New `dockerfile_path` input (default `""`) — forwarded to `file:`; empty falls back to `<context_path>/Dockerfile`, matching docker/build-push-action's implicit default.
- The 3 build steps (`test` / `devel` / `runtime`) all read both inputs.

`test/unit/build_worker_yaml_spec.bats` (new, 7 tests) — locks the YAML invariants so a future refactor can't silently revert one of the 3 build steps:

| Assertion | Tests |
|---|---|
| Inputs declared with right defaults | 2 |
| 3 build steps forward `context_path` | 1 |
| 3 build steps forward `dockerfile_path` with `format()` fallback | 1 |
| No leftover `context: .` / `file: ./Dockerfile` literals | 2 |
| Default values together preserve repo-root callers | 1 |

### Why

`ycpss91255-docker/seggpt` wants to keep template-managed docker assets under `seggpt/docker/` separate from `src/` and `test/` (Python source tree). The repo's layout — confirmed by inspection just now — looks like:

```
seggpt/
├── docker/
│   ├── Dockerfile           # standard template Dockerfile.example
│   ├── compose.yaml         # context: .  (relative to docker/)
│   ├── build.sh             # symlinks → docker/template/script/docker/
│   ├── template/            # full template subtree at v0.13.0
│   ├── test/, script/, config/, setup.conf{,.local}
├── src/                     # Python source (3-layer)
├── test/                    # Python tests (NOT smoke)
├── third_party/, .github/, pyproject.toml, README.md
```

`./build.sh` from inside `docker/` works (compose's `context: .` resolves to `docker/`). The CI workflow was the gap: pre-#195 `build-worker.yaml` hardcoded `context: .` at repo root, so docker/build-push-action couldn't find `Dockerfile`. With this PR, seggpt's `main.yaml` can change one line:

```yaml
jobs:
  call-docker-build:
    uses: ycpss91255-docker/template/.github/workflows/build-worker.yaml@v0.15.0
    with:
      image_name: seggpt
      context_path: docker      # ← new
```

### Backwards compatibility

The 17 existing downstream repos pass only `image_name:` to this workflow. Both new inputs default such that `context: .` + `file: ./Dockerfile` is the resolved behaviour, identical to pre-#195. No downstream main.yaml needs to change.

### Why not bundle into a wider "support arbitrary subtree prefix" change

That was the alternative. Rejected for this PR: every other piece of template plumbing (init.sh, build.sh, Dockerfile.example COPY paths, smoke test fixture paths) still assumes the standard layout, and seggpt deliberately mirrors that layout inside its `docker/` folder so all those tools keep working. The reusable workflow is the only piece that didn't have an equivalent variable. Closing this gap is the minimal change that solves the actual reported failure.

## Test plan

- [ ] Self Test green on this PR (full Bats unit + integration suite, including the 7 new structural tests)
- [ ] Reviewer eyeballs the YAML diff: 2 input declarations + 3 × 2-line edits in build steps; nothing else touched
- [ ] After merge: cut a v0.15.0 tag, then test in seggpt by adding `context_path: docker` to its main.yaml and pinning to `@v0.15.0`. seggpt PR was the trigger for this issue and serves as the real-world integration test.
