### PR TITLE
docs(test): purge 7 stale TEST.md rows + add Smoke Tests section

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+- **`doc/test/TEST.md` cleanup**: removed 7 stale rows referencing tests that no longer exist (all referencing the obsolete `template/VERSION` / `.template_version` migration completed in v0.16) and renamed 5 rows whose underlying test was renamed (e.g. `_create_symlinks: produces all five docker-script symlinks` → `…all seven docker-script symlinks`, `_detect_template_version: reads VERSION file when present` → `…reads .version file when present`). Added a 27-test `## Smoke Tests` section documenting `test/smoke/script_help.bats` (16) and `test/smoke/display_env.bats` (11), which run at Dockerfile `test`-stage build time and are intentionally excluded from the headline 935-test self-test count. Headline now carries an explicit note clarifying scope. No code change.
+
 ### Added
 - **`build.sh` / `run.sh` config summary now prints a `Variables` block** mapping `setup.conf` `[volumes]` placeholders (`${USER_NAME}` / `${USER_UID}` / `${USER_GROUP}` / `${USER_GID}` / `${WS_PATH}`) to their detected runtime values. Pre-fix the Identity block showed resolved values under translated labels (`使用者 : alice` / `工作區 : /home/alice/work`), while the `setup.conf` dump printed the raw `${USER_NAME}` / `${WS_PATH}` placeholders, leaving the user to derive the substitution table. The new block sits between Identity and `setup.conf` in `_print_config_summary` and gives an explicit one-line-per-variable map. setup.conf stays the source of truth (placeholder form unchanged); the block adds 5 more lines to the printout. Coverage: 2 new unit tests in `lib_spec.bats` (populated case + unset-fallback case) and a new `variables` i18n key (en / zh-TW / zh-CN / ja).
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -2,6 +2,14 @@
 
 Template self-tests: **935 tests** total (881 unit + 54 integration).
 
+> Counted scope is the `make -f Makefile.ci test` self-test suite —
+> what runs in the `Self Test` CI job. The 27 shared smoke tests under
+> `test/smoke/` are a separate suite that runs at Dockerfile `test`-stage
+> build time (via `./build.sh test`) inside both this repo and every
+> downstream repo, and are documented in [Smoke Tests](#smoke-tests)
+> below. They are **not** included in the 935 figure because they are
+> build-time assertions, not self-tests.
+
 ## Test Files
 
 ### test/unit/lib_spec.bats (41)
@@ -345,11 +353,10 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `exec.sh -h works when i18n.sh is missing` | i18n fallback |
 | `stop.sh -h works when i18n.sh is missing` | i18n fallback |
 | `setup.sh does not redefine _detect_lang` | No duplication |
-| `VERSION file exists in template root` | Version file check |
-| `upgrade.sh reads version from template/VERSION` | VERSION path |
-| `upgrade.sh does not write .template_version` | No legacy write |
+| `.version file exists in template root` | Version file check |
+| `upgrade.sh reads version from template/.version` | .version path |
+| `upgrade.sh does not reference legacy VERSION or .template_version` | Legacy refs purged |
 | `upgrade.sh runs init.sh after subtree pull` | Sync symlinks |
-| `upgrade.sh cleans up legacy .template_version` | Legacy cleanup |
 | `upgrade.sh supports --gen-conf flag` | Flag exists |
 | `upgrade.sh --gen-conf delegates to init.sh --gen-conf` | Delegation |
 | `upgrade.sh --help mentions --gen-conf` | Help text |
@@ -445,15 +452,13 @@ are hard to trigger from a real `bash template/init.sh` invocation
 | `_detect_template_version: returns empty when git ls-remote fails` | Network-down fallback |
 | `_detect_template_version: returns empty when no v*.*.* tags exist` | Nothing to match |
 | `_detect_template_version: ignores non-semver tags (e.g. rc suffixes)` | Regex filters rc / pre-release |
-| `_detect_template_version: reads VERSION file when present (no network)` | VERSION file priority |
-| `_detect_template_version: VERSION file takes priority over git ls-remote` | Local-first resolution |
-| `init.sh removes legacy .template_version when present` | Legacy cleanup |
-| `init.sh succeeds when no legacy .template_version exists` | Clean state |
+| `_detect_template_version: reads .version file when present (no network)` | .version file priority |
+| `_detect_template_version: .version file takes priority over git ls-remote` | Local-first resolution |
 | `_create_new_repo: main.yaml uses given ref in workflow @ref` | Ref threading |
 | `_create_new_repo: main.yaml falls back to @main when ref arg omitted` | Default ref |
 | `_create_new_repo: main.yaml falls back to @main when ref arg is empty` | Empty-string → `@main` |
-| `_create_new_repo: generates .env.example with IMAGE_NAME=<repo>` | Fallback image name |
-| `_create_symlinks: produces all five docker-script symlinks` | Symlink set |
+| `_create_new_repo: does NOT generate .env.example (image name via setup.conf)` | setup.conf rules drive IMAGE_NAME |
+| `_create_symlinks: produces all seven docker-script symlinks` | Symlink set |
 | `_create_symlinks: replaces a stale file at the symlink path` | Re-init over existing files |
 | `_create_symlinks: keeps custom .hadolint.yaml when it differs` | Custom-hadolint preservation |
 
@@ -637,7 +642,7 @@ which has access to a Docker daemon on the host runner.
 | `init.sh detects empty dir and creates new repo skeleton` | Smoke |
 | `new repo: Dockerfile is copied from template` | Dockerfile gen |
 | `new repo: compose.yaml exists and references the repo name` | compose gen |
-| `new repo: .env.example contains IMAGE_NAME=<reponame>` | env fallback |
+| `new repo: .env.example is NOT generated (image name via setup.conf rules)` | setup.conf rules drive IMAGE_NAME |
 | `new repo: script/entrypoint.sh exists and is executable` | entrypoint gen |
 | `new repo: smoke test skeleton exists for the repo` | smoke skeleton |
 | `new repo: .github/workflows/main.yaml exists with reusable workflow ref` | CI gen |
@@ -647,7 +652,7 @@ which has access to a Docker daemon on the host runner.
 | `new repo: doc/changelog/CHANGELOG.md exists` | CHANGELOG gen |
 | `new repo: build.sh symlink → template/script/docker/build.sh` | symlink target |
 | `new repo: run.sh / exec.sh / stop.sh / Makefile symlinks correct` | symlink set |
-| `new repo: template/VERSION exists (no legacy .template_version)` | version file |
+| `new repo: template/.version exists (no legacy VERSION / .template_version)` | version file |
 | `new repo: re-running init.sh on the result is idempotent` | idempotent |
 | `new repo: init.sh creates setup_tui.sh symlink (not legacy tui.sh)` | post-rename symlink |
 | `new repo: init.sh removes stale tui.sh symlink from earlier versions` | upgrade cleanup |
@@ -660,7 +665,7 @@ which has access to a Docker daemon on the host runner.
 | `new repo: .gitignore contains compose.yaml (derived artifact)` | gitignore compose.yaml |
 | `new repo: .gitignore contains .env (derived artifact)` | gitignore .env |
 | `new repo: compose.yaml has AUTO-GENERATED header (produced by setup.sh)` | setup.sh generated compose.yaml |
-| `new repo: per-repo setup.conf not created by default` | template default usage |
+| `new repo: per-repo setup.conf auto-created on first init (workspace writeback)` | #201 — bootstrap writes WS_PATH back |
 
 ### test/integration/fresh_clone_portability_spec.bats (2)
 
@@ -716,3 +721,79 @@ gitignore sync requires the **real** `init.sh` to run during Step 3 of
 | `init.sh existing-repo: idempotent — second run produces no .gitignore changes` | Re-run no-op |
 | `upgrade.sh end-to-end: synced .gitignore + untracked compose.yaml in single commit` | One-shot upgrade |
 | `upgrade.sh end-to-end: idempotent on a second run — no extra commits` | Re-upgrade clean |
+
+## Smoke Tests
+
+Shared specs that ship with `template/test/smoke/` and run at Dockerfile
+`test`-stage build time (i.e. during `./build.sh test`) inside both this
+repo and every downstream repo that consumes the template. They assert
+the integrity of the generated `compose.yaml` + the wrapper scripts'
+`-h` / `--help` paths. **Not** part of the 935-test self-test count
+(those run via `make -f Makefile.ci test` and never enter the build
+graph).
+
+How they reach downstream repos: each `Dockerfile`'s `test` stage does
+
+```dockerfile
+COPY template/test/smoke/ /smoke_test/
+COPY test/smoke/ /smoke_test/
+RUN bats /smoke_test/
+```
+
+so the shared specs and any per-repo `test/smoke/` overlay execute
+together. `display_env.bats` self-skips on headless repos by detecting
+the absence of GUI lines in the generated `compose.yaml`.
+
+### test/smoke/script_help.bats (16)
+
+Locks the `-h` / `--help` invariants on the four wrapper scripts
+(`build.sh` / `run.sh` / `exec.sh` / `stop.sh`) plus the `_LANG`
+auto-detection rules in `build.sh` (`LANG=zh_TW.UTF-8` → zh, `ja_JP`
+→ ja, `en_US` → en, `SETUP_LANG` overrides `LANG`).
+
+| Test | Description |
+|------|-------------|
+| `build.sh -h exits 0` | Wrapper smoke |
+| `build.sh --help exits 0` | Long flag |
+| `build.sh -h prints usage` | Output sanity |
+| `run.sh -h exits 0` | Wrapper smoke |
+| `run.sh --help exits 0` | Long flag |
+| `run.sh -h prints usage` | Output sanity |
+| `exec.sh -h exits 0` | Wrapper smoke |
+| `exec.sh --help exits 0` | Long flag |
+| `exec.sh -h prints usage` | Output sanity |
+| `stop.sh -h exits 0` | Wrapper smoke |
+| `stop.sh --help exits 0` | Long flag |
+| `stop.sh -h prints usage` | Output sanity |
+| `build.sh detects zh from LANG=zh_TW.UTF-8` | i18n detect — zh-TW |
+| `build.sh detects ja from LANG=ja_JP.UTF-8` | i18n detect — ja |
+| `build.sh defaults to en for LANG=en_US.UTF-8` | i18n detect — en default |
+| `build.sh SETUP_LANG overrides LANG` | i18n env override |
+
+### test/smoke/display_env.bats (11)
+
+Asserts the generated `compose.yaml` carries the X11 / Wayland env
++ volume block expected by GUI containers, and that `run.sh` runs the
+right `xhost` command per session type. Auto-skipped when the repo's
+`compose.yaml` has no GUI block (headless repos like `multi_run`).
+
+| Test | Description |
+|------|-------------|
+| `compose.yaml contains WAYLAND_DISPLAY env` | Wayland env line |
+| `compose.yaml contains XDG_RUNTIME_DIR env` | Wayland session dir env |
+| `compose.yaml contains XAUTHORITY env` | X11 auth env |
+| `compose.yaml mounts XDG_RUNTIME_DIR as rw` | Wayland socket mount |
+| `compose.yaml mounts XAUTHORITY volume` | X11 auth mount |
+| `compose.yaml has no consecutive duplicate keys` | YAML hygiene |
+| `compose.yaml mounts X11-unix volume` | X11 socket mount |
+| `run.sh contains XDG_SESSION_TYPE check` | Session-type branch |
+| `run.sh calls xhost +SI:localuser on wayland` | Wayland xhost path |
+| `run.sh calls xhost +local: on X11` | X11 xhost path |
+| `run.sh defaults to X11 xhost when XDG_SESSION_TYPE unset` | Fallback path |
+
+### test/smoke/test_helper.bash
+
+Not a spec — runtime helper (`assert_compose_has` / `skip_if_headless`
+etc.) loaded by every smoke spec via `load "${BATS_TEST_DIRNAME}/test_helper"`.
+Asserts in this file are exercised via `test/unit/smoke_helper_spec.bats`
+(which IS in the 935 self-test count).


### PR DESCRIPTION
## Summary

Doc-only cleanup of `doc/test/TEST.md`. Two changes:

1. **Purge stale rows** — 12 row entries referenced tests that no longer exist or have been renamed.
2. **Add Smoke Tests section** — 27 previously-undocumented smoke tests now have a dedicated section with an explicit explanation of why they're not in the headline self-test count.

No code change. No version bump. No downstream fanout (per offline discussion: this is a docs-only correction, the downstream repos already shipped on v0.16.2 and don't reference `template/doc/test/TEST.md` at runtime).

### Why

While auditing the template post-v0.16.2 release I found:

- **7 fully stale rows** — all about the obsolete `template/VERSION` / `.template_version` migration completed in v0.16:
  - `VERSION file exists in template root` (test renamed to `.version file...`)
  - `upgrade.sh reads version from template/VERSION` (renamed to `template/.version`)
  - `upgrade.sh does not write .template_version` (consolidated into `upgrade.sh does not reference legacy VERSION or .template_version`)
  - `upgrade.sh cleans up legacy .template_version` (consolidated into the row above)
  - `init.sh removes legacy .template_version when present` (test removed outright; legacy cleanup no longer relevant)
  - `init.sh succeeds when no legacy .template_version exists` (same reason)
  - `new repo: template/VERSION exists (no legacy .template_version)` (renamed to `template/.version exists...`)

- **5 more stale rows** with renamed underlying tests:
  - `_detect_template_version: reads VERSION file when present` → `…reads .version file when present`
  - `_detect_template_version: VERSION file takes priority over git ls-remote` → `…\.version file takes priority`
  - `_create_new_repo: generates .env.example with IMAGE_NAME=<repo>` → `…does NOT generate .env.example (image name via setup.conf)` (#201 inverted the behaviour)
  - `_create_symlinks: produces all five docker-script symlinks` → `…all seven docker-script symlinks` (added `setup.sh` and `setup_tui.sh` symlinks)
  - `new repo: .env.example contains IMAGE_NAME=<reponame>` / `new repo: per-repo setup.conf not created by default` — both inverted by #201

- **27 undocumented smoke tests** — `test/smoke/script_help.bats` (16) and `test/smoke/display_env.bats` (11) ship inside the template subtree, run at Dockerfile `test`-stage build time (`./build.sh test`) inside both this repo and every downstream repo, and were not listed anywhere in TEST.md. Headline reads "**935 tests** total (881 unit + 54 integration)" — the 27 smoke tests are deliberately excluded because they're build-time assertions, not part of `make -f Makefile.ci test`. Without explanation this looked like an oversight.

### Files changed

- `doc/test/TEST.md`
  - Headline: same 935 figure, added a `>` blockquote note clarifying scope and pointing to the new Smoke Tests section
  - `template_spec.bats` table: 5 rows → 4 rows (3 renamed, 2 consolidated into 1)
  - `init_spec.bats` table: 9 rows → 7 rows (3 renamed, 2 deleted)
  - `init_new_repo_spec.bats` table: 3 rows fixed in place
  - New `## Smoke Tests` section near the end: explainer + 2 spec sub-sections (script_help.bats / display_env.bats) with one row per test + a note about `test_helper.bash` (helper, not a spec)

- `doc/changelog/CHANGELOG.md`: `[Unreleased]` `### Documentation` entry

### Verification

- Local audit script confirms 0 count-drift between TEST.md `### test/X.bats (N)` headers and `^@test` counts in each file (including the 2 newly-indexed smoke specs).
- Stale-name sweep across TEST.md confirms 0 rows reference any of the 12 known stale test names.
- `make -f Makefile.ci test` (Docker): **935 tests** (881 unit + 54 integration), all green. ShellCheck clean.

## Test plan

- [ ] Self Test green on this PR (sanity — no code touched)
- [ ] Reviewer eyeballs the diff: only `doc/test/TEST.md` and `doc/changelog/CHANGELOG.md` change; no code, no test files
- [ ] Spot-check 2-3 of the renamed rows against the actual `^@test` line in the corresponding `*.bats` file
