### PR TITLE
fix(build-worker): align user build-args with Dockerfile.example long-form names (closes #198)

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -203,10 +203,10 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: false
           build-args: |
-            USER=ci
-            GROUP=ci
-            UID=1000
-            GID=1000
+            USER_NAME=ci
+            USER_GROUP=ci
+            USER_UID=1000
+            USER_GID=1000
             HARDWARE=${{ matrix.hardware }}
             TEST_TOOLS_IMAGE=ghcr.io/ycpss91255-docker/test-tools:${{ inputs.test_tools_version }}
             ${{ inputs.build_args }}
@@ -220,10 +220,10 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: false
           build-args: |
-            USER=ci
-            GROUP=ci
-            UID=1000
-            GID=1000
+            USER_NAME=ci
+            USER_GROUP=ci
+            USER_UID=1000
+            USER_GID=1000
             HARDWARE=${{ matrix.hardware }}
             ${{ inputs.build_args }}
 
@@ -237,10 +237,10 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: false
           build-args: |
-            USER=ci
-            GROUP=ci
-            UID=1000
-            GID=1000
+            USER_NAME=ci
+            USER_GROUP=ci
+            USER_UID=1000
+            USER_GID=1000
             ${{ inputs.build_args }}
 
   # ────────────────────────────────────────────────────────────────

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v0.16.0] - 2026-04-30
+### Fixed
+- **`build-worker.yaml` user build-args now match `Dockerfile.example` sys-stage names** (#198). Pre-fix the workflow passed `USER=ci` / `GROUP=ci` / `UID=1000` / `GID=1000` (short form) to all 3 `docker/build-push-action` calls, while `Dockerfile.example`'s sys stage `useradd` reads `USER_NAME` / `USER_GROUP` / `USER_UID` / `USER_GID` (long form, also what the same workflow's "Generate .env" step writes). Result: `useradd` created `user` (the Dockerfile default), but the devel stage's `ARG USER="${USER_NAME}"` got overridden by the build-arg `USER=ci` so `USER "${USER}"` switched the image to UID-with-no-passwd-entry, exploding any subsequent `RUN` that resolved the username — `seggpt`'s CI hit `unable to find user ci: no matching entries in passwd file`. Fix: rename the 12 build-args lines (3 steps × 4 args) to long form so they hit the Dockerfile's sys-stage ARGs directly. No downstream Dockerfile change required (every existing `Dockerfile.example`-derived Dockerfile already declares the long-form ARGs). Coverage: 5 new `build_worker_yaml_spec.bats` tests lock the long-form invariant + assert no short-form regression.
 
 Minor release bundling three setup.conf-area changes. Includes a
 **BREAKING** restructure: `setup.conf.local` (introduced in #174) is

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **923 tests** total (869 unit + 54 integration).
+Template self-tests: **928 tests** total (874 unit + 54 integration).
 
 ## Test Files
 
@@ -130,7 +130,7 @@ target areas the issue body called out.
 | `_edit_section_deploy` (off short-circuits — only writes gpu_mode) | 1 |
 | Multi-section dispatch from main menu (network → host → save) | 1 |
 
-### test/unit/build_worker_yaml_spec.bats (7)
+### test/unit/build_worker_yaml_spec.bats (12)
 
 Structural assertions for `.github/workflows/build-worker.yaml` (#195).
 Reusable workflows are not exec'd by these tests; instead grep
@@ -148,6 +148,7 @@ steps forwarding those inputs, and no leftover `context: .` /
 | No leftover `context: .` literals | 1 |
 | No leftover `file: ./Dockerfile` literals | 1 |
 | Default values together preserve repo-root-Dockerfile callers | 1 |
+| User build-args use long form matching Dockerfile.example sys stage (#198: USER_NAME / USER_GROUP / USER_UID / USER_GID across 3 build steps + no short-form regression) | 5 |
 
 ### test/unit/build_sh_spec.bats (35)
 

--- a/test/unit/build_worker_yaml_spec.bats
+++ b/test/unit/build_worker_yaml_spec.bats
@@ -88,3 +88,43 @@ setup() {
   [[ "${_ctx}" == *'"."'* ]]
   [[ "${_df}" == *'""'* ]]
 }
+
+# ── User build-args alignment with Dockerfile.example (#198) ──────────
+
+@test "build-worker.yaml: 3 build steps pass USER_NAME=ci (long form, matching Dockerfile.example sys stage)" {
+  # Pre-#198 the workflow passed `USER=ci` (short form) which the
+  # Dockerfile only sees in the devel stage; the sys-stage useradd
+  # reads USER_NAME and stuck on the default "user". The container
+  # then USER-switched to "ci" with no /etc/passwd entry, exploding
+  # any RUN that resolved the username.
+  run grep -c '^            USER_NAME=ci$' "${WF}"
+  assert_success
+  assert_output "3"
+}
+
+@test "build-worker.yaml: 3 build steps pass USER_GROUP=ci (long form)" {
+  run grep -c '^            USER_GROUP=ci$' "${WF}"
+  assert_success
+  assert_output "3"
+}
+
+@test "build-worker.yaml: 3 build steps pass USER_UID=1000 (long form)" {
+  run grep -c '^            USER_UID=1000$' "${WF}"
+  assert_success
+  assert_output "3"
+}
+
+@test "build-worker.yaml: 3 build steps pass USER_GID=1000 (long form)" {
+  run grep -c '^            USER_GID=1000$' "${WF}"
+  assert_success
+  assert_output "3"
+}
+
+@test "build-worker.yaml: no short-form USER=/GROUP=/UID=/GID= build-args (regression #198)" {
+  # The Generate-.env step at the top of the workflow uses long-form
+  # writes via `printf 'USER_NAME=...'`; only build-args lines (8-space
+  # indent inside the build steps) are at risk. Anchor on that
+  # indentation to avoid false positives from the env-file write.
+  run grep -E '^            (USER|GROUP|UID|GID)=' "${WF}"
+  [ "${status}" -ne 0 ] || [ -z "${output}" ]
+}


### PR DESCRIPTION
## Summary

Closes #198. `build-worker.yaml`'s 3 `docker/build-push-action` calls passed `USER=ci` / `GROUP=ci` / `UID=1000` / `GID=1000` (short form) as build-args, while `Dockerfile.example`'s sys-stage `useradd` reads `USER_NAME` / `USER_GROUP` / `USER_UID` / `USER_GID` (long form — also what the same workflow's "Generate .env" step writes). The mismatch caused CI failures on any downstream Dockerfile derived from `Dockerfile.example`.

### Bug trace

1. CI passes `USER=ci`. Sys-stage `useradd` reads `USER_NAME` (default `"user"`) because no build-arg overrides it. The image therefore has a real user named `user`, not `ci`.
2. Devel stage's `ARG USER="${USER_NAME}"` is overridden by the build-arg `USER=ci`, so `USER "${USER}"` directive switches container to `ci`.
3. `ci` has no `/etc/passwd` entry. Subsequent `RUN`s that resolve the username (e.g. `seggpt`'s `pip/setup.sh`) explode with `unable to find user ci: no matching entries in passwd file`.

### Fix (Option A from the issue body)

Rename the 12 build-args lines (3 steps × 4 args) in `.github/workflows/build-worker.yaml` to long form:

```diff
           build-args: |
-            USER=ci
-            GROUP=ci
-            UID=1000
-            GID=1000
+            USER_NAME=ci
+            USER_GROUP=ci
+            USER_UID=1000
+            USER_GID=1000
```

Matches what the same workflow's "Generate .env" step already writes (`USER_NAME=ci` etc.), and every `Dockerfile.example`-derived downstream Dockerfile already declares the long-form ARGs — **zero downstream code change required**.

### Tests

5 new `build_worker_yaml_spec.bats` tests:

| Test | Purpose |
|---|---|
| `3 build steps pass USER_NAME=ci (long form, matching Dockerfile.example sys stage)` | Locks the fix |
| `3 build steps pass USER_GROUP=ci (long form)` | Same for GROUP |
| `3 build steps pass USER_UID=1000 (long form)` | Same for UID |
| `3 build steps pass USER_GID=1000 (long form)` | Same for GID |
| `no short-form USER=/GROUP=/UID=/GID= build-args (regression #198)` | Catches reverts |

The negative regression test anchors on the 12-space indent unique to build-args lines, so it doesn't false-positive on the `printf 'USER_NAME=...'` line in the `.env` write step.

Total: 928 tests (874 unit + 54 integration), all green.

### Backwards compatibility

The long-form names match what every existing `Dockerfile.example`-derived downstream already expects via its sys-stage ARG declarations. No downstream Dockerfile change required. The `seggpt` repo (which prompted this issue) keeps its existing Dockerfile unchanged once it picks up `v0.16.x`.

## Test plan

- [ ] Self Test green on this PR (full Bats unit + integration suite, including the 5 new structural tests)
- [ ] Reviewer eyeballs the YAML diff: 12 build-args renamed, no other lines touched
- [ ] After merge: cut a v0.16.1 patch tag (or fold into the next minor) so downstream `seggpt` (and any other repo whose CI hit this) can pick up the fix
