### PR TITLE
test(setup): per-section setup.conf parameter end-to-end coverage (closes #202)

### DIFF
--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **898 tests** total (844 unit + 54 integration).
+Template self-tests: **923 tests** total (869 unit + 54 integration).
 
 ## Test Files
 
@@ -35,7 +35,7 @@ Template self-tests: **898 tests** total (844 unit + 54 integration).
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
 | `_print_config_summary warns when setup.conf exists but has no [section] headers` | #157 empty-conf hint on build/run summary |
 
-### test/unit/setup_spec.bats (181)
+### test/unit/setup_spec.bats (206)
 
 Covers core detection (user/hardware/docker/GPU/GUI), the INI parser
 (`_parse_ini_section`), setup.conf section merging (`_load_setup_conf`
@@ -68,6 +68,7 @@ writeback (first-time bootstrap / user-edit respect / opt-out).
 | Per-repo setup.conf missing / empty WARN (#150 / #186: missing → WARN, empty → WARN, partial → silent, zh-TW lang) | 4 |
 | Per-repo setup.conf WARN on check-drift path (#157 / #186: missing → WARN, empty → WARN, partial → silent, zh-TW lang) | 4 |
 | `[additional_contexts]` parsing + compose emission (#199: omitted by default, devel/test block, runtime block, numeric sort, empty-slot skip, _setup_known_section) | 6 |
+| Per-section setup.conf parameter end-to-end coverage (#202: [deploy] gpu_mode/count/capabilities/runtime, [gui] mode, [network] mode/ipc/network_name/port_*, [resources] shm_size, [environment] env_*, [tmpfs] tmpfs_*, [devices] device_*/cgroup_rule_*, [volumes] mount_2..N, [security] privileged) | 25 |
 
 ### test/unit/tui_spec.bats (92)
 

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -2190,3 +2190,400 @@ EOF
   BASE_PATH="${TEMP_DIR}" detect_image_name _result "/tmp/whatever"
   assert_equal "${_result}" "my-app-name"
 }
+
+# ════════════════════════════════════════════════════════════════════
+# Per-section setup.conf parameter end-to-end coverage (#202)
+#
+# Each test sets a single key in <repo>/setup.conf and asserts the
+# expected line appears in compose.yaml or .env. Companion negative
+# tests confirm the corresponding compose / env block is omitted when
+# the key is empty / cleared. Ensures every key documented in
+# template/setup.conf has a setting → output assertion.
+# ════════════════════════════════════════════════════════════════════
+
+# ── [deploy] ─────────────────────────────────────────────────────────
+
+@test "[deploy] gpu_mode = off omits deploy.resources block from compose.yaml" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[deploy]
+gpu_mode = off
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -F 'deploy:' '${TEMP_DIR}/compose.yaml' | head -1
+  "
+  assert_output ""
+}
+
+@test "[deploy] gpu_mode = force emits deploy.resources GPU block" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[deploy]
+gpu_mode = force
+gpu_count = all
+gpu_capabilities = gpu compute
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -E 'driver: nvidia' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[deploy] gpu_count = 2 emits count: 2 in compose deploy block" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[deploy]
+gpu_mode = force
+gpu_count = 2
+gpu_capabilities = gpu
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -E 'count: 2$' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[deploy] gpu_capabilities multi-value emits as YAML array" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[deploy]
+gpu_mode = force
+gpu_count = all
+gpu_capabilities = gpu compute utility
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -F 'capabilities: [gpu, compute, utility]' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[deploy] runtime = nvidia emits runtime: nvidia at service level" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[deploy]
+gpu_mode = off
+runtime = nvidia
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -E '^    runtime: nvidia$' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[deploy] runtime = off omits runtime line entirely" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[deploy]
+gpu_mode = off
+runtime = off
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -c '^    runtime:' '${TEMP_DIR}/compose.yaml' || true
+  "
+  assert_output "0"
+}
+
+# ── [gui] ────────────────────────────────────────────────────────────
+
+@test "[gui] mode = off omits X11 / DISPLAY env from compose" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[gui]
+mode = off
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -c 'DISPLAY' '${TEMP_DIR}/compose.yaml' || true
+  "
+  assert_output "0"
+}
+
+@test "[gui] mode = force emits X11 environment + /tmp/.X11-unix mount" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[gui]
+mode = force
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -F '/tmp/.X11-unix:/tmp/.X11-unix:ro' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+# ── [network] ────────────────────────────────────────────────────────
+
+@test "[network] mode = host writes NETWORK_MODE=host to .env" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[network]
+mode = host
+ipc = host
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep '^NETWORK_MODE=' '${TEMP_DIR}/.env'
+  "
+  assert_output "NETWORK_MODE=host"
+}
+
+@test "[network] ipc = private writes IPC_MODE=private to .env" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[network]
+mode = host
+ipc = private
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep '^IPC_MODE=' '${TEMP_DIR}/.env'
+  "
+  assert_output "IPC_MODE=private"
+}
+
+@test "[network] network_name = my_bridge under mode=bridge emits external network ref" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[network]
+mode = bridge
+ipc = private
+network_name = my_bridge
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -E '^networks:' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[network] port_1 = 8080:80 emits ports: block under bridge mode" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[network]
+mode = bridge
+ipc = private
+port_1 = 8080:80
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -E '8080:80' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[network] port_* under mode=host is silently dropped" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[network]
+mode = host
+ipc = host
+port_1 = 8080:80
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -c '8080:80' '${TEMP_DIR}/compose.yaml' || true
+  "
+  assert_output "0"
+}
+
+# ── [resources] ──────────────────────────────────────────────────────
+
+@test "[resources] shm_size = 2gb under ipc=private emits shm_size: 2gb" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[network]
+ipc = private
+[resources]
+shm_size = 2gb
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -E 'shm_size: 2gb' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[resources] shm_size empty omits shm_size line" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[resources]
+shm_size =
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -c 'shm_size:' '${TEMP_DIR}/compose.yaml' || true
+  "
+  assert_output "0"
+}
+
+# ── [environment] ────────────────────────────────────────────────────
+
+@test "[environment] env_1 = ROS_DOMAIN_ID=7 emits environment: block in compose" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[environment]
+env_1 = ROS_DOMAIN_ID=7
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -F 'ROS_DOMAIN_ID=7' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[environment] empty section omits environment: block" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[environment]
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -c '^    environment:' '${TEMP_DIR}/compose.yaml' || true
+  "
+  assert_output "0"
+}
+
+# ── [tmpfs] ──────────────────────────────────────────────────────────
+
+@test "[tmpfs] tmpfs_1 = /tmp emits tmpfs: block with the entry" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[tmpfs]
+tmpfs_1 = /tmp
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -E '^      - /tmp$' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[tmpfs] tmpfs_1 with size= suffix preserved verbatim" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[tmpfs]
+tmpfs_1 = /tmp/cache:size=1g
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -F '/tmp/cache:size=1g' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[tmpfs] empty section omits tmpfs: block" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[tmpfs]
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -c '^    tmpfs:' '${TEMP_DIR}/compose.yaml' || true
+  "
+  assert_output "0"
+}
+
+# ── [devices] ────────────────────────────────────────────────────────
+
+@test "[devices] device_1 = /dev/video0:/dev/video0 emits devices: block" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[devices]
+device_1 = /dev/video0:/dev/video0
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -E -- '- /dev/video0:/dev/video0' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[devices] cgroup_rule_1 emits device_cgroup_rules: block" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[devices]
+device_1 = /dev:/dev
+cgroup_rule_1 = c 189:* rwm
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -F 'c 189:* rwm' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+# ── [volumes] mount_2..N ─────────────────────────────────────────────
+
+@test "[volumes] mount_2 = /data:/data emits as additional volume entry" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[volumes]
+mount_1 =
+mount_2 = /data:/data
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -E -- '- /data:/data' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+@test "[volumes] mount_N supports :ro suffix" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[volumes]
+mount_1 =
+mount_2 = /etc/machine-id:/etc/machine-id:ro
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -F '/etc/machine-id:/etc/machine-id:ro' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
+# ── [security] privileged toggle ─────────────────────────────────────
+
+@test "[security] privileged = false writes PRIVILEGED=false to .env" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[security]
+privileged = false
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep '^PRIVILEGED=' '${TEMP_DIR}/.env'
+  "
+  assert_output "PRIVILEGED=false"
+}


### PR DESCRIPTION
## Summary

Closes #202. Adds 25 setting-to-output tests covering every key documented in `template/setup.conf` that wasn't already exercised end-to-end. Stacked on top of #201 (already merged) so the new fixtures use the post-#201 single `setup.conf` layout.

### What's new

Each test sets a single key in `<repo>/setup.conf`, runs `main apply`, and asserts the expected line appears in `compose.yaml` or `.env`. Companion negative tests confirm the corresponding compose / env block is omitted when the key is empty / cleared.

| Section | Tests | Coverage |
|---|---|---|
| `[deploy]` | 6 | `gpu_mode` (off/force) → deploy block emit/omit, `gpu_count` (`2`) → `count: 2`, `gpu_capabilities` (multi-value) → YAML array, `runtime` (nvidia/off) → service-level `runtime:` |
| `[gui]` | 2 | `mode = off` omits DISPLAY/X11; `mode = force` emits `/tmp/.X11-unix:/tmp/.X11-unix:ro` |
| `[network]` | 5 | `mode` → `NETWORK_MODE` in .env, `ipc` → `IPC_MODE` in .env, `network_name` under bridge → `networks:` block, `port_1` under bridge → emitted, `port_*` under host → silently dropped |
| `[resources]` | 2 | `shm_size = 2gb` under `ipc=private` → `shm_size: 2gb`, empty value → omitted |
| `[environment]` | 2 | `env_1` → `environment:` block with entry, empty section → no block |
| `[tmpfs]` | 3 | plain `/tmp` entry, `size=` suffix preserved, empty section → no block |
| `[devices]` | 2 | `device_*` → `devices:` block, `cgroup_rule_*` → `device_cgroup_rules:` block |
| `[volumes]` | 2 | `mount_2..N` extras land in volumes list, `:ro` suffix preserved |
| `[security]` | 1 | `privileged = false` → `PRIVILEGED=false` in .env |

### Existing coverage (untouched)

- `[image]` — rule engine + sanitization
- `[build]` — `arg_N`, `target_arch`, `network`, back-compat
- `[security]` — cap_add / security_opt fallback + override
- `[volumes]` — `mount_1` workspace bootstrap
- `[additional_contexts]` — parse + emit (added in #199)

Total: **923 tests** (869 unit + 54 integration), all green.

### Why now

These tests guard against silent regressions when `setup.sh` evolves. Today, a breaking change to (say) the `[gui] mode = force` emission path would only surface when a downstream repo's GUI stopped working in production. With these tests, the regression is caught at PR time. They also serve as live documentation: each test demonstrates exactly what `setup.conf` value produces what compose/env line.

The architecture change in #201 (collapse to 2-file model) was a natural moment to add this — fixtures all use the single `setup.conf`, so the test bodies are short and uniform.

## Test plan

- [ ] Self Test green on this PR
- [ ] After merge: cut `v0.16.0` bundling #199 (additional_contexts) + #201 (architecture redesign + bootstrap fix) + #202 (per-section coverage)
- [ ] After tag: run `.claude/scripts/migrate-local-to-setupconf.sh --dry-run env/ros_noetic app/ros1_bridge`, verify, then real run; if green, fanout to remaining 15 repos via `/batch-template-upgrade v0.16.0`
