### PR TITLE
feat(setup): print Variables block mapping setup.conf placeholders to detected values

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`build.sh` / `run.sh` config summary now prints a `Variables` block** mapping `setup.conf` `[volumes]` placeholders (`${USER_NAME}` / `${USER_UID}` / `${USER_GROUP}` / `${USER_GID}` / `${WS_PATH}`) to their detected runtime values. Pre-fix the Identity block showed resolved values under translated labels (`使用者 : alice` / `工作區 : /home/alice/work`), while the `setup.conf` dump printed the raw `${USER_NAME}` / `${WS_PATH}` placeholders, leaving the user to derive the substitution table. The new block sits between Identity and `setup.conf` in `_print_config_summary` and gives an explicit one-line-per-variable map. setup.conf stays the source of truth (placeholder form unchanged); the block adds 5 more lines to the printout. Coverage: 2 new unit tests in `lib_spec.bats` (populated case + unset-fallback case) and a new `variables` i18n key (en / zh-TW / zh-CN / ja).
+
 ## [v0.16.2] - 2026-05-04
 
 Patch release. Single seed-template alignment fix for `Dockerfile.example`.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,10 +1,10 @@
 # TEST.md
 
-Template self-tests: **933 tests** total (879 unit + 54 integration).
+Template self-tests: **935 tests** total (881 unit + 54 integration).
 
 ## Test Files
 
-### test/unit/lib_spec.bats (39)
+### test/unit/lib_spec.bats (41)
 
 | Test | Description |
 |------|-------------|
@@ -31,6 +31,8 @@ Template self-tests: **933 tests** total (879 unit + 54 integration).
 | `_dump_conf_section returns silent empty for missing file` | Missing file |
 | `_dump_conf_section returns silent empty for unknown section` | Missing section |
 | `_print_config_summary prints files, identity, all populated sections, resolved` | Full config dump |
+| `_print_config_summary prints Variables block mapping setup.conf placeholders to detected values` | Variables block populated |
+| `_print_config_summary Variables block falls back to '-' for unset values` | Variables fallback |
 | `_print_config_summary hides sections that are empty in setup.conf` | Empty-section skip |
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
 | `_print_config_summary warns when setup.conf exists but has no [section] headers` | #157 empty-conf hint on build/run summary |

--- a/script/docker/_lib.sh
+++ b/script/docker/_lib.sh
@@ -115,6 +115,10 @@ _lib_msg() {
     zh-CN:resolved)          echo "解析结果" ;;
     ja:resolved)             echo "解決済み" ;;
     *:resolved)              echo "Resolved" ;;
+    zh-TW:variables)         echo "變數對映" ;;
+    zh-CN:variables)         echo "变量映射" ;;
+    ja:variables)            echo "変数マッピング" ;;
+    *:variables)             echo "Variables" ;;
     # Identity field labels
     zh-TW:user)              echo "使用者" ;;
     zh-CN:user)              echo "用户" ;;
@@ -220,6 +224,19 @@ _print_config_summary() {
   printf "[%s]   %-12s : %s\n" "${_tag}" "$(_lib_msg image_tag)" "${_img}"
   printf "[%s]   %-12s : %s\n" "${_tag}" "$(_lib_msg project)" "${_proj}"
   printf "[%s]   %-12s : %s\n" "${_tag}" "$(_lib_msg workspace)" "${WS_PATH:--}"
+
+  # Variables block: explicit map from setup.conf placeholders to the
+  # detected runtime values. Identity prints the resolved values with
+  # i18n labels (e.g. "使用者 : alice"); the [volumes] dump prints raw
+  # `${USER_NAME}` / `${WS_PATH}` placeholders. This block bridges the
+  # two so users can read mount_* lines without re-deriving the mapping
+  # from translated labels.
+  printf "[%s] %s\n" "${_tag}" "$(_lib_msg variables)"
+  printf "[%s]   \${USER_NAME} = %s\n"  "${_tag}" "${USER_NAME:--}"
+  printf "[%s]   \${USER_UID}  = %s\n"  "${_tag}" "${USER_UID:--}"
+  printf "[%s]   \${USER_GROUP} = %s\n" "${_tag}" "${USER_GROUP:--}"
+  printf "[%s]   \${USER_GID}  = %s\n"  "${_tag}" "${USER_GID:--}"
+  printf "[%s]   \${WS_PATH}   = %s\n"  "${_tag}" "${WS_PATH:--}"
 
   # setup.conf section-by-section dump. Each section prints only if
   # non-empty to stay readable. Order matches the TUI main menu so

--- a/test/unit/lib_spec.bats
+++ b/test/unit/lib_spec.bats
@@ -336,6 +336,50 @@ EOF
   assert_output --partial "./setup_tui.sh"
 }
 
+@test "_print_config_summary prints Variables block mapping setup.conf placeholders to detected values" {
+  # The Identity block already shows resolved user/workspace, but the
+  # setup.conf [volumes] dump prints raw `${WS_PATH}` / `${USER_NAME}`
+  # placeholders. Variables block bridges the gap so users can map the
+  # placeholder to the value at a glance without re-deriving from
+  # Identity field labels.
+  local _fp="${BATS_TEST_TMPDIR}"
+  _write_sample_conf "${_fp}/setup.conf"
+  run bash -c "
+    source ${LIB}
+    FILE_PATH='${_fp}'
+    USER_NAME=alice USER_UID=1000 USER_GROUP=alice USER_GID=1000
+    HARDWARE=x86_64 DOCKER_HUB_USER=alice IMAGE_NAME=myrepo
+    WS_PATH=/home/alice/work
+    GPU_ENABLED=true GPU_COUNT=all GPU_CAPABILITIES='gpu compute'
+    SETUP_GUI_DETECTED=true NETWORK_MODE=host IPC_MODE=host PRIVILEGED=false
+    TZ=Asia/Taipei APT_MIRROR_UBUNTU=tw.archive.ubuntu.com
+    APT_MIRROR_DEBIAN=mirror.twds.com.tw
+    PROJECT_NAME=alice-myrepo
+    _print_config_summary build
+  "
+  assert_success
+  assert_output --partial "Variables"
+  assert_output --partial "\${USER_NAME} = alice"
+  assert_output --partial "\${USER_UID}  = 1000"
+  assert_output --partial "\${USER_GROUP} = alice"
+  assert_output --partial "\${USER_GID}  = 1000"
+  assert_output --partial "\${WS_PATH}   = /home/alice/work"
+}
+
+@test "_print_config_summary Variables block falls back to '-' for unset values" {
+  local _fp="${BATS_TEST_TMPDIR}"
+  _write_sample_conf "${_fp}/setup.conf"
+  run bash -c "
+    source ${LIB}
+    FILE_PATH='${_fp}'
+    unset USER_NAME USER_UID USER_GROUP USER_GID WS_PATH
+    _print_config_summary build
+  "
+  assert_success
+  assert_output --partial "\${USER_NAME} = -"
+  assert_output --partial "\${WS_PATH}   = -"
+}
+
 @test "_print_config_summary hides sections that are empty in setup.conf" {
   local _fp="${BATS_TEST_TMPDIR}"
   # Minimal conf with only [image]; expect no [build]/[volumes] headers


### PR DESCRIPTION
## Summary

Adds a `Variables` block to `_print_config_summary` (the config dump shown by `build.sh` / `run.sh`) that maps `setup.conf` `[volumes]` placeholders to their detected runtime values.

### Why

Pre-fix, the config printout had this asymmetry:

```
[build] Identity
[build]   user         : yunchien (uid=1000)  ...
[build]   workspace    : /home/.../coresam_ws
[build] setup.conf
[build]   [volumes]
[build]     mount_1 = ${WS_PATH}/src/seggpt:/home/${USER_NAME}/work
```

- Identity prints **resolved values under i18n field labels** (`user : yunchien` / `workspace : /home/.../coresam_ws`, with the `user` / `workspace` label translated when `_LANG` is non-en)
- `setup.conf` dump prints **raw placeholders** (`${WS_PATH}` / `${USER_NAME}`)

Users had to mentally re-derive `${USER_NAME} = yunchien` and `${WS_PATH} = /home/.../coresam_ws` from the i18n labels. With i18n turned on (zh-TW / zh-CN / ja) the mapping was even less obvious because the label changes per language while the placeholder stays in English.

### Fix

New block sits between Identity and `setup.conf`:

```
[build] Variables
[build]   ${USER_NAME} = yunchien
[build]   ${USER_UID}  = 1000
[build]   ${USER_GROUP} = yunchien
[build]   ${USER_GID}  = 1000
[build]   ${WS_PATH}   = /home/.../coresam_ws
```

- `setup.conf` stays the source of truth — placeholder form in `[volumes] mount_*` is unchanged
- Block is purely additive: 1 section header + 5 value lines, ~7 lines total
- Same 5 vars regardless of which placeholders the active `setup.conf` references — keeps the printout stable across repos
- New `variables` i18n key (`en` / `zh-TW` / `zh-CN` / `ja`) covers the section header

### Files changed

- `script/docker/_lib.sh`
  - `_lib_msg`: add `variables` key (4 languages)
  - `_print_config_summary`: 6 `printf` lines after the existing Identity `workspace` line, before the setup.conf dump
- `test/unit/lib_spec.bats`: 2 new tests (populated case + unset-fallback case)
- `doc/test/TEST.md`: 933 → 935 total, `lib_spec.bats` 39 → 41
- `doc/changelog/CHANGELOG.md`: `[Unreleased]` `### Added` entry

### Tests

`make -f Makefile.ci test` (Docker): **935 tests** (881 unit + 54 integration), all green. ShellCheck clean.

## Test plan

- [ ] Self Test green (full Bats unit + integration suite + ShellCheck + Hadolint)
- [ ] Reviewer eyeballs the diff: 5 new value lines under a new section header, no existing behavior touched
- [ ] After merge: future `build.sh` / `run.sh` invocations print the new block
