### PR TITLE
feat(setup): per-stage [stage:NAME] overrides for runtime knobs (#220)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,13 +204,62 @@ Constraints:
 - Names colliding with the baseline (`sys` / `base` / `devel` / `test`)
   are a hard error from `setup.sh apply`. So are names colliding with
   the template-controlled image-tag namespace (`latest`, `v[0-9]*`).
-- Per-stage diff (different volumes / GPU / network than `devel`) is
-  out of scope — declare via Dockerfile `ARG` + conditional `RUN`
-  instead. The `extends` baseline is the same for every emitted stage.
 - Adding / removing a stage triggers `setup.sh check-drift` (via
   `SETUP_DOCKERFILE_HASH` in `.env`), so wrappers auto-regenerate
   `compose.yaml` on the next invocation. Unrelated `RUN apt-get
   install` edits do **not** trigger drift.
+
+#### Per-stage `setup.conf` overrides (#220)
+
+Stages auto-emitted by #215 share devel's runtime config (volumes /
+GPU / network / GUI) by default. When a stage needs different runtime
+settings — e.g. NVIDIA Isaac Sim's `headless` running a WebRTC
+livestream wants `network=bridge` + a port mapping + `gui=off`, while
+`devel` and `gui` keep `network=host` + X11 — add a `[stage:<name>]`
+section to your repo's `setup.conf`:
+
+```ini
+[gui]
+mode = auto
+
+[network]
+mode = host
+
+[stage:headless]
+gui.mode = off
+network.mode = bridge
+network.port_1 = 8080:80
+deploy.gpu_capabilities = gpu compute utility graphics video
+```
+
+Use `./setup_tui.sh` → Advanced → "Per-stage overrides" for an
+interactive editor; the entry only appears when your Dockerfile has at
+least one non-baseline stage.
+
+Allowlist (v1 — keys that can be overridden per-stage):
+
+| Section | Keys |
+|---|---|
+| `[deploy]` | `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime` |
+| `[gui]` | `mode` |
+| `[network]` | `mode`, `ipc`, `network_name`, `port_<N>`, `port_inherit` |
+| `[security]` | `privileged` |
+| `[volumes]` | `mount_<N>`, `mount_inherit` |
+| `[environment]` | `env_<N>`, `env_inherit` |
+
+List fields (`mount_*` / `port_*` / `env_*`) follow **append-default**:
+the stage's items are appended to top-level entries. To replace
+top-level entirely, set `<list>_inherit = false` (e.g.
+`volumes.mount_inherit = false`).
+
+Notes:
+
+- `[stage:devel]` is **reserved** (v1 no-op + WARN). Edit top-level
+  sections to tune devel. Revisit in v2.
+- `[stage:sys|base|test]` is a **hard error** (baseline collision).
+- `[stage:foo]` referencing a stage absent from the Dockerfile is
+  **WARN + skipped** (the rest of `setup.sh apply` continues).
+- Override keys outside the allowlist are **WARN + skipped per-key**.
 
 ### Smoke test helpers (for downstream repos)
 

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Per-stage `setup.conf` overrides for runtime knobs** (#220). `[stage:<name>]` sections in `<repo>/setup.conf` override top-level settings on a per-stage basis when a corresponding `FROM ... AS <name>` stage exists in the Dockerfile (auto-emitted via #215). Driving use case: NVIDIA Isaac Sim's three-stage shape (`devel` for interactive dev with X11, `headless` for WebRTC livestream that needs `mode=bridge` + ports + GPU `video` capability + `gui=off`, `gui` for local-display that needs `gui=auto`) — previously all three stages shared one set of runtime knobs from top-level. Allowlist (v1):
+  - `[deploy]` whole section: `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime`
+  - `[gui] mode`
+  - `[network]` whole section: `mode`, `ipc`, `network_name`, `port_<N>` + `port_inherit` meta-key
+  - `[security] privileged`
+  - `[volumes] mount_<N>` + `mount_inherit` meta-key
+  - `[environment] env_<N>` + `env_inherit` meta-key
+  - Excluded by design: `[image_name]` (image tag is one per image, not per-stage), `apt_mirror_*` (build-time, not runtime), other `[security]` keys (no driving use case yet — re-evaluate v2).
+- **Append-default + opt-out merge semantics for list fields**: stage's `mount_*` / `port_*` / `env_*` items append to top-level by default; setting `<list>_inherit = false` switches to replace mode (drop top-level entries entirely). Reverse toggle preserves the stage's own entries in `setup.conf` so flipping back to inherit doesn't lose typed values.
+- **Stage section validator**: `[stage:sys|base|test]` is hard-error (baseline collision); `[stage:devel]` is reserved (v1 no-op, WARN; revisit in v2 — devel emits via env-var refs `${NETWORK_MODE}` / `${PRIVILEGED}` / `${IPC_MODE}` so override semantics are non-trivial); `[stage:foo]` referencing a stage absent from the Dockerfile is WARN + skipped; override keys outside the v1 allowlist are WARN + skipped per-key. 2 new 4-language i18n keys (`stage_unknown_referenced`, `stage_override_key_not_allowed`) supplementing #215's existing 3 keys.
+- **TUI integration in `setup_tui.sh`**: new "Per-stage overrides" entry under the Advanced menu, **only shown when the Dockerfile has at least one non-baseline stage** — zero noise for the 17 existing downstream repos. Submenu structure: stage list (with override-count label) → per-stage section picker (gui / deploy / network / volumes / environment) → typed editors for scalars and the existing list editor for `mount_*` / `port_*` / `env_*` plus an inherit-toggle row. ~14 new TUI i18n keys × 4 languages. Menu placement / restructure (potentially promoting per-stage to main menu after user feedback) tracked separately in #221.
+- **`_tui_conf.sh` writer extended to append NEW sections**: previously `_write_setup_conf` only handled overrides for sections present in the template. The first time a user adds `[stage:headless]` via TUI Save, the section is brand new; the writer now tracks template sections separately and appends new ones (with their keys, in user-input order) at end-of-file. Reader (`_load_setup_conf_full`) already handled stage sections via generic `<section>.<key>` namespacing — no change needed there.
+- **Compose-emit integration**: `generate_compose_yaml` validates `[stage:*]` sections after Dockerfile-stage validation, then for each non-baseline stage with overrides, emits the resolved effective values as inline overrides on top of the existing `extends: devel` block. Stages with no overrides keep the byte-for-byte identical zero-diff path from v0.17.0 (#215). gui changes force `environment:` + `volumes:` re-emit (compose extends's child-replaces-list semantics drop X11 baseline cleanly). gpu mode flip-on with new caps re-emits the `deploy:` block; v1 limitation: turning gpu off when devel has it on isn't representable via compose extends and is documented as deferred to v2.
+
+### Tests
+- Total: **1011 tests** (957 unit + 54 integration). 42 new tests since v0.17.0:
+  - `setup_spec.bats` +27: 20 helper unit tests (`_parse_stage_sections` / `_load_stage_overrides` / `_validate_stage_override_key` allowlist / `_resolve_stage_scalar` / `_resolve_stage_list` append-replace + ordering + meta-key skip) + 7 compose-emit integration tests (zero-diff regression, gui.mode=off strips X11, network.mode=bridge + ports, volumes.mount_inherit=false replaces, orphan WARN, disallowed-key WARN, `[stage:sys]` hard-error).
+  - `tui_spec.bats` +5: stage round-trip via `_load_setup_conf_full` / `_write_setup_conf` (namespaced load, append new section, multi-section, full round-trip, in-place update).
+  - `tui_flow.bats` +10: `_list_dockerfile_stages_available` / `_count_stage_overrides` / `_edit_stage_gui` / `_edit_stage_scalar` / `_edit_stage_list` (inherit toggle + add).
+
 ## [v0.17.0] - 2026-05-06
 
 Minor release bundling two `setup.sh` / `run.sh` feature additions plus

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -196,14 +196,64 @@ ENTRYPOINT ["/isaac-sim/runapp.sh"]
 - baseline（`sys` / `base` / `devel` / `test`）と衝突する場合は
   `setup.sh apply` が hard error で exit 1。template が管理する
   image tag namespace（`latest`、`v[0-9]*`）との衝突も hard error。
-- Per-stage の差分（volumes / GPU / network が `devel` と異なる）
-  は現状 out-of-scope — Dockerfile `ARG` + 条件付き `RUN` で
-  表現してください。emit される全 stage は同一の `devel` baseline
-  を共有します。
 - Stage の追加 / 削除は `setup.sh check-drift` をトリガーします
   （`.env` 内の `SETUP_DOCKERFILE_HASH` 経由）。次回 wrapper 起動
   時に自動的に `compose.yaml` を再生成します。`RUN apt-get install`
   などの他の編集は drift をトリガー**しません**。
+
+#### Per-stage `setup.conf` overrides（#220）
+
+#215 で auto-emit された stage はデフォルトで devel の runtime 設定
+（volumes / GPU / network / GUI）を共有します。stage ごとに異なる
+runtime 設定が必要な場合 — 例えば NVIDIA Isaac Sim の `headless`
+が WebRTC livestream で `network=bridge` + port mapping + `gui=off`
+を必要とし、`devel` と `gui` は `network=host` + X11 を維持する
+場合 — repo の `setup.conf` に `[stage:<name>]` セクションを
+追加します：
+
+```ini
+[gui]
+mode = auto
+
+[network]
+mode = host
+
+[stage:headless]
+gui.mode = off
+network.mode = bridge
+network.port_1 = 8080:80
+deploy.gpu_capabilities = gpu compute utility graphics video
+```
+
+`./setup_tui.sh` → Advanced → 「Per-stage overrides」でも対話的に
+編集できます。このメニューは Dockerfile に少なくとも 1 つの
+非 baseline stage がある場合のみ表示されます。
+
+Override 可能な key (v1)：
+
+| Section | Keys |
+|---|---|
+| `[deploy]` | `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime` |
+| `[gui]` | `mode` |
+| `[network]` | `mode`, `ipc`, `network_name`, `port_<N>`, `port_inherit` |
+| `[security]` | `privileged` |
+| `[volumes]` | `mount_<N>`, `mount_inherit` |
+| `[environment]` | `env_<N>`, `env_inherit` |
+
+List フィールド（`mount_*` / `port_*` / `env_*`）は **append-default**：
+stage の項目が top-level の後に追加されます。完全に top-level を
+置き換える場合は `<list>_inherit = false` を設定します
+（例：`volumes.mount_inherit = false`）。
+
+注意事項：
+
+- `[stage:devel]` は**予約済み** (v1 no-op + WARN)。devel を
+  調整する場合は top-level セクションを直接編集してください。
+  v2 で再検討します。
+- `[stage:sys|base|test]` は **hard error**（baseline collision）。
+- `[stage:foo]` で参照される stage が Dockerfile に存在しない
+  場合 → **WARN + skip**（`setup.sh apply` の他の処理は継続）。
+- allowlist 外の override key → **WARN + key 単位で skip**。
 
 ### Smoke test ヘルパー（ダウンストリーム repo 用）
 

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -193,12 +193,60 @@ ENTRYPOINT ["/isaac-sim/runapp.sh"]
 - 撞到 baseline（`sys` / `base` / `devel` / `test`）`setup.sh apply`
   hard error 退出 1。撞到 template 控制的 image tag namespace
   （`latest`、`v[0-9]*`）也是 hard error。
-- Per-stage 差异（volumes / GPU / network 跟 `devel` 不同）目前
-  out-of-scope — 改用 Dockerfile `ARG` + 条件 `RUN` 表达。每个
-  emit 出来的 stage 共享一份 `devel` baseline。
 - 添加 / 移除 stage 会触发 `setup.sh check-drift`（通过 `.env` 内
   的 `SETUP_DOCKERFILE_HASH`），下次 wrapper 跑会自动 regen
   `compose.yaml`。其他 `RUN apt-get install` 等修改**不会**触发 drift。
+
+#### Per-stage `setup.conf` overrides（#220）
+
+#215 auto-emit 出的 stage 默认共用 devel 的 runtime 设置
+（volumes / GPU / network / GUI）。当某 stage 需要不同的 runtime
+设置 — 例如 NVIDIA Isaac Sim 的 `headless` 跑 WebRTC livestream
+要 `network=bridge` + 一个 port mapping + `gui=off`，但 `devel` 跟
+`gui` 维持 `network=host` + X11 — 在 repo 的 `setup.conf` 加上
+`[stage:<name>]` section：
+
+```ini
+[gui]
+mode = auto
+
+[network]
+mode = host
+
+[stage:headless]
+gui.mode = off
+network.mode = bridge
+network.port_1 = 8080:80
+deploy.gpu_capabilities = gpu compute utility graphics video
+```
+
+也可以用 `./setup_tui.sh` → Advanced → 「Per-stage overrides」走
+交互式编辑；该 entry 仅在 Dockerfile 有至少一个非 baseline stage
+时才显示。
+
+允许 override 的 key（v1）：
+
+| Section | Keys |
+|---|---|
+| `[deploy]` | `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime` |
+| `[gui]` | `mode` |
+| `[network]` | `mode`, `ipc`, `network_name`, `port_<N>`, `port_inherit` |
+| `[security]` | `privileged` |
+| `[volumes]` | `mount_<N>`, `mount_inherit` |
+| `[environment]` | `env_<N>`, `env_inherit` |
+
+List 字段（`mount_*` / `port_*` / `env_*`）采 **append-default**：
+stage 的项目附加在 top-level 之后。要完全取代 top-level，设
+`<list>_inherit = false`（例：`volumes.mount_inherit = false`）。
+
+注意事项：
+
+- `[stage:devel]` 是**保留**的 (v1 no-op + WARN)。要调 devel 直接
+  改 top-level section。v2 会重新评估。
+- `[stage:sys|base|test]` 是 **hard error**（baseline collision）。
+- `[stage:foo]` 对应的 stage 在 Dockerfile 不存在 → **WARN + 跳过**
+  （`setup.sh apply` 其他流程继续）。
+- 不在 allowlist 内的 override key → **WARN + 跳过该 key**。
 
 ### Smoke test helpers（供下游 repo 使用）
 

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -193,12 +193,60 @@ ENTRYPOINT ["/isaac-sim/runapp.sh"]
 - 撞到 baseline（`sys` / `base` / `devel` / `test`）`setup.sh apply`
   hard error 退出 1。撞到 template 控制的 image tag namespace
   （`latest`、`v[0-9]*`）也是 hard error。
-- Per-stage 差異（volumes / GPU / network 跟 `devel` 不同）目前
-  out-of-scope — 改用 Dockerfile `ARG` + 條件 `RUN` 表達。每個
-  emit 出來的 stage 共用一份 `devel` baseline。
 - 加 / 移 stage 會觸發 `setup.sh check-drift`（透過 `.env` 內的
   `SETUP_DOCKERFILE_HASH`），下次 wrapper 跑會自動 regen
   `compose.yaml`。其他 `RUN apt-get install` 等修改**不會**觸發 drift。
+
+#### Per-stage `setup.conf` overrides（#220）
+
+#215 auto-emit 出來的 stage 預設共用 devel 的 runtime 設定
+（volumes / GPU / network / GUI）。當某 stage 需要不同的 runtime
+設定 — 例如 NVIDIA Isaac Sim 的 `headless` 跑 WebRTC livestream
+要 `network=bridge` + 一個 port mapping + `gui=off`，但 `devel`
+跟 `gui` 維持 `network=host` + X11 — 在 repo 的 `setup.conf` 加上
+`[stage:<name>]` section：
+
+```ini
+[gui]
+mode = auto
+
+[network]
+mode = host
+
+[stage:headless]
+gui.mode = off
+network.mode = bridge
+network.port_1 = 8080:80
+deploy.gpu_capabilities = gpu compute utility graphics video
+```
+
+也可以用 `./setup_tui.sh` → Advanced → 「Per-stage overrides」走互動
+式編輯；該 entry 只在 Dockerfile 有至少一個非 baseline stage 時才會
+出現。
+
+允許 override 的 key（v1）：
+
+| Section | Keys |
+|---|---|
+| `[deploy]` | `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime` |
+| `[gui]` | `mode` |
+| `[network]` | `mode`, `ipc`, `network_name`, `port_<N>`, `port_inherit` |
+| `[security]` | `privileged` |
+| `[volumes]` | `mount_<N>`, `mount_inherit` |
+| `[environment]` | `env_<N>`, `env_inherit` |
+
+List 欄位（`mount_*` / `port_*` / `env_*`）採 **append-default**：
+stage 的項目附加在 top-level 之後。要完全取代 top-level，設
+`<list>_inherit = false`（例：`volumes.mount_inherit = false`）。
+
+注意事項：
+
+- `[stage:devel]` 是**保留**的 (v1 no-op + WARN)。要調 devel 直接
+  改 top-level section。v2 會重新評估。
+- `[stage:sys|base|test]` 是 **hard error**（baseline collision）。
+- `[stage:foo]` 對應的 stage 在 Dockerfile 不存在 → **WARN + 跳過**
+  （`setup.sh apply` 其他流程繼續）。
+- 不在 allowlist 內的 override key → **WARN + 跳過該 key**。
 
 ### Smoke test helpers（供下游 repo 使用）
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **969 tests** total (915 unit + 54 integration).
+Template self-tests: **1011 tests** total (957 unit + 54 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 27 shared smoke tests under
@@ -45,7 +45,7 @@ Template self-tests: **969 tests** total (915 unit + 54 integration).
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
 | `_print_config_summary warns when setup.conf exists but has no [section] headers` | #157 empty-conf hint on build/run summary |
 
-### test/unit/setup_spec.bats (232)
+### test/unit/setup_spec.bats (259)
 
 Covers core detection (user/hardware/docker/GPU/GUI), the INI parser
 (`_parse_ini_section`), setup.conf section merging (`_load_setup_conf`
@@ -83,8 +83,10 @@ writeback (first-time bootstrap / user-edit respect / opt-out).
 | `_parse_dockerfile_stages` (#215: extract, dedup, file-order, missing file, lowercase `as` rejection) | 6 |
 | `_compute_dockerfile_hash` (#215: stable / add / remove / non-FROM-AS edits / missing) | 5 |
 | `auto-emit` end-to-end (#215: #108 runtime regression, multi-stage emit, target/image/container_name shape, no-extras, baseline collision, reserved tag latest/v0, invalid format WARN+skip, SETUP_DOCKERFILE_HASH, drift on add, drift on remove) | 11 |
+| Per-stage overrides #220 helpers (`_parse_stage_sections`, `_load_stage_overrides`, `_validate_stage_override_key` allowlist, `_resolve_stage_scalar`, `_resolve_stage_list` append/replace + ordering + meta-key skip) | 20 |
+| Per-stage overrides #220 compose emit integration (zero-diff regression for stages w/o overrides, `gui.mode=off` strips X11, `network.mode=bridge` per-stage + ports, `volumes.mount_inherit=false` replaces, orphan `[stage:foo]` WARN, disallowed override-key WARN, `[stage:sys]` hard-error) | 7 |
 
-### test/unit/tui_spec.bats (92)
+### test/unit/tui_spec.bats (97)
 
 Pure-logic unit tests for the TUI support libraries (`_tui_conf.sh`).
 No dialog/whiptail invocations here — strictly validators, mount-string
@@ -100,6 +102,7 @@ parsers, and setup.conf round-trip.
 | `_upsert_conf_value` (updates existing, leaves other sections untouched) | 2 |
 | `_edit_image_rule __remove` index compaction (#177) — first / middle / last / sole rule | 4 |
 | `_validate_additional_context` (#199: relative paths, BuildKit schemes, name punctuation, reject empty / missing pieces, reject invalid name shapes) | 5 |
+| Per-stage `[stage:NAME]` round-trip (#220: namespaced load, append new section, multi-section append, round-trip, in-place update of existing section) | 5 |
 
 ### test/unit/tui_backend_spec.bats (28)
 
@@ -118,7 +121,7 @@ a canned response; exercised with `TUI_STUB_RESPONSE` / `TUI_STUB_EXIT`.
 | `_tui_msgbox` / `_tui_yesno` (correct flags, propagates exit code) | 2 |
 | whiptail flag-spelling translation (#136: `--ok-button` / `--cancel-button` instead of `--*-label`, no `--extra-button`) + Save-button unification (#178: dialog also drops `--extra-button`) | 6 |
 
-### test/unit/tui_flow.bats (53)
+### test/unit/tui_flow.bats (63)
 
 Interactive-flow tests for `setup_tui.sh` (#189). Sources `setup_tui.sh`
 directly and overrides `_tui_menu` / `_tui_select` / `_tui_inputbox` /
@@ -143,6 +146,7 @@ target areas the issue body called out.
 | `_edit_section_network` (host+host no shm prompt, bridge prompts name+ports, ipc=private prompts shm, empty network_name allowed) | 4 |
 | `_edit_section_deploy` (off short-circuits — only writes gpu_mode) | 1 |
 | Multi-section dispatch from main menu (network → host → save) | 1 |
+| Per-stage UI #220 (`_list_dockerfile_stages_available` from-Dockerfile + baseline filter, `_count_stage_overrides` OVR+CURRENT dedup + empty skip, `_edit_stage_gui` mode + __inherit, `_edit_stage_scalar` write + empty-clears, `_edit_stage_list` inherit toggle + add) | 10 |
 
 ### test/unit/build_worker_yaml_spec.bats (15)
 

--- a/script/docker/_tui_conf.sh
+++ b/script/docker/_tui_conf.sh
@@ -423,9 +423,60 @@ _write_setup_conf() {
       if [[ "${__ovk}" == "${__current}."* && -z "${__emitted[${__ovk}]:-}" ]]; then
         [[ -n "${__removed[${__ovk}]+x}" ]] && continue
         printf '%s = %s\n' "${__ovk#"${__current}".}" "${__override[${__ovk}]}" >> "${_dst}"
+        __emitted[${__ovk}]=1
       fi
     done
   fi
+
+  # Append NEW sections — overrides whose `<section>.<key>` namespace
+  # references a section never seen in the template. Per-stage
+  # `[stage:NAME]` sections (#220) are the typical case: template's
+  # setup.conf carries no per-repo stage overrides, so the first time
+  # a user adds `[stage:headless]` via TUI Save the section is brand
+  # new and would otherwise be silently dropped here.
+  #
+  # Section-name extraction uses the `<section>.<key>` split rule
+  # established by `_load_setup_conf_full`: section name has no `.`,
+  # key may. `stage:headless.gui.mode` → section=stage:headless,
+  # key=gui.mode.
+  local -A __template_sections=()
+  local __l
+  for __l in "${__tpl_lines[@]}"; do
+    if [[ "${__l}" =~ ^[[:space:]]*\[(.+)\][[:space:]]*$ ]]; then
+      __template_sections["${BASH_REMATCH[1]}"]=1
+    fi
+  done
+
+  # Walk override keys in the order the caller provided them so new
+  # sections appear in user-input order (predictable for tests + Save
+  # output diffs). Bash associative-array iteration is unspecified.
+  local -a __new_section_order=()
+  local -A __new_section_seen=()
+  local _wsc_i
+  for (( _wsc_i = 0; _wsc_i < ${#_wsc_keys[@]}; _wsc_i++ )); do
+    local __ovk_key="${_wsc_keys[_wsc_i]}"
+    local __ovk_sect="${__ovk_key%%.*}"
+    if [[ -z "${__template_sections[${__ovk_sect}]:-}" ]] \
+       && [[ -z "${__new_section_seen[${__ovk_sect}]:-}" ]]; then
+      __new_section_order+=("${__ovk_sect}")
+      __new_section_seen[${__ovk_sect}]=1
+    fi
+  done
+
+  # Emit each new section + its keys (skip emitted / removed entries
+  # so re-saves don't double-write).
+  local __ns
+  for __ns in "${__new_section_order[@]}"; do
+    printf '\n[%s]\n' "${__ns}" >> "${_dst}"
+    for (( _wsc_i = 0; _wsc_i < ${#_wsc_keys[@]}; _wsc_i++ )); do
+      local __key="${_wsc_keys[_wsc_i]}"
+      [[ "${__key}" == "${__ns}."* ]] || continue
+      [[ -n "${__emitted[${__key}]:-}" ]] && continue
+      [[ -n "${__removed[${__key}]+x}" ]] && continue
+      printf '%s = %s\n' "${__key#"${__ns}".}" "${_wsc_values[_wsc_i]}" >> "${_dst}"
+      __emitted[${__key}]=1
+    done
+  done
 }
 
 # ════════════════════════════════════════════════════════════════════

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -61,6 +61,8 @@ _setup_msg() {
         stage_invalid_format) echo "Dockerfile stage 名稱格式無效，已跳過該 stage" ;;
         stage_baseline_collision) echo "Dockerfile stage 名稱與 template 內建 stage 衝突，請改名" ;;
         stage_reserved_tag) echo "Dockerfile stage 名稱使用 template 控制的 image tag namespace，請改名" ;;
+        stage_unknown_referenced) echo "setup.conf 內 [stage:...] 對應的 stage 在 Dockerfile 中不存在，已忽略該區段" ;;
+        stage_override_key_not_allowed) echo "[stage:...] 區段內含不在 per-stage 允許清單內的 key，已忽略該 key" ;;
       esac ;;
     zh-CN)
       case "${_key}" in
@@ -86,6 +88,8 @@ _setup_msg() {
         stage_invalid_format) echo "Dockerfile stage 名称格式无效，已跳过该 stage" ;;
         stage_baseline_collision) echo "Dockerfile stage 名称与 template 内建 stage 冲突，请改名" ;;
         stage_reserved_tag) echo "Dockerfile stage 名称使用 template 控制的 image tag namespace，请改名" ;;
+        stage_unknown_referenced) echo "setup.conf 内 [stage:...] 对应的 stage 在 Dockerfile 中不存在，已忽略该区段" ;;
+        stage_override_key_not_allowed) echo "[stage:...] 区段内含不在 per-stage 允许清单内的 key，已忽略该 key" ;;
       esac ;;
     ja)
       case "${_key}" in
@@ -111,6 +115,8 @@ _setup_msg() {
         stage_invalid_format) echo "Dockerfile stage 名のフォーマットが無効です。該当 stage はスキップされます" ;;
         stage_baseline_collision) echo "Dockerfile stage 名が template 管理の stage と衝突しています。改名してください" ;;
         stage_reserved_tag) echo "Dockerfile stage 名が template が管理する image tag namespace を使用しています。改名してください" ;;
+        stage_unknown_referenced) echo "setup.conf 内の [stage:...] が指す stage が Dockerfile に存在しません。該当セクションは無視されます" ;;
+        stage_override_key_not_allowed) echo "[stage:...] セクション内に per-stage 許可リスト外の key が含まれています。該当 key は無視されます" ;;
       esac ;;
     *)
       case "${_key}" in
@@ -136,6 +142,8 @@ _setup_msg() {
         stage_invalid_format) echo "invalid Dockerfile stage name format; stage skipped" ;;
         stage_baseline_collision) echo "Dockerfile stage name collides with a template-managed baseline stage; rename it" ;;
         stage_reserved_tag) echo "Dockerfile stage name uses a template-controlled image tag namespace; rename it" ;;
+        stage_unknown_referenced) echo "setup.conf [stage:...] references a stage missing from the Dockerfile; section ignored" ;;
+        stage_override_key_not_allowed) echo "[stage:...] section contains a key outside the per-stage allowlist; key ignored" ;;
       esac ;;
   esac
 }
@@ -939,6 +947,196 @@ _compute_dockerfile_hash() {
 }
 
 # ════════════════════════════════════════════════════════════════════
+# Per-stage overrides (#220)
+#
+# `[stage:<name>]` sections in <repo>/setup.conf override top-level
+# settings on a per-stage basis. Only the v1 allowlist (gui.mode, the
+# whole [deploy] / [network] blocks, security.privileged, [volumes]
+# mounts, [environment] env_*) is honored — anything else is WARN'd
+# and skipped by the validator.
+#
+# List fields use append-default + opt-out semantics: stage's `mount_*`
+# / `port_*` / `env_*` items are appended to the top-level list unless
+# the matching `<list>_inherit = false` flag is set, in which case
+# only the stage's own entries survive.
+# ════════════════════════════════════════════════════════════════════
+
+# _parse_stage_sections <file> <out_array_var>
+#
+# Scans <file> for `^\[stage:NAME\]$` headers, returns NAME list in
+# file order. Stage names matching `[a-z][a-z0-9_-]*` are collected;
+# malformed names are silently skipped here (caller surfaces them
+# via _validate_stage_name). Empty / missing file → empty output.
+_parse_stage_sections() {
+  local _file="${1:?"${FUNCNAME[0]}: missing file"}"
+  local -n _pss_out="${2:?"${FUNCNAME[0]}: missing out array"}"
+  _pss_out=()
+  [[ -f "${_file}" ]] || return 0
+  local _line
+  while IFS= read -r _line || [[ -n "${_line}" ]]; do
+    if [[ "${_line}" =~ ^\[stage:([a-z][a-z0-9_-]*)\][[:space:]]*$ ]]; then
+      _pss_out+=("${BASH_REMATCH[1]}")
+    fi
+  done < "${_file}"
+}
+
+# _load_stage_overrides <base_path> <stage> <keys_outvar> <values_outvar>
+#
+# Reads the `[stage:<stage>]` section from <base_path>/setup.conf into
+# parallel arrays. Stage sections only live in the per-repo file
+# (template's setup.conf doesn't carry stage overrides — it doesn't
+# know which Dockerfile stages exist downstream). Honors SETUP_CONF
+# the same way _load_setup_conf does.
+_load_stage_overrides() {
+  local _base="${1:?"${FUNCNAME[0]}: missing base_path"}"
+  local _stage="${2:?"${FUNCNAME[0]}: missing stage"}"
+  local -n _lso_keys="${3:?"${FUNCNAME[0]}: missing keys outvar"}"
+  local -n _lso_values="${4:?"${FUNCNAME[0]}: missing values outvar"}"
+  _lso_keys=()
+  _lso_values=()
+
+  local _conf
+  if [[ -n "${SETUP_CONF:-}" ]]; then
+    _conf="${SETUP_CONF}"
+  else
+    _conf="${_base}/setup.conf"
+  fi
+  [[ -f "${_conf}" ]] || return 0
+  _parse_ini_section "${_conf}" "stage:${_stage}" _lso_keys _lso_values
+}
+
+# _validate_stage_override_key <key>
+#
+# Returns 0 when <key> is in the v1 per-stage override allowlist,
+# 1 otherwise. Allowlist scope:
+#
+#   [deploy]      gpu_mode, gpu_count, gpu_capabilities, runtime
+#   [gui]         mode
+#   [network]     mode, ipc, network_name, port_<N>, port_inherit
+#   [security]    privileged
+#   [volumes]     mount_<N>, mount_inherit
+#   [environment] env_<N>, env_inherit
+#
+# Excluded by design (v1):
+#   [image_name] / [build] / security.cap_*/security_opt_* / [devices] /
+#   [tmpfs] / [additional_contexts] / [resources] — outside the
+#   "Isaac Sim per-stage runtime" use case driving #220. Re-evaluate in
+#   v2 once a real downstream need surfaces.
+_validate_stage_override_key() {
+  local _key="${1:?"${FUNCNAME[0]}: missing key"}"
+  case "${_key}" in
+    deploy.gpu_mode|deploy.gpu_count|deploy.gpu_capabilities|deploy.runtime) return 0 ;;
+    gui.mode) return 0 ;;
+    network.mode|network.ipc|network.network_name) return 0 ;;
+    security.privileged) return 0 ;;
+    network.port_inherit|volumes.mount_inherit|environment.env_inherit) return 0 ;;
+  esac
+  if [[ "${_key}" =~ ^(network\.port|volumes\.mount|environment\.env)_[0-9]+$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# _resolve_stage_scalar <keys_var> <values_var> <key> <fallback> <out_var>
+#
+# Look up <key> in the stage's parallel arrays. If found, set <out_var>
+# to that value; otherwise set <out_var> to <fallback>. Used for
+# per-stage scalar overrides (gui.mode, network.mode, etc.) where there
+# is no merge — the stage value either replaces the top-level or
+# falls through entirely.
+_resolve_stage_scalar() {
+  local -n _rss_keys="${1:?"${FUNCNAME[0]}: missing keys array"}"
+  local -n _rss_values="${2:?"${FUNCNAME[0]}: missing values array"}"
+  local _key="${3:?"${FUNCNAME[0]}: missing key"}"
+  local _fallback="${4-}"
+  local -n _rss_out="${5:?"${FUNCNAME[0]}: missing out var"}"
+  local i
+  for (( i = 0; i < ${#_rss_keys[@]}; i++ )); do
+    if [[ "${_rss_keys[i]}" == "${_key}" ]]; then
+      _rss_out="${_rss_values[i]}"
+      return 0
+    fi
+  done
+  _rss_out="${_fallback}"
+}
+
+# _resolve_stage_list <keys_var> <values_var> <prefix> <inherit_key> \
+#                     <top_level_str> <out_var>
+#
+# Computes the effective list for a list field (volumes.mount_*,
+# network.port_*, environment.env_*) on a per-stage basis.
+#
+# Args:
+#   keys_var / values_var  Stage's parallel override arrays
+#   prefix                 Full dotted prefix e.g. "volumes.mount_"
+#                          — keys matching `<prefix>[0-9]+` are list items
+#   inherit_key            Meta-key e.g. "volumes.mount_inherit"
+#                          — value "false" switches to replace mode
+#   top_level_str          Newline-separated top-level list (the same
+#                          aggregate format setup.sh uses elsewhere)
+#   out_var                Newline-separated effective list (no
+#                          trailing newline)
+#
+# Default (inherit unspecified or anything ≠ "false"): top-level entries
+# come first, stage entries appended afterward in setup.conf order.
+# Replace mode (inherit=false): only stage entries appear; top-level
+# is dropped. The opt-out lets a stage opt out of inherited mounts
+# entirely (e.g. headless that wants no host-side ssh keys, regardless
+# of the top-level mount_2 setting).
+_resolve_stage_list() {
+  local -n _rsl_keys="${1:?"${FUNCNAME[0]}: missing keys array"}"
+  local -n _rsl_values="${2:?"${FUNCNAME[0]}: missing values array"}"
+  local _prefix="${3:?"${FUNCNAME[0]}: missing prefix"}"
+  local _inherit_key="${4:?"${FUNCNAME[0]}: missing inherit_key"}"
+  local _top="${5-}"
+  local -n _rsl_out="${6:?"${FUNCNAME[0]}: missing out var"}"
+
+  # Default to inheriting top-level. Only the literal "false" toggles
+  # replace mode — anything else (including "true", empty, malformed)
+  # keeps the safe append-default behavior.
+  local _inherit="true" i
+  for (( i = 0; i < ${#_rsl_keys[@]}; i++ )); do
+    if [[ "${_rsl_keys[i]}" == "${_inherit_key}" ]]; then
+      [[ "${_rsl_values[i]}" == "false" ]] && _inherit="false"
+      break
+    fi
+  done
+
+  # Collect stage's own list entries in setup.conf order. Match only
+  # `<prefix><digits>` so meta-keys like `mount_inherit` (which share
+  # the prefix) are not pulled in.
+  local -a _stage_entries=()
+  local _suffix
+  for (( i = 0; i < ${#_rsl_keys[@]}; i++ )); do
+    [[ "${_rsl_keys[i]}" == "${_prefix}"* ]] || continue
+    _suffix="${_rsl_keys[i]#"${_prefix}"}"
+    [[ "${_suffix}" =~ ^[0-9]+$ ]] || continue
+    _stage_entries+=("${_rsl_values[i]}")
+  done
+
+  if [[ "${_inherit}" == "true" ]]; then
+    if [[ -n "${_top}" ]] && (( ${#_stage_entries[@]} > 0 )); then
+      _rsl_out="${_top}"$'\n'"$(printf '%s\n' "${_stage_entries[@]}")"
+      _rsl_out="${_rsl_out%$'\n'}"
+    elif [[ -n "${_top}" ]]; then
+      _rsl_out="${_top}"
+    elif (( ${#_stage_entries[@]} > 0 )); then
+      _rsl_out="$(printf '%s\n' "${_stage_entries[@]}")"
+      _rsl_out="${_rsl_out%$'\n'}"
+    else
+      _rsl_out=""
+    fi
+  else
+    if (( ${#_stage_entries[@]} > 0 )); then
+      _rsl_out="$(printf '%s\n' "${_stage_entries[@]}")"
+      _rsl_out="${_rsl_out%$'\n'}"
+    else
+      _rsl_out=""
+    fi
+  fi
+}
+
+# ════════════════════════════════════════════════════════════════════
 # generate_compose_yaml <out> <repo_name> <gui_enabled> <gpu_enabled>
 #                       <gpu_count> <gpu_caps> <extras_array_ref>
 #                       [<network_name>]
@@ -1039,8 +1237,9 @@ generate_compose_yaml() {
   # caller exits non-zero so user fixes the Dockerfile before retry.
   # Per-stage diff (different volumes / GPU / network than devel) is
   # out of scope v1; declare via Dockerfile ARG + conditional RUN.
-  local _dockerfile
-  _dockerfile="$(dirname -- "${_out}")/Dockerfile"
+  local _dockerfile _setup_base
+  _setup_base="$(dirname -- "${_out}")"
+  _dockerfile="${_setup_base}/Dockerfile"
   local -a _emit_stages=()
   local _stage _vrc
   while IFS= read -r _stage; do
@@ -1054,6 +1253,48 @@ generate_compose_yaml() {
       3) printf '[setup] ERROR: %s: %q\n' "$(_setup_msg stage_reserved_tag)" "${_stage}" >&2; return 1 ;;
     esac
   done < <(_parse_dockerfile_stages "${_dockerfile}")
+
+  # Per-stage overrides (#220) — validate setup.conf [stage:*] sections.
+  #
+  #   sys / base / test       → hard error (baseline collision)
+  #   latest / v[0-9]*        → hard error (reserved tag namespace)
+  #   devel                   → reserved (v1 no-op WARN)
+  #   foo (not in Dockerfile) → orphan WARN, ignored
+  #
+  # Stages with malformed names that don't match `[a-z][a-z0-9_-]*`
+  # never reach _conf_stages because _parse_stage_sections's regex
+  # already filters them; that's an acceptable v1 silent-drop since
+  # the TUI is the primary write path and validates names upfront.
+  local -a _conf_stages=()
+  _parse_stage_sections "${_setup_base}/setup.conf" _conf_stages
+  local _cs
+  for _cs in "${_conf_stages[@]}"; do
+    case "${_cs}" in
+      sys|base|test)
+        printf '[setup] ERROR: %s: [stage:%s]\n' \
+          "$(_setup_msg stage_baseline_collision)" "${_cs}" >&2
+        return 1
+        ;;
+      latest|v[0-9]*)
+        printf '[setup] ERROR: %s: [stage:%s]\n' \
+          "$(_setup_msg stage_reserved_tag)" "${_cs}" >&2
+        return 1
+        ;;
+      devel)
+        printf '[setup] WARN: [stage:devel] is reserved; not applied in v1 (#220). Edit top-level sections to tune devel.\n' >&2
+        continue
+        ;;
+    esac
+    # Orphan check: stage is referenced but Dockerfile doesn't have it.
+    local _is_emitted=0 _es
+    for _es in "${_emit_stages[@]}"; do
+      [[ "${_es}" == "${_cs}" ]] && _is_emitted=1 && break
+    done
+    if (( ! _is_emitted )); then
+      printf '[setup] WARN: %s: [stage:%s]\n' \
+        "$(_setup_msg stage_unknown_referenced)" "${_cs}" >&2
+    fi
+  done
 
   # Convert space-separated caps to YAML array form [a, b, c]
   local -a _caps_arr=()
@@ -1260,8 +1501,38 @@ YAML
     # `runtime` is no longer special-cased (#108) — it falls through
     # this loop like any other non-baseline stage, preserving its
     # behavior since `runtime` is not in the baseline blocklist.
+    # Build a snapshot of the top-level volumes list (newline-separated
+    # — same shape `_resolve_stage_list` consumes/produces). The list is
+    # what feeds into compose.yaml's volumes block before per-stage
+    # append/replace logic kicks in. _gcy_extras already excludes the
+    # GUI baseline (X11) — those are emitted separately based on
+    # effective gui resolution.
+    local _top_volumes_str=""
+    if (( ${#_gcy_extras[@]} > 0 )); then
+      _top_volumes_str="$(printf '%s\n' "${_gcy_extras[@]}")"
+      _top_volumes_str="${_top_volumes_str%$'\n'}"
+    fi
+
     local _emit_stage
     for _emit_stage in "${_emit_stages[@]}"; do
+      # Load + filter [stage:<name>] overrides for this stage.
+      local -a _so_keys=() _so_values=()
+      _load_stage_overrides "${_setup_base}" "${_emit_stage}" _so_keys _so_values
+      local -a _so_filtered_keys=() _so_filtered_values=()
+      local _ki
+      for (( _ki = 0; _ki < ${#_so_keys[@]}; _ki++ )); do
+        if _validate_stage_override_key "${_so_keys[_ki]}"; then
+          _so_filtered_keys+=("${_so_keys[_ki]}")
+          _so_filtered_values+=("${_so_values[_ki]}")
+        else
+          printf '[setup] WARN: %s: %q (stage=%s)\n' \
+            "$(_setup_msg stage_override_key_not_allowed)" \
+            "${_so_keys[_ki]}" "${_emit_stage}" >&2
+        fi
+      done
+      local _has_overrides=0
+      (( ${#_so_filtered_keys[@]} > 0 )) && _has_overrides=1
+
       cat <<YAML
 
   ${_emit_stage}:
@@ -1281,6 +1552,184 @@ YAML
     profiles:
       - ${_emit_stage}
 YAML
+
+      # Zero-diff path: when stage has no overrides, the minimal block
+      # above is sufficient — compose extends inherits everything from
+      # devel. Skip the override-emit logic entirely. Critical for the
+      # 17 existing downstream repos (no [stage:*] sections → byte-for-
+      # byte identical compose.yaml output to pre-#220).
+      if (( ! _has_overrides )); then
+        continue
+      fi
+
+      # Resolve effective per-stage values. For modes (gui / gpu),
+      # absent or "auto" inherits the parent's already-resolved boolean
+      # — we don't re-detect inside the stage. For other scalars, the
+      # parent's effective value is the fallback.
+      local _eff_gui_mode _eff_gui
+      _resolve_stage_scalar _so_filtered_keys _so_filtered_values "gui.mode" "" _eff_gui_mode
+      case "${_eff_gui_mode}" in
+        off)   _eff_gui="false" ;;
+        force) _eff_gui="true" ;;
+        *)     _eff_gui="${_gui}" ;;
+      esac
+
+      local _eff_gpu_mode _eff_gpu
+      _resolve_stage_scalar _so_filtered_keys _so_filtered_values "deploy.gpu_mode" "" _eff_gpu_mode
+      case "${_eff_gpu_mode}" in
+        off)   _eff_gpu="false" ;;
+        force) _eff_gpu="true" ;;
+        *)     _eff_gpu="${_gpu}" ;;
+      esac
+
+      local _eff_gpu_count _eff_gpu_caps _eff_runtime
+      _resolve_stage_scalar _so_filtered_keys _so_filtered_values "deploy.gpu_count" "${_gpu_count}" _eff_gpu_count
+      _resolve_stage_scalar _so_filtered_keys _so_filtered_values "deploy.gpu_capabilities" "${_gpu_caps}" _eff_gpu_caps
+      _resolve_stage_scalar _so_filtered_keys _so_filtered_values "deploy.runtime" "${_runtime}" _eff_runtime
+
+      local _eff_net_mode _eff_ipc_mode _eff_net_name _eff_privileged
+      _resolve_stage_scalar _so_filtered_keys _so_filtered_values "network.mode" "${_net_mode}" _eff_net_mode
+      _resolve_stage_scalar _so_filtered_keys _so_filtered_values "network.ipc" "${_ipc_mode}" _eff_ipc_mode
+      _resolve_stage_scalar _so_filtered_keys _so_filtered_values "network.network_name" "${_net_name}" _eff_net_name
+      _resolve_stage_scalar _so_filtered_keys _so_filtered_values "security.privileged" "" _eff_privileged
+
+      local _eff_volumes _eff_environment _eff_ports
+      _resolve_stage_list _so_filtered_keys _so_filtered_values "volumes.mount_" "volumes.mount_inherit" "${_top_volumes_str}" _eff_volumes
+      _resolve_stage_list _so_filtered_keys _so_filtered_values "environment.env_" "environment.env_inherit" "${_env_str}" _eff_environment
+      _resolve_stage_list _so_filtered_keys _so_filtered_values "network.port_" "network.port_inherit" "${_ports_str}" _eff_ports
+
+      # Did the stage's gui resolution differ from devel's? Both
+      # environment + volumes blocks must be re-emitted explicitly when
+      # gui differs (X11 env vars + X11 mounts are GUI-conditional in
+      # devel, and compose extends's child-replaces-list semantics
+      # require us to emit the full effective list here).
+      local _gui_diff=0
+      [[ "${_eff_gui}" != "${_gui}" ]] && _gui_diff=1
+      local _has_env_overrides=0 _has_volume_overrides=0 _has_port_overrides=0
+      [[ "${_eff_environment}" != "${_env_str}" ]] && _has_env_overrides=1
+      [[ "${_eff_volumes}" != "${_top_volumes_str}" ]] && _has_volume_overrides=1
+      [[ "${_eff_ports}" != "${_ports_str}" ]] && _has_port_overrides=1
+
+      # Scalar overrides — emit only when they differ from parent
+      # (i.e. would otherwise inherit the same value via extends).
+      if [[ -n "${_eff_privileged}" ]]; then
+        echo "    privileged: ${_eff_privileged}"
+      fi
+      if [[ "${_eff_ipc_mode}" != "${_ipc_mode}" ]]; then
+        echo "    ipc: ${_eff_ipc_mode}"
+      fi
+      # network_mode override: when stage flips bridge<->host, compose
+      # extends won't merge `networks:` and `network_mode:` cleanly, so
+      # we always emit network_mode for clarity. networks: is only
+      # re-emitted under bridge with a network_name set.
+      if [[ "${_eff_net_mode}" != "${_net_mode}" ]] || \
+         [[ "${_eff_net_name}" != "${_net_name}" ]]; then
+        if [[ "${_eff_net_mode}" == "bridge" ]] && [[ -n "${_eff_net_name}" ]]; then
+          cat <<YAML
+    networks:
+      - ${_eff_net_name}
+YAML
+        else
+          echo "    network_mode: ${_eff_net_mode}"
+        fi
+      fi
+      # runtime override: only when explicitly set (empty/auto/off
+      # = no runtime line, mirroring devel's _emit_runtime_line).
+      if [[ "${_eff_runtime}" != "${_runtime}" ]] && \
+         [[ -n "${_eff_runtime}" ]] && \
+         [[ "${_eff_runtime}" != "off" ]] && \
+         [[ "${_eff_runtime}" != "auto" ]]; then
+        echo "    runtime: ${_eff_runtime}"
+      fi
+
+      # environment block: emit when GUI status differs OR env list
+      # differs. compose extends replaces parent's full list with this
+      # one, so we re-emit the GUI baseline (when stage's gui = true)
+      # plus the resolved env list.
+      if (( _gui_diff || _has_env_overrides )); then
+        echo "    environment:"
+        if [[ "${_eff_gui}" == "true" ]]; then
+          cat <<'YAML'
+      - DISPLAY=${DISPLAY:-}
+      - WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-}
+      - XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-/run/user/1000}
+      - XAUTHORITY=${XAUTHORITY:-}
+YAML
+        fi
+        if [[ -n "${_eff_environment}" ]]; then
+          local _ev
+          while IFS= read -r _ev; do
+            [[ -z "${_ev}" ]] && continue
+            echo "      - ${_ev}"
+          done <<< "${_eff_environment}"
+        fi
+      fi
+
+      # ports block: only meaningful under bridge mode. Emit when the
+      # stage flips the resolved port list. ports under host mode is
+      # silently a no-op for compose, so we still emit if the user
+      # asked for one (for clarity / future-proofing).
+      if [[ "${_eff_net_mode}" == "bridge" ]] && \
+         (( _has_port_overrides )) && [[ -n "${_eff_ports}" ]]; then
+        echo "    ports:"
+        local _p
+        while IFS= read -r _p; do
+          [[ -z "${_p}" ]] && continue
+          echo "      - \"${_p}\""
+        done <<< "${_eff_ports}"
+      fi
+
+      # volumes block: emit when GUI status differs OR mount list
+      # differs. Same compose-extends list-replacement reasoning as
+      # environment above.
+      if (( _gui_diff || _has_volume_overrides )); then
+        echo "    volumes:"
+        if [[ "${_eff_gui}" == "true" ]]; then
+          cat <<'YAML'
+      - /tmp/.X11-unix:/tmp/.X11-unix:ro
+      - ${XDG_RUNTIME_DIR:-/run/user/1000}:${XDG_RUNTIME_DIR:-/run/user/1000}:rw
+      - ${XAUTHORITY:-/dev/null}:${XAUTHORITY:-/dev/null}:ro
+YAML
+        fi
+        if [[ -n "${_eff_volumes}" ]]; then
+          local _m
+          while IFS= read -r _m; do
+            [[ -z "${_m}" ]] && continue
+            echo "      - ${_m}"
+          done <<< "${_eff_volumes}"
+        fi
+      fi
+
+      # deploy / GPU block: emit when gpu enabled status differs OR
+      # count/capabilities differ. v1 limitation: turning GPU off when
+      # devel has it on is not cleanly representable via compose
+      # extends (no way to "remove" parent's deploy block). For now,
+      # gpu disabled at stage means we just don't emit the block;
+      # compose extends will inherit devel's. Document as known
+      # limitation; revisit in v2 if a real use case surfaces.
+      if [[ "${_eff_gpu}" == "true" ]] && \
+         { [[ "${_eff_gpu}" != "${_gpu}" ]] || \
+           [[ "${_eff_gpu_count}" != "${_gpu_count}" ]] || \
+           [[ "${_eff_gpu_caps}" != "${_gpu_caps}" ]]; }; then
+        local -a _eff_caps_arr=()
+        read -ra _eff_caps_arr <<< "${_eff_gpu_caps}"
+        local _eff_caps_yaml="["
+        local _ef=1 _ec
+        for _ec in "${_eff_caps_arr[@]}"; do
+          if (( _ef )); then _eff_caps_yaml+="${_ec}"; _ef=0
+          else _eff_caps_yaml+=", ${_ec}"; fi
+        done
+        _eff_caps_yaml+="]"
+        cat <<YAML
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: ${_eff_gpu_count}
+              capabilities: ${_eff_caps_yaml}
+YAML
+      fi
     done
 
     cat <<YAML

--- a/script/docker/setup_tui.sh
+++ b/script/docker/setup_tui.sh
@@ -55,6 +55,21 @@ _TUI_MSG_EN[advanced.title]="Advanced"
 _TUI_MSG_EN[advanced.menu]="Select an advanced section"
 _TUI_MSG_EN[advanced.back]="Back to main menu"
 _TUI_MSG_EN[advanced.reset]="Reset to defaults"
+_TUI_MSG_EN[advanced.per_stage]="Per-stage overrides (#220)"
+_TUI_MSG_EN[per_stage.title]="Per-stage overrides"
+_TUI_MSG_EN[per_stage.menu]="Pick a stage to edit, or Back"
+_TUI_MSG_EN[per_stage.empty]=$'No non-baseline stages found in Dockerfile.\n\nPer-stage overrides apply to `FROM ... AS <name>` stages outside\nthe baseline blocklist {sys, base, devel, test}. Add a stage to your\nDockerfile first, then return here to override its runtime config.'
+_TUI_MSG_EN[per_stage.back]="Back"
+_TUI_MSG_EN[per_stage.overrides_set]="overrides set"
+_TUI_MSG_EN[per_stage.inherits_all]="(inherits all)"
+_TUI_MSG_EN[per_stage.one.menu]="Pick a section to edit, or Back"
+_TUI_MSG_EN[per_stage.scalar.menu]="Pick a key to edit, or Back"
+_TUI_MSG_EN[per_stage.scalar.prompt]=$'Override value\n  - Empty = inherit top-level (clear this override)\n  - For mode keys: auto / force / off (gui, gpu)\n  - For network mode: host / bridge / none\n  - For ipc: host / shareable / private\n  - For privileged: true / false\n  - For runtime: auto / nvidia / off'
+_TUI_MSG_EN[per_stage.list.menu]="Edit list entries, toggle inheritance, or Back"
+_TUI_MSG_EN[per_stage.list.entry_prompt]=$'List entry value\n  - Empty = delete this entry\n  - Format depends on the list (mount: host:container[:mode] / port: host:container[/proto] / env: KEY=VALUE)'
+_TUI_MSG_EN[per_stage.network.ports]="ports list (per-stage)"
+_TUI_MSG_EN[per_stage.inherit]="(inherit top-level — clear override)"
+_TUI_MSG_EN[per_stage.inherit_flag]="Inherit top-level entries"
 _TUI_MSG_EN[reset.title]="Reset to defaults"
 _TUI_MSG_EN[reset.confirm]=$'Reset ALL settings to template defaults?\n\n  - <repo>/setup.conf will be removed\n  - setup.sh re-runs to regenerate from template\n  - Your current customizations will be LOST\n\nThis cannot be undone.'
 _TUI_MSG_EN[reset.done]="All settings reset to template defaults."
@@ -216,6 +231,21 @@ _TUI_MSG_ZH_TW[advanced.title]="Advanced"
 _TUI_MSG_ZH_TW[advanced.menu]="選擇進階區段"
 _TUI_MSG_ZH_TW[advanced.back]="回主選單"
 _TUI_MSG_ZH_TW[advanced.reset]="重置為預設值"
+_TUI_MSG_ZH_TW[advanced.per_stage]="Per-stage overrides (#220)"
+_TUI_MSG_ZH_TW[per_stage.title]="Per-stage overrides"
+_TUI_MSG_ZH_TW[per_stage.menu]="選擇要編輯的 stage，或返回"
+_TUI_MSG_ZH_TW[per_stage.empty]=$'Dockerfile 中沒有非 baseline 的 stage。\n\nPer-stage overrides 套用於 baseline {sys, base, devel, test} 以外的\n`FROM ... AS <name>` stage。請先在 Dockerfile 中加入額外 stage，\n再回來這裡 override 該 stage 的 runtime 設定。'
+_TUI_MSG_ZH_TW[per_stage.back]="返回"
+_TUI_MSG_ZH_TW[per_stage.overrides_set]="個 override"
+_TUI_MSG_ZH_TW[per_stage.inherits_all]="(全部繼承)"
+_TUI_MSG_ZH_TW[per_stage.one.menu]="選擇要編輯的 section，或返回"
+_TUI_MSG_ZH_TW[per_stage.scalar.menu]="選擇要編輯的 key，或返回"
+_TUI_MSG_ZH_TW[per_stage.scalar.prompt]=$'Override 值\n  - 空白 = 繼承 top-level（清除此 override）\n  - mode keys：auto / force / off (gui, gpu)\n  - network mode：host / bridge / none\n  - ipc：host / shareable / private\n  - privileged：true / false\n  - runtime：auto / nvidia / off'
+_TUI_MSG_ZH_TW[per_stage.list.menu]="編輯 list 項目、切換繼承、或返回"
+_TUI_MSG_ZH_TW[per_stage.list.entry_prompt]=$'List 項目值\n  - 空白 = 刪除此項目\n  - 格式依 list 不同（mount: host:container[:mode] / port: host:container[/proto] / env: KEY=VALUE）'
+_TUI_MSG_ZH_TW[per_stage.network.ports]="ports list (per-stage)"
+_TUI_MSG_ZH_TW[per_stage.inherit]="(繼承 top-level — 清除 override)"
+_TUI_MSG_ZH_TW[per_stage.inherit_flag]="繼承 top-level 項目"
 _TUI_MSG_ZH_TW[reset.title]="重置為預設值"
 _TUI_MSG_ZH_TW[reset.confirm]=$'重置所有設定為 template 預設值？\n\n  - 移除 <repo>/setup.conf\n  - 重跑 setup.sh 從 template 重建\n  - 你目前的客製化會遺失\n\n無法復原。'
 _TUI_MSG_ZH_TW[reset.done]="所有設定已重置為預設值。"
@@ -375,6 +405,21 @@ _TUI_MSG_ZH_CN[advanced.title]="Advanced"
 _TUI_MSG_ZH_CN[advanced.menu]="选择进阶区段"
 _TUI_MSG_ZH_CN[advanced.back]="回主菜单"
 _TUI_MSG_ZH_CN[advanced.reset]="重置为默认值"
+_TUI_MSG_ZH_CN[advanced.per_stage]="Per-stage overrides (#220)"
+_TUI_MSG_ZH_CN[per_stage.title]="Per-stage overrides"
+_TUI_MSG_ZH_CN[per_stage.menu]="选择要编辑的 stage，或返回"
+_TUI_MSG_ZH_CN[per_stage.empty]=$'Dockerfile 中没有非 baseline 的 stage。\n\nPer-stage overrides 应用于 baseline {sys, base, devel, test} 以外的\n`FROM ... AS <name>` stage。请先在 Dockerfile 中加入额外 stage，\n再回来这里 override 该 stage 的 runtime 设定。'
+_TUI_MSG_ZH_CN[per_stage.back]="返回"
+_TUI_MSG_ZH_CN[per_stage.overrides_set]="个 override"
+_TUI_MSG_ZH_CN[per_stage.inherits_all]="(全部继承)"
+_TUI_MSG_ZH_CN[per_stage.one.menu]="选择要编辑的 section，或返回"
+_TUI_MSG_ZH_CN[per_stage.scalar.menu]="选择要编辑的 key，或返回"
+_TUI_MSG_ZH_CN[per_stage.scalar.prompt]=$'Override 值\n  - 空白 = 继承 top-level（清除此 override）\n  - mode keys：auto / force / off (gui, gpu)\n  - network mode：host / bridge / none\n  - ipc：host / shareable / private\n  - privileged：true / false\n  - runtime：auto / nvidia / off'
+_TUI_MSG_ZH_CN[per_stage.list.menu]="编辑 list 项目、切换继承、或返回"
+_TUI_MSG_ZH_CN[per_stage.list.entry_prompt]=$'List 项目值\n  - 空白 = 删除此项目\n  - 格式依 list 不同（mount: host:container[:mode] / port: host:container[/proto] / env: KEY=VALUE）'
+_TUI_MSG_ZH_CN[per_stage.network.ports]="ports list (per-stage)"
+_TUI_MSG_ZH_CN[per_stage.inherit]="(继承 top-level — 清除 override)"
+_TUI_MSG_ZH_CN[per_stage.inherit_flag]="继承 top-level 项目"
 _TUI_MSG_ZH_CN[reset.title]="重置为默认值"
 _TUI_MSG_ZH_CN[reset.confirm]=$'重置所有设定为 template 默认值？\n\n  - 移除 <repo>/setup.conf\n  - 重跑 setup.sh 从 template 重建\n  - 你当前的定制会丢失\n\n无法撤销。'
 _TUI_MSG_ZH_CN[reset.done]="所有设定已重置为默认值。"
@@ -529,6 +574,21 @@ _TUI_MSG_JA[advanced.title]="Advanced"
 _TUI_MSG_JA[advanced.menu]="Advanced セクションを選択"
 _TUI_MSG_JA[advanced.back]="メインメニューへ戻る"
 _TUI_MSG_JA[advanced.reset]="デフォルトにリセット"
+_TUI_MSG_JA[advanced.per_stage]="Per-stage overrides (#220)"
+_TUI_MSG_JA[per_stage.title]="Per-stage overrides"
+_TUI_MSG_JA[per_stage.menu]="編集する stage を選択するか、戻る"
+_TUI_MSG_JA[per_stage.empty]=$'Dockerfile に非 baseline の stage がありません。\n\nPer-stage overrides は baseline {sys, base, devel, test} 以外の\n`FROM ... AS <name>` stage に適用されます。先に Dockerfile に\nstage を追加してから、このメニューで runtime 設定を override してください。'
+_TUI_MSG_JA[per_stage.back]="戻る"
+_TUI_MSG_JA[per_stage.overrides_set]="件の override"
+_TUI_MSG_JA[per_stage.inherits_all]="(すべて継承)"
+_TUI_MSG_JA[per_stage.one.menu]="編集する section を選択するか、戻る"
+_TUI_MSG_JA[per_stage.scalar.menu]="編集する key を選択するか、戻る"
+_TUI_MSG_JA[per_stage.scalar.prompt]=$'Override 値\n  - 空白 = top-level を継承（この override をクリア）\n  - mode keys：auto / force / off (gui, gpu)\n  - network mode：host / bridge / none\n  - ipc：host / shareable / private\n  - privileged：true / false\n  - runtime：auto / nvidia / off'
+_TUI_MSG_JA[per_stage.list.menu]="list 項目の編集、継承の切替、または戻る"
+_TUI_MSG_JA[per_stage.list.entry_prompt]=$'List 項目の値\n  - 空白 = この項目を削除\n  - 形式は list ごとに異なります（mount: host:container[:mode] / port: host:container[/proto] / env: KEY=VALUE）'
+_TUI_MSG_JA[per_stage.network.ports]="ports list (per-stage)"
+_TUI_MSG_JA[per_stage.inherit]="(top-level を継承 — override をクリア)"
+_TUI_MSG_JA[per_stage.inherit_flag]="top-level 項目を継承"
 _TUI_MSG_JA[reset.title]="デフォルトにリセット"
 _TUI_MSG_JA[reset.confirm]=$'全ての設定を template のデフォルトにリセット？\n\n  - <repo>/setup.conf を削除\n  - setup.sh を再実行して template から再生成\n  - 現在のカスタマイズは失われます\n\n元に戻せません。'
 _TUI_MSG_JA[reset.done]="全ての設定がデフォルトにリセットされました。"
@@ -1531,6 +1591,336 @@ _edit_section_additional_contexts() {
 
 # ── Main menu ────────────────────────────────────────────────────────────
 
+# ── Per-stage overrides (#220) ───────────────────────────────────────────
+
+# _list_dockerfile_stages_available <out_array_var> [<base_path>]
+#
+# Parses <base_path>/Dockerfile and returns non-baseline stages (the
+# same set _parse_dockerfile_stages emits in setup.sh — duplicated here
+# rather than sourcing setup.sh because setup_tui.sh keeps its
+# dependency surface deliberately small).
+#
+# <base_path> defaults to ${FILE_PATH} (the repo's compose-yaml dir).
+# Test code overrides it to point at a temp Dockerfile, since
+# FILE_PATH is readonly in setup_tui.sh and cannot be reassigned in
+# the same shell.
+_list_dockerfile_stages_available() {
+  local -n _ldsa_out="${1:?}"
+  local _base="${2:-${FILE_PATH}}"
+  _ldsa_out=()
+  local _df="${_base}/Dockerfile"
+  [[ -f "${_df}" ]] || return 0
+  local _line _stage _seen=" "
+  while IFS= read -r _line || [[ -n "${_line}" ]]; do
+    [[ "${_line}" =~ ^FROM[[:space:]]+[^[:space:]#]+[[:space:]]+AS[[:space:]]+([^[:space:]#]+)[[:space:]]*$ ]] || continue
+    _stage="${BASH_REMATCH[1]}"
+    case "${_stage}" in
+      sys|base|devel|test) continue ;;
+    esac
+    case "${_seen}" in
+      *" ${_stage} "*) continue ;;
+    esac
+    _seen+="${_stage} "
+    _ldsa_out+=("${_stage}")
+  done < "${_df}"
+}
+
+# _count_stage_overrides <stage> <out_var>
+#
+# Counts the number of non-empty override entries belonging to the
+# stage's [stage:NAME] section (across both _TUI_OVR_* and
+# _TUI_CURRENT, deduped). Used for the stage-list label.
+_count_stage_overrides() {
+  local _stage="${1}"
+  local -n _cso_out="${2:?}"
+  _cso_out=0
+  local _prefix="stage:${_stage}."
+  local -A _seen=()
+  local i
+  for (( i=0; i<${#_TUI_OVR_KEYS[@]}; i++ )); do
+    if [[ "${_TUI_OVR_KEYS[i]}" == "${_prefix}"* ]]; then
+      [[ -n "${_TUI_OVR_VALUES[i]}" ]] || continue
+      _seen[${_TUI_OVR_KEYS[i]}]=1
+    fi
+  done
+  local _k
+  for _k in "${!_TUI_CURRENT[@]}"; do
+    if [[ "${_k}" == "${_prefix}"* ]]; then
+      [[ -n "${_TUI_CURRENT[${_k}]}" ]] || continue
+      _seen[${_k}]=1
+    fi
+  done
+  _cso_out="${#_seen[@]}"
+}
+
+# _edit_section_per_stage
+#
+# Top-level "Per-stage overrides" entry — shows the stage list with
+# per-stage override-counts; click into one stage opens the section
+# submenu (_edit_per_stage_one).
+_edit_section_per_stage() {
+  while :; do
+    local -a _stages=()
+    _list_dockerfile_stages_available _stages
+    if (( ${#_stages[@]} == 0 )); then
+      _tui_msgbox "$(_tui_msg per_stage.title)" "$(_tui_msg per_stage.empty)"
+      return 0
+    fi
+    local -a _menu_args=()
+    local _stage _count _label
+    for _stage in "${_stages[@]}"; do
+      _count_stage_overrides "${_stage}" _count
+      if (( _count > 0 )); then
+        # shellcheck disable=SC2059  # message source is our own i18n table
+        _label="$(printf '%d %s' "${_count}" "$(_tui_msg per_stage.overrides_set)")"
+      else
+        _label="$(_tui_msg per_stage.inherits_all)"
+      fi
+      _menu_args+=("${_stage}" "${_label}")
+    done
+    _menu_args+=("__back" "$(_tui_msg per_stage.back)")
+
+    local _choice
+    _choice="$(_tui_menu "$(_tui_msg per_stage.title)" \
+      "$(_tui_msg per_stage.menu)" "${_menu_args[@]}")" || return 0
+    case "${_choice}" in
+      __back|"") return 0 ;;
+      *) _edit_per_stage_one "${_choice}" ;;
+    esac
+  done
+}
+
+# _edit_per_stage_one <stage>
+#
+# Submenu for one stage: the 5 sections we expose for per-stage
+# override (gui / deploy / network / volumes / environment).
+_edit_per_stage_one() {
+  local _stage="${1}"
+  while :; do
+    local _choice
+    _choice="$(_tui_menu "stage: ${_stage}" \
+      "$(_tui_msg per_stage.one.menu)" \
+      gui         "$(_tui_msg main.gui)" \
+      deploy      "$(_tui_msg main.deploy)" \
+      network     "$(_tui_msg main.network)" \
+      volumes     "$(_tui_msg main.volumes)" \
+      environment "$(_tui_msg main.environment)" \
+      __back      "$(_tui_msg per_stage.back)")" || return 0
+    case "${_choice}" in
+      gui)         _edit_stage_gui "${_stage}" ;;
+      deploy)      _edit_stage_deploy "${_stage}" ;;
+      network)     _edit_stage_network "${_stage}" ;;
+      volumes)     _edit_stage_volumes "${_stage}" ;;
+      environment) _edit_stage_environment "${_stage}" ;;
+      __back|"")   return 0 ;;
+    esac
+  done
+}
+
+# _edit_stage_scalar <stage> <dotted_key>
+#
+# Generic scalar editor — text input. Empty input clears the override
+# (the stage falls back to inheriting top-level).
+_edit_stage_scalar() {
+  local _stage="${1}" _dotted="${2}"
+  local _nskey="stage:${_stage}.${_dotted}"
+  local _cur _v
+  _cur="$(_override_get "${_nskey}" "")"
+  _v="$(_tui_inputbox "stage:${_stage} / ${_dotted}" \
+    "$(_tui_msg per_stage.scalar.prompt)" "${_cur}")" || return 0
+  if [[ -z "${_v}" ]]; then
+    _mark_removed "${_nskey}"
+  else
+    _override_set "${_nskey}" "${_v}"
+  fi
+}
+
+# _edit_stage_gui <stage>
+#
+# gui.mode override: radio for auto/force/off plus an explicit
+# __inherit option (clears the override so the stage inherits
+# top-level gui resolution).
+_edit_stage_gui() {
+  local _stage="${1}"
+  local _nskey="stage:${_stage}.gui.mode"
+  local _cur _v
+  _cur="$(_override_get "${_nskey}" "")"
+  _v="$(_tui_select "stage:${_stage} / gui" \
+    "$(_tui_msg gui.mode.prompt)" \
+    auto      "$(_tui_msg gui.mode.auto)"      "$([[ "${_cur}" == auto ]]   && echo ON || echo off)" \
+    force     "$(_tui_msg gui.mode.force)"     "$([[ "${_cur}" == force ]]  && echo ON || echo off)" \
+    off       "$(_tui_msg gui.mode.off)"       "$([[ "${_cur}" == off ]]    && echo ON || echo off)" \
+    __inherit "$(_tui_msg per_stage.inherit)"  "$([[ -z "${_cur}" ]]        && echo ON || echo off)")" \
+    || return 0
+  if [[ "${_v}" == "__inherit" || -z "${_v}" ]]; then
+    _mark_removed "${_nskey}"
+  else
+    _override_set "${_nskey}" "${_v}"
+  fi
+}
+
+# _edit_stage_deploy <stage>
+#
+# Deploy section: gpu_mode + gpu_count + gpu_capabilities + runtime.
+# Each currently goes through _edit_stage_scalar (free-form input);
+# v1 ships with that for simplicity. Future polish (#221 menu work)
+# can swap each into a typed editor (radio for gpu_mode, etc.).
+_edit_stage_deploy() {
+  local _stage="${1}"
+  while :; do
+    local _gm _gc _gcaps _rt _ph
+    _gm="$(_override_get "stage:${_stage}.deploy.gpu_mode" "")"
+    _gc="$(_override_get "stage:${_stage}.deploy.gpu_count" "")"
+    _gcaps="$(_override_get "stage:${_stage}.deploy.gpu_capabilities" "")"
+    _rt="$(_override_get "stage:${_stage}.deploy.runtime" "")"
+    _ph="$(_tui_msg per_stage.inherits_all)"
+    local _choice
+    _choice="$(_tui_menu "stage:${_stage} / deploy" \
+      "$(_tui_msg per_stage.scalar.menu)" \
+      gpu_mode         "${_gm:-${_ph}}" \
+      gpu_count        "${_gc:-${_ph}}" \
+      gpu_capabilities "${_gcaps:-${_ph}}" \
+      runtime          "${_rt:-${_ph}}" \
+      __back           "$(_tui_msg per_stage.back)")" || return 0
+    case "${_choice}" in
+      __back|"") return 0 ;;
+      *) _edit_stage_scalar "${_stage}" "deploy.${_choice}" ;;
+    esac
+  done
+}
+
+# _edit_stage_network <stage>
+#
+# Network section: mode / ipc / network_name / privileged + the ports
+# sublist. privileged lives in the [security] section in setup.conf
+# but is bundled here for the user since it's network-adjacent in the
+# top-level menu structure.
+_edit_stage_network() {
+  local _stage="${1}"
+  while :; do
+    local _m _ipc _nn _pri _ph
+    _m="$(_override_get "stage:${_stage}.network.mode" "")"
+    _ipc="$(_override_get "stage:${_stage}.network.ipc" "")"
+    _nn="$(_override_get "stage:${_stage}.network.network_name" "")"
+    _pri="$(_override_get "stage:${_stage}.security.privileged" "")"
+    _ph="$(_tui_msg per_stage.inherits_all)"
+    local _choice
+    _choice="$(_tui_menu "stage:${_stage} / network" \
+      "$(_tui_msg per_stage.scalar.menu)" \
+      mode         "${_m:-${_ph}}" \
+      ipc          "${_ipc:-${_ph}}" \
+      network_name "${_nn:-${_ph}}" \
+      privileged   "${_pri:-${_ph}}" \
+      ports        "$(_tui_msg per_stage.network.ports)" \
+      __back       "$(_tui_msg per_stage.back)")" || return 0
+    case "${_choice}" in
+      __back|"") return 0 ;;
+      mode|ipc|network_name) _edit_stage_scalar "${_stage}" "network.${_choice}" ;;
+      privileged) _edit_stage_scalar "${_stage}" "security.privileged" ;;
+      ports) _edit_stage_list "${_stage}" "network" "port_" "network.port_inherit" ;;
+    esac
+  done
+}
+
+# _edit_stage_volumes <stage>
+#   _edit_stage_environment <stage>
+#
+# Thin wrappers over _edit_stage_list with section-specific args.
+_edit_stage_volumes() {
+  _edit_stage_list "${1}" "volumes" "mount_" "volumes.mount_inherit"
+}
+_edit_stage_environment() {
+  _edit_stage_list "${1}" "environment" "env_" "environment.env_inherit"
+}
+
+# _edit_stage_list <stage> <section> <prefix> <inherit_dotted>
+#
+# Generic list editor for per-stage list fields (volumes.mount_*,
+# network.port_*, environment.env_*). Mirrors the top-level
+# _edit_list_section (numeric-suffix add/edit/remove) plus an inherit
+# toggle row that flips `<list>_inherit` between true (default) and
+# false (replace mode — drop top-level entries entirely).
+#
+# Args:
+#   stage           Stage name (becomes part of the namespace prefix)
+#   section         Top-level section name (volumes / environment / network)
+#   prefix          List item key prefix (mount_ / env_ / port_)
+#   inherit_dotted  Dotted meta-key path inside the stage section
+#                   (e.g. volumes.mount_inherit)
+_edit_stage_list() {
+  local _stage="${1}" _section="${2}" _prefix="${3}" _inherit_dotted="${4}"
+  local _ns="stage:${_stage}.${_section}"
+  while :; do
+    local -a _nums=()
+    local _k _n _x _found
+    for _k in "${!_TUI_CURRENT[@]}"; do
+      if [[ "${_k}" == "${_ns}.${_prefix}"* ]]; then
+        _n="${_k#"${_ns}.${_prefix}"}"
+        [[ "${_n}" =~ ^[0-9]+$ ]] && _nums+=("${_n}")
+      fi
+    done
+    local i
+    for (( i=0; i<${#_TUI_OVR_KEYS[@]}; i++ )); do
+      if [[ "${_TUI_OVR_KEYS[i]}" == "${_ns}.${_prefix}"* ]]; then
+        _n="${_TUI_OVR_KEYS[i]#"${_ns}.${_prefix}"}"
+        if [[ "${_n}" =~ ^[0-9]+$ ]]; then
+          _found=0
+          for _x in "${_nums[@]}"; do [[ "${_x}" == "${_n}" ]] && _found=1 && break; done
+          (( _found )) || _nums+=("${_n}")
+        fi
+      fi
+    done
+    # shellcheck disable=SC2207
+    mapfile -t _nums < <(printf '%s\n' "${_nums[@]}" | sort -n | uniq)
+
+    local -a _menu_args=()
+    for _n in "${_nums[@]}"; do
+      local _cur_v
+      _cur_v="$(_override_get "${_ns}.${_prefix}${_n}" "")"
+      [[ -z "${_cur_v}" ]] && continue
+      _menu_args+=("${_prefix}${_n}" "${_cur_v}")
+    done
+    # Inherit toggle row — display current state in the label.
+    local _inherit_v _inherit_label
+    _inherit_v="$(_override_get "stage:${_stage}.${_inherit_dotted}" "true")"
+    [[ -z "${_inherit_v}" ]] && _inherit_v="true"
+    _inherit_label="$(_tui_msg per_stage.inherit_flag): ${_inherit_v}"
+    _menu_args+=("__inherit" "${_inherit_label}")
+    _menu_args+=("add"       "$(_tui_msg volumes.add)")
+    _menu_args+=("__back"    "$(_tui_msg per_stage.back)")
+
+    local _choice
+    _choice="$(_tui_menu "stage:${_stage} / ${_section}" \
+      "$(_tui_msg per_stage.list.menu)" "${_menu_args[@]}")" || return 0
+    case "${_choice}" in
+      __back|"") return 0 ;;
+      __inherit)
+        # Toggle the inherit flag. true is the default — clearing the
+        # override is equivalent to true. false = explicit replace mode.
+        if [[ "${_inherit_v}" == "false" ]]; then
+          _mark_removed "stage:${_stage}.${_inherit_dotted}"
+        else
+          _override_set "stage:${_stage}.${_inherit_dotted}" "false"
+        fi
+        ;;
+      add)
+        local _next=1 _v
+        while :; do
+          _v="$(_override_get "${_ns}.${_prefix}${_next}" "")"
+          [[ -z "${_v}" ]] && break
+          (( _next++ ))
+        done
+        _edit_list_entry "${_ns}" "${_prefix}" "${_next}" \
+          "$(_tui_msg per_stage.list.entry_prompt)" || true
+        ;;
+      "${_prefix}"*)
+        _edit_list_entry "${_ns}" "${_prefix}" "${_choice#"${_prefix}"}" \
+          "$(_tui_msg per_stage.list.entry_prompt)" || true
+        ;;
+    esac
+  done
+}
+
 _render_main_menu() {
   # Footer button labels are NOT i18n'd — keep a stable English
   # "Enter / Cancel" row across all locales so users never see a mix
@@ -1574,17 +1964,31 @@ _render_main_menu() {
 _render_advanced_menu() {
   while :; do
     local _choice
+    # Per-stage entry is only shown when the Dockerfile has at least
+    # one non-baseline stage (#220). Zero-noise for the 17 existing
+    # downstream repos that ship with only baseline stages.
+    local -a _stages_check=()
+    _list_dockerfile_stages_available _stages_check
+    local -a _menu_args=(
+      image                "$(_tui_msg main.image)"
+      build                "$(_tui_msg main.build)"
+      devices              "$(_tui_msg main.devices)"
+      tmpfs                "$(_tui_msg main.tmpfs)"
+      security             "$(_tui_msg main.security)"
+      additional_contexts  "$(_tui_msg main.additional_contexts)"
+    )
+    if (( ${#_stages_check[@]} > 0 )); then
+      _menu_args+=(per_stage "$(_tui_msg advanced.per_stage)")
+    fi
+    _menu_args+=(
+      reset                "$(_tui_msg advanced.reset)"
+      __back               "$(_tui_msg advanced.back)"
+    )
     _choice="$(_tui_menu "$(_tui_msg advanced.title)" "$(_tui_msg advanced.menu)" \
-      image                "$(_tui_msg main.image)" \
-      build                "$(_tui_msg main.build)" \
-      devices              "$(_tui_msg main.devices)" \
-      tmpfs                "$(_tui_msg main.tmpfs)" \
-      security             "$(_tui_msg main.security)" \
-      additional_contexts  "$(_tui_msg main.additional_contexts)" \
-      reset                "$(_tui_msg advanced.reset)" \
-      __back               "$(_tui_msg advanced.back)")" || break
+      "${_menu_args[@]}")" || break
     case "${_choice}" in
       image|build|devices|tmpfs|security|additional_contexts) "_edit_section_${_choice}" ;;
+      per_stage) _edit_section_per_stage ;;
       reset)    _do_reset ;;
       __back|"") break ;;
     esac

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -3081,3 +3081,462 @@ EOF
   assert_failure
   assert_output --partial "Dockerfile stage list changed"
 }
+
+# ════════════════════════════════════════════════════════════════════
+# Per-stage overrides (#220)
+#
+# `[stage:<name>]` sections in <repo>/setup.conf override top-level
+# settings on a per-stage basis when a corresponding `FROM ... AS <name>`
+# stage exists in the Dockerfile. Allowlist gates which keys can be
+# overridden; list fields (mount_*/port_*/env_*) use append-default
+# with opt-out via `<list>_inherit = false`.
+# ════════════════════════════════════════════════════════════════════
+
+# ─── _parse_stage_sections ────────────────────────────────────────
+
+@test "_parse_stage_sections: empty file → empty output" {
+  : > "${TEMP_DIR}/setup.conf"
+  local -a _stages=()
+  _parse_stage_sections "${TEMP_DIR}/setup.conf" _stages
+  [[ "${#_stages[@]}" -eq 0 ]] || { echo "expected 0 stages, got ${#_stages[@]}: ${_stages[*]}"; return 1; }
+}
+
+@test "_parse_stage_sections: missing file → empty output (no error)" {
+  local -a _stages=()
+  _parse_stage_sections "${TEMP_DIR}/no-such-file.conf" _stages
+  [[ "${#_stages[@]}" -eq 0 ]] || { echo "expected 0 stages, got ${#_stages[@]}: ${_stages[*]}"; return 1; }
+}
+
+@test "_parse_stage_sections: extracts [stage:NAME] sections in file order" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[gui]
+mode = auto
+
+[stage:headless]
+gui.mode = off
+
+[network]
+mode = host
+
+[stage:gui]
+gui.mode = auto
+
+[stage:web]
+network.mode = bridge
+EOF
+  local -a _stages=()
+  _parse_stage_sections "${TEMP_DIR}/setup.conf" _stages
+  [[ "${#_stages[@]}" -eq 3 ]] || { echo "expected 3 stages, got ${#_stages[@]}: ${_stages[*]}"; return 1; }
+  [[ "${_stages[0]}" == "headless" ]] || { echo "expected headless first, got ${_stages[0]}"; return 1; }
+  [[ "${_stages[1]}" == "gui" ]] || { echo "expected gui second, got ${_stages[1]}"; return 1; }
+  [[ "${_stages[2]}" == "web" ]] || { echo "expected web third, got ${_stages[2]}"; return 1; }
+}
+
+@test "_parse_stage_sections: ignores plain sections that are not [stage:...]" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[gui]
+mode = auto
+[network]
+mode = host
+[volumes]
+mount_1 = /etc/localtime:/etc/localtime
+EOF
+  local -a _stages=()
+  _parse_stage_sections "${TEMP_DIR}/setup.conf" _stages
+  [[ "${#_stages[@]}" -eq 0 ]] || { echo "expected 0 stages, got ${#_stages[@]}: ${_stages[*]}"; return 1; }
+}
+
+# ─── _load_stage_overrides ────────────────────────────────────────
+
+@test "_load_stage_overrides: returns the keys+values under [stage:NAME]" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[gui]
+mode = auto
+
+[stage:headless]
+gui.mode = off
+network.mode = bridge
+network.port_1 = 8080:80
+volumes.mount_1 = /tmp/cache:/cache
+
+[stage:gui]
+gui.mode = auto
+EOF
+  local -a _keys=() _values=()
+  _load_stage_overrides "${TEMP_DIR}" "headless" _keys _values
+  [[ "${#_keys[@]}" -eq 4 ]] || { echo "expected 4 keys, got ${#_keys[@]}: ${_keys[*]}"; return 1; }
+  [[ "${_keys[0]}" == "gui.mode" && "${_values[0]}" == "off" ]] || return 1
+  [[ "${_keys[1]}" == "network.mode" && "${_values[1]}" == "bridge" ]] || return 1
+  [[ "${_keys[2]}" == "network.port_1" && "${_values[2]}" == "8080:80" ]] || return 1
+  [[ "${_keys[3]}" == "volumes.mount_1" && "${_values[3]}" == "/tmp/cache:/cache" ]] || return 1
+}
+
+@test "_load_stage_overrides: missing setup.conf → empty arrays" {
+  local -a _keys=() _values=()
+  _load_stage_overrides "${TEMP_DIR}" "headless" _keys _values
+  [[ "${#_keys[@]}" -eq 0 ]] || { echo "expected 0 keys, got ${#_keys[@]}: ${_keys[*]}"; return 1; }
+  [[ "${#_values[@]}" -eq 0 ]] || return 1
+}
+
+@test "_load_stage_overrides: stage absent from setup.conf → empty arrays" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[gui]
+mode = auto
+
+[stage:headless]
+gui.mode = off
+EOF
+  local -a _keys=() _values=()
+  _load_stage_overrides "${TEMP_DIR}" "gui" _keys _values
+  [[ "${#_keys[@]}" -eq 0 ]] || { echo "expected 0 keys for absent stage, got ${#_keys[@]}: ${_keys[*]}"; return 1; }
+}
+
+# ─── _validate_stage_override_key ──────────────────────────────────
+
+@test "_validate_stage_override_key: accepts allowlisted scalars" {
+  for _k in \
+    deploy.gpu_mode \
+    deploy.gpu_count \
+    deploy.gpu_capabilities \
+    deploy.runtime \
+    gui.mode \
+    network.mode \
+    network.ipc \
+    network.network_name \
+    security.privileged
+  do
+    run _validate_stage_override_key "${_k}"
+    assert_success
+  done
+}
+
+@test "_validate_stage_override_key: accepts list-item keys with numeric suffix" {
+  for _k in \
+    network.port_1 \
+    network.port_2 \
+    network.port_99 \
+    volumes.mount_1 \
+    volumes.mount_42 \
+    environment.env_1 \
+    environment.env_7
+  do
+    run _validate_stage_override_key "${_k}"
+    assert_success
+  done
+}
+
+@test "_validate_stage_override_key: accepts inherit meta-keys" {
+  for _k in network.port_inherit volumes.mount_inherit environment.env_inherit; do
+    run _validate_stage_override_key "${_k}"
+    assert_success
+  done
+}
+
+@test "_validate_stage_override_key: rejects keys outside allowlist" {
+  for _k in \
+    image.rule_1 \
+    build.arg_1 \
+    build.target_arch \
+    security.cap_add_1 \
+    security.security_opt_1 \
+    devices.device_1 \
+    tmpfs.tmpfs_1 \
+    additional_contexts.context_1 \
+    foo.bar \
+    not_dotted_key
+  do
+    run _validate_stage_override_key "${_k}"
+    [[ "${status}" -ne 0 ]] || { echo "expected failure for ${_k}"; return 1; }
+  done
+}
+
+# ─── _resolve_stage_scalar ─────────────────────────────────────────
+
+@test "_resolve_stage_scalar: returns stage value when override present" {
+  local -a _keys=("gui.mode" "network.mode")
+  local -a _values=("off" "bridge")
+  local _out=""
+  _resolve_stage_scalar _keys _values "gui.mode" "auto" _out
+  [[ "${_out}" == "off" ]] || { echo "expected 'off', got '${_out}'"; return 1; }
+}
+
+@test "_resolve_stage_scalar: returns fallback when key absent" {
+  local -a _keys=("gui.mode")
+  local -a _values=("off")
+  local _out=""
+  _resolve_stage_scalar _keys _values "network.mode" "host" _out
+  [[ "${_out}" == "host" ]] || { echo "expected 'host', got '${_out}'"; return 1; }
+}
+
+@test "_resolve_stage_scalar: returns empty fallback when neither set" {
+  local -a _keys=()
+  local -a _values=()
+  local _out="initial"
+  _resolve_stage_scalar _keys _values "gui.mode" "" _out
+  [[ -z "${_out}" ]] || { echo "expected empty, got '${_out}'"; return 1; }
+}
+
+# ─── _resolve_stage_list ───────────────────────────────────────────
+
+@test "_resolve_stage_list: append-default with stage entries (inherit unset)" {
+  local -a _keys=("volumes.mount_1" "volumes.mount_2")
+  local -a _values=("/tmp/cache:/cache" "/data:/data")
+  local _top="/etc/localtime:/etc/localtime:ro"$'\n'"\${HOME}/.ssh:/home/user/.ssh:ro"
+  local _out=""
+  _resolve_stage_list _keys _values "volumes.mount_" "volumes.mount_inherit" "${_top}" _out
+  # Top-level 2 entries + stage 2 entries = 4 lines
+  local -a _lines=()
+  IFS=$'\n' read -rd '' -a _lines <<< "${_out}" || true
+  [[ "${#_lines[@]}" -eq 4 ]] || { echo "expected 4 lines, got ${#_lines[@]}: ${_out}"; return 1; }
+  [[ "${_lines[0]}" == "/etc/localtime:/etc/localtime:ro" ]] || return 1
+  [[ "${_lines[2]}" == "/tmp/cache:/cache" ]] || return 1
+  [[ "${_lines[3]}" == "/data:/data" ]] || return 1
+}
+
+@test "_resolve_stage_list: replace mode (inherit=false) drops top-level" {
+  local -a _keys=("volumes.mount_inherit" "volumes.mount_1")
+  local -a _values=("false" "/only:/only")
+  local _top="/etc/localtime:/etc/localtime:ro"
+  local _out=""
+  _resolve_stage_list _keys _values "volumes.mount_" "volumes.mount_inherit" "${_top}" _out
+  [[ "${_out}" == "/only:/only" ]] || { echo "expected only stage entry, got '${_out}'"; return 1; }
+}
+
+@test "_resolve_stage_list: empty stage with inherit=true → top-level only" {
+  local -a _keys=()
+  local -a _values=()
+  local _top="/etc/localtime:/etc/localtime:ro"$'\n'"/data:/data"
+  local _out=""
+  _resolve_stage_list _keys _values "volumes.mount_" "volumes.mount_inherit" "${_top}" _out
+  [[ "${_out}" == "${_top}" ]] || { echo "expected top-level passthrough, got '${_out}'"; return 1; }
+}
+
+@test "_resolve_stage_list: empty stage with inherit=false → empty result" {
+  local -a _keys=("volumes.mount_inherit")
+  local -a _values=("false")
+  local _top="/etc/localtime:/etc/localtime:ro"
+  local _out="initial"
+  _resolve_stage_list _keys _values "volumes.mount_" "volumes.mount_inherit" "${_top}" _out
+  [[ -z "${_out}" ]] || { echo "expected empty, got '${_out}'"; return 1; }
+}
+
+@test "_resolve_stage_list: preserves stage entries in setup.conf order" {
+  # User wrote port_3 first, then port_1, then port_2 — preserve that
+  # order rather than re-sorting numerically. The on-disk order is what
+  # the user sees in setup_tui.sh and what _parse_ini_section returns.
+  local -a _keys=("network.port_3" "network.port_1" "network.port_2")
+  local -a _values=("9000:9000" "8080:80" "5000:5000")
+  local _out=""
+  _resolve_stage_list _keys _values "network.port_" "network.port_inherit" "" _out
+  local -a _lines=()
+  IFS=$'\n' read -rd '' -a _lines <<< "${_out}" || true
+  [[ "${_lines[0]}" == "9000:9000" ]] || return 1
+  [[ "${_lines[1]}" == "8080:80" ]] || return 1
+  [[ "${_lines[2]}" == "5000:5000" ]] || return 1
+}
+
+@test "_resolve_stage_list: ignores keys with non-numeric suffix" {
+  # `mount_inherit` is the meta-key, not a list item — must not be
+  # collected even though it shares the `mount_` prefix.
+  local -a _keys=("volumes.mount_1" "volumes.mount_inherit" "volumes.mount_2")
+  local -a _values=("/a:/a" "false" "/b:/b")
+  local _out=""
+  _resolve_stage_list _keys _values "volumes.mount_" "volumes.mount_inherit" "" _out
+  # inherit=false → only stage entries
+  local -a _lines=()
+  IFS=$'\n' read -rd '' -a _lines <<< "${_out}" || true
+  [[ "${#_lines[@]}" -eq 2 ]] || { echo "expected 2, got ${#_lines[@]}: ${_out}"; return 1; }
+  [[ "${_lines[0]}" == "/a:/a" ]] || return 1
+  [[ "${_lines[1]}" == "/b:/b" ]] || return 1
+}
+
+# ─── Per-stage overrides — compose.yaml emit integration (#220) ────
+
+@test "stage-override: regression — stage with NO overrides keeps extends:devel minimal block" {
+  # Zero-diff path: existing 17 downstream repos have setup.conf with
+  # no [stage:*] sections. compose.yaml output for emitted stages must
+  # match #215's extends-only shape exactly.
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM scratch AS sys
+FROM sys AS base
+FROM base AS devel
+FROM devel AS headless
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+  "
+  assert_success
+  # extends: devel still emitted under the headless service block
+  run grep -A 3 '^  headless:$' "${TEMP_DIR}/compose.yaml"
+  assert_output --partial "extends:"
+  assert_output --partial "service: devel"
+  # No `network_mode:`, `ports:`, `volumes:` block underneath headless
+  # (compose extends inherits all from devel — no override block emitted)
+  run bash -c "awk '/^  headless:\$/{f=1; next} /^  [a-z][a-z0-9_-]*:\$/{f=0} f' '${TEMP_DIR}/compose.yaml'"
+  assert_success
+  refute_output --partial "network_mode: bridge"
+  refute_output --partial "ports:"
+  refute_output --partial "volumes:"
+  refute_output --partial "environment:"
+}
+
+@test "stage-override: gui.mode=off in [stage:headless] strips X11 env+volumes from headless" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM scratch AS sys
+FROM sys AS base
+FROM base AS devel
+FROM devel AS headless
+EOF
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[gui]
+mode = force
+
+[stage:headless]
+gui.mode = off
+EOF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+  "
+  assert_success
+  # headless block emits its own environment + volumes (compose
+  # extends's child-replaces-list semantics) — without DISPLAY etc.
+  # Assert explicit override block is present so compose actually drops
+  # parent's X11 entries at runtime (not just absent in source).
+  run bash -c "awk '/^  headless:\$/{f=1; next} /^  [a-z][a-z0-9_-]*:\$/{f=0} f' '${TEMP_DIR}/compose.yaml'"
+  assert_success
+  assert_output --partial "environment:"
+  assert_output --partial "volumes:"
+  refute_output --partial "DISPLAY="
+  refute_output --partial "/tmp/.X11-unix"
+  # devel block (top-level gui = force) still has X11 entries
+  run bash -c "awk '/^  devel:\$/{f=1; next} /^  [a-z][a-z0-9_-]*:\$/{f=0} f' '${TEMP_DIR}/compose.yaml'"
+  assert_success
+  assert_output --partial "DISPLAY="
+}
+
+@test "stage-override: network.mode=bridge + port_1 in [stage:headless] emits per-stage ports" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM scratch AS sys
+FROM sys AS base
+FROM base AS devel
+FROM devel AS headless
+EOF
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[network]
+mode = host
+
+[stage:headless]
+network.mode = bridge
+network.port_1 = 8080:80
+EOF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+  "
+  assert_success
+  # devel still on host
+  run bash -c "awk '/^  devel:\$/{f=1; next} /^  [a-z][a-z0-9_-]*:\$/{f=0} f' '${TEMP_DIR}/compose.yaml'"
+  assert_success
+  # NETWORK_MODE is filled into .env from top-level network.mode=host
+  assert_output --partial "network_mode:"
+  # headless flips to bridge + has its own port mapping
+  run bash -c "awk '/^  headless:\$/{f=1; next} /^  [a-z][a-z0-9_-]*:\$/{f=0} f' '${TEMP_DIR}/compose.yaml'"
+  assert_success
+  assert_output --partial "network_mode: bridge"
+  assert_output --partial "8080:80"
+}
+
+@test "stage-override: volumes.mount_inherit=false drops top-level mounts for that stage" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM scratch AS sys
+FROM sys AS base
+FROM base AS devel
+FROM devel AS headless
+EOF
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[volumes]
+mount_1 =
+mount_2 = /etc/localtime:/etc/localtime:ro
+mount_3 = /data:/data
+
+[stage:headless]
+volumes.mount_inherit = false
+volumes.mount_1 = /only:/only
+EOF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+  "
+  assert_success
+  # headless volumes block contains /only:/only and NOT /etc/localtime
+  run bash -c "awk '/^  headless:\$/{f=1; next} /^  [a-z][a-z0-9_-]*:\$/{f=0} f' '${TEMP_DIR}/compose.yaml'"
+  assert_success
+  assert_output --partial "/only:/only"
+  refute_output --partial "/etc/localtime"
+}
+
+@test "stage-override: orphan [stage:foo] (no foo in Dockerfile) prints WARN, does not abort" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM scratch AS sys
+FROM sys AS base
+FROM base AS devel
+FROM devel AS headless
+EOF
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[stage:headless]
+gui.mode = off
+
+[stage:foo]
+gui.mode = off
+EOF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' 2>&1 >/dev/null
+  "
+  assert_success
+  assert_output --partial "[stage:foo]"
+  # generic phrase — uses our new i18n key
+  assert_output --partial "stage"
+}
+
+@test "stage-override: disallowed override key (image.rule_1) prints WARN and skips that key" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM scratch AS sys
+FROM sys AS base
+FROM base AS devel
+FROM devel AS headless
+EOF
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[stage:headless]
+gui.mode = off
+image.rule_1 = prefix:bogus_
+EOF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' 2>&1 >/dev/null
+  "
+  assert_success
+  assert_output --partial "image.rule_1"
+}
+
+@test "stage-override: [stage:sys] in setup.conf is hard-error (baseline collision)" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM scratch AS sys
+FROM sys AS base
+FROM base AS devel
+FROM devel AS headless
+EOF
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[stage:sys]
+gui.mode = off
+EOF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' 2>&1 >/dev/null
+  "
+  assert_failure
+  assert_output --partial "[stage:sys]"
+}

--- a/test/unit/tui_flow.bats
+++ b/test/unit/tui_flow.bats
@@ -550,3 +550,128 @@ EOF
   [[ "$(ovr_get deploy.gpu_mode)" == "off" ]]
   ! ovr_get deploy.gpu_count
 }
+
+# ════════════════════════════════════════════════════════════════════
+# Per-stage overrides UI (#220)
+# ════════════════════════════════════════════════════════════════════
+
+# Helper: stage a Dockerfile with the given non-baseline stages.
+# Returns the directory path on stdout so callers can pass it to
+# _list_dockerfile_stages_available's optional base-path arg —
+# FILE_PATH is readonly in setup_tui.sh, so tests can't override it.
+_make_dockerfile_with_stages() {
+  local _df="${BATS_TEST_TMPDIR}/Dockerfile"
+  {
+    echo 'FROM scratch AS sys'
+    echo 'FROM sys AS base'
+    echo 'FROM base AS devel'
+    local _s
+    for _s in "$@"; do
+      printf 'FROM devel AS %s\n' "${_s}"
+    done
+    echo 'FROM devel AS test'
+  } > "${_df}"
+  printf '%s' "${BATS_TEST_TMPDIR}"
+}
+
+@test "_list_dockerfile_stages_available: returns non-baseline stages in file order" {
+  local _base
+  _base="$(_make_dockerfile_with_stages headless gui web)"
+  local -a _out=()
+  _list_dockerfile_stages_available _out "${_base}"
+  [[ "${#_out[@]}" -eq 3 ]] || { echo "got ${_out[*]}"; return 1; }
+  [[ "${_out[0]}" == "headless" ]] || return 1
+  [[ "${_out[1]}" == "gui" ]] || return 1
+  [[ "${_out[2]}" == "web" ]] || return 1
+}
+
+@test "_list_dockerfile_stages_available: empty when only baseline stages" {
+  local _base
+  _base="$(_make_dockerfile_with_stages)"
+  local -a _out=()
+  _list_dockerfile_stages_available _out "${_base}"
+  [[ "${#_out[@]}" -eq 0 ]] || { echo "got ${_out[*]}"; return 1; }
+}
+
+@test "_count_stage_overrides: counts unique non-empty keys across OVR + CURRENT" {
+  _TUI_OVR_KEYS=("stage:headless.gui.mode" "stage:headless.network.mode")
+  _TUI_OVR_VALUES=("off" "bridge")
+  _TUI_CURRENT[stage:headless.volumes.mount_1]="/cache:/cache"
+  _TUI_CURRENT[stage:gui.gui.mode]="auto"
+  local _c
+  _count_stage_overrides headless _c
+  [[ "${_c}" -eq 3 ]] || { echo "expected 3, got ${_c}"; return 1; }
+  _count_stage_overrides gui _c
+  [[ "${_c}" -eq 1 ]] || { echo "expected 1, got ${_c}"; return 1; }
+  _count_stage_overrides web _c
+  [[ "${_c}" -eq 0 ]] || { echo "expected 0, got ${_c}"; return 1; }
+}
+
+@test "_count_stage_overrides: skips empty values" {
+  _TUI_OVR_KEYS=("stage:headless.gui.mode")
+  _TUI_OVR_VALUES=("")
+  local _c
+  _count_stage_overrides headless _c
+  [[ "${_c}" -eq 0 ]] || { echo "expected 0, got ${_c}"; return 1; }
+}
+
+@test "_edit_stage_gui: explicit mode write" {
+  _make_dockerfile_with_stages headless
+  queue "0|off"
+  _edit_stage_gui headless
+  [[ "$(ovr_get stage:headless.gui.mode)" == "off" ]] || {
+    echo "expected stage:headless.gui.mode=off, got: '$(ovr_get stage:headless.gui.mode || echo MISSING)'"
+    return 1
+  }
+}
+
+@test "_edit_stage_gui: __inherit clears any existing override" {
+  _make_dockerfile_with_stages headless
+  _TUI_OVR_KEYS=("stage:headless.gui.mode")
+  _TUI_OVR_VALUES=("force")
+  queue "0|__inherit"
+  _edit_stage_gui headless
+  ! ovr_get stage:headless.gui.mode
+  is_removed stage:headless.gui.mode
+}
+
+@test "_edit_stage_scalar: writes the dotted key under stage namespace" {
+  _make_dockerfile_with_stages headless
+  queue "0|bridge"
+  _edit_stage_scalar headless network.mode
+  [[ "$(ovr_get stage:headless.network.mode)" == "bridge" ]] || return 1
+}
+
+@test "_edit_stage_scalar: empty input clears (inherit)" {
+  _TUI_OVR_KEYS=("stage:headless.network.mode")
+  _TUI_OVR_VALUES=("bridge")
+  queue "0|"
+  _edit_stage_scalar headless network.mode
+  ! ovr_get stage:headless.network.mode
+}
+
+@test "_edit_stage_list: __inherit toggle flips false then back to true (clears flag)" {
+  _make_dockerfile_with_stages headless
+  # First toggle: default true → false
+  queue "0|__inherit" "0|__back"
+  _edit_stage_list headless volumes mount_ volumes.mount_inherit
+  [[ "$(ovr_get stage:headless.volumes.mount_inherit)" == "false" ]] || {
+    echo "1st toggle: expected false, got: '$(ovr_get stage:headless.volumes.mount_inherit || echo MISSING)'"
+    return 1
+  }
+  # Second toggle: false → true (which means CLEAR the override)
+  queue "0|__inherit" "0|__back"
+  _edit_stage_list headless volumes mount_ volumes.mount_inherit
+  ! ovr_get stage:headless.volumes.mount_inherit
+}
+
+@test "_edit_stage_list: add appends a list entry under the stage namespace" {
+  _make_dockerfile_with_stages headless
+  # Add → enter "/cache:/cache" → __back
+  queue "0|add" "0|/cache:/cache" "0|__back"
+  _edit_stage_list headless volumes mount_ volumes.mount_inherit
+  [[ "$(ovr_get stage:headless.volumes.mount_1)" == "/cache:/cache" ]] || {
+    echo "got: '$(ovr_get stage:headless.volumes.mount_1 || echo MISSING)'"
+    return 1
+  }
+}

--- a/test/unit/tui_spec.bats
+++ b/test/unit/tui_spec.bats
@@ -1293,3 +1293,167 @@ _b_remove_setup() {
   _v1="$(_override_get "image.rule_1" "")"
   [ -z "${_v1}" ]
 }
+
+# ════════════════════════════════════════════════════════════════════
+# Per-stage [stage:NAME] section round-trip (#220)
+#
+# `_load_setup_conf_full` already namespaces all keys as
+# `<section>.<key>`, so reading `[stage:headless] gui.mode = off`
+# produces `stage:headless.gui.mode = off` automatically (the
+# section name "stage:headless" is opaque to the parser).
+#
+# `_write_setup_conf` historically only handled overrides for
+# sections present in the template. #220 needs it to emit NEW
+# `[stage:NAME]` sections too, since template's setup.conf doesn't
+# carry per-repo stage overrides.
+# ════════════════════════════════════════════════════════════════════
+
+@test "_load_setup_conf_full reads [stage:NAME] sections with namespaced keys" {
+  cat > "${TEMP_DIR}/setup.conf" <<'EOF'
+[gui]
+mode = auto
+
+[stage:headless]
+gui.mode = off
+network.mode = bridge
+network.port_1 = 8080:80
+
+[stage:gui]
+gui.mode = auto
+EOF
+  local -a _sections=() _keys=() _values=()
+  _load_setup_conf_full "${TEMP_DIR}/setup.conf" _sections _keys _values
+
+  # Sections: gui, stage:headless, stage:gui in file order
+  [[ "${_sections[0]}" == "gui" ]] || { echo "expected gui, got ${_sections[0]}"; return 1; }
+  [[ "${_sections[1]}" == "stage:headless" ]] || { echo "expected stage:headless, got ${_sections[1]}"; return 1; }
+  [[ "${_sections[2]}" == "stage:gui" ]] || { echo "expected stage:gui, got ${_sections[2]}"; return 1; }
+
+  # Stage-namespaced keys are present
+  local _found_gui_mode=0 _found_net_mode=0 _found_port=0 _found_gui_stage=0
+  local i
+  for (( i=0; i<${#_keys[@]}; i++ )); do
+    case "${_keys[i]}" in
+      "stage:headless.gui.mode")
+        [[ "${_values[i]}" == "off" ]] && _found_gui_mode=1 ;;
+      "stage:headless.network.mode")
+        [[ "${_values[i]}" == "bridge" ]] && _found_net_mode=1 ;;
+      "stage:headless.network.port_1")
+        [[ "${_values[i]}" == "8080:80" ]] && _found_port=1 ;;
+      "stage:gui.gui.mode")
+        [[ "${_values[i]}" == "auto" ]] && _found_gui_stage=1 ;;
+    esac
+  done
+  (( _found_gui_mode )) || { echo "missing stage:headless.gui.mode=off"; return 1; }
+  (( _found_net_mode )) || { echo "missing stage:headless.network.mode=bridge"; return 1; }
+  (( _found_port )) || { echo "missing stage:headless.network.port_1=8080:80"; return 1; }
+  (( _found_gui_stage )) || { echo "missing stage:gui.gui.mode=auto"; return 1; }
+}
+
+@test "_write_setup_conf appends new [stage:NAME] section when not present in template" {
+  # Template has no per-stage section; user TUI Save adds one. Without
+  # the new-section flush, the override would be silently lost.
+  cat > "${TEMP_DIR}/template.conf" <<'EOF'
+[gui]
+mode = auto
+
+[network]
+mode = host
+EOF
+  local -a _sections=("stage:headless") \
+    _keys=("stage:headless.gui.mode" "stage:headless.network.mode") \
+    _values=("off" "bridge")
+  _write_setup_conf "${TEMP_DIR}/out.conf" "${TEMP_DIR}/template.conf" \
+    _sections _keys _values
+
+  run cat "${TEMP_DIR}/out.conf"
+  assert_success
+  # Original sections preserved
+  assert_output --partial "[gui]"
+  assert_output --partial "mode = auto"
+  assert_output --partial "[network]"
+  assert_output --partial "mode = host"
+  # New stage section emitted with its keys
+  assert_output --partial "[stage:headless]"
+  assert_output --partial "gui.mode = off"
+  assert_output --partial "network.mode = bridge"
+}
+
+@test "_write_setup_conf supports multiple new [stage:*] sections in one write" {
+  cat > "${TEMP_DIR}/template.conf" <<'EOF'
+[gui]
+mode = auto
+EOF
+  local -a _sections=("stage:headless" "stage:gui") \
+    _keys=("stage:headless.gui.mode" "stage:gui.gui.mode") \
+    _values=("off" "force")
+  _write_setup_conf "${TEMP_DIR}/out.conf" "${TEMP_DIR}/template.conf" \
+    _sections _keys _values
+
+  run cat "${TEMP_DIR}/out.conf"
+  assert_success
+  assert_output --partial "[stage:headless]"
+  assert_output --partial "[stage:gui]"
+}
+
+@test "_write_setup_conf round-trips [stage:NAME] via _load_setup_conf_full" {
+  cat > "${TEMP_DIR}/template.conf" <<'EOF'
+[gui]
+mode = auto
+EOF
+  local -a _sections=("gui" "stage:headless") \
+    _keys=("gui.mode" "stage:headless.gui.mode" "stage:headless.network.port_1") \
+    _values=("auto" "off" "8080:80")
+  _write_setup_conf "${TEMP_DIR}/out.conf" "${TEMP_DIR}/template.conf" \
+    _sections _keys _values
+
+  local -a _sect2=() _keys2=() _values2=()
+  _load_setup_conf_full "${TEMP_DIR}/out.conf" _sect2 _keys2 _values2
+
+  # stage:headless section present after round-trip
+  local _has_stage=0 s
+  for s in "${_sect2[@]}"; do
+    [[ "${s}" == "stage:headless" ]] && _has_stage=1
+  done
+  (( _has_stage )) || { echo "stage:headless lost in round-trip: sections=${_sect2[*]}"; return 1; }
+
+  # Both stage keys survive
+  local _found_gui=0 _found_port=0 i
+  for (( i=0; i<${#_keys2[@]}; i++ )); do
+    case "${_keys2[i]}" in
+      "stage:headless.gui.mode")        [[ "${_values2[i]}" == "off" ]] && _found_gui=1 ;;
+      "stage:headless.network.port_1")  [[ "${_values2[i]}" == "8080:80" ]] && _found_port=1 ;;
+    esac
+  done
+  (( _found_gui )) || { echo "stage:headless.gui.mode not round-tripped"; return 1; }
+  (( _found_port )) || { echo "stage:headless.network.port_1 not round-tripped"; return 1; }
+}
+
+@test "_write_setup_conf preserves existing [stage:NAME] when re-saving" {
+  # Common case: user Saves once → repo setup.conf has [stage:headless].
+  # On the next Save (still editing same stage), _commit_and_setup uses
+  # the EXISTING repo conf as the template_src, so [stage:headless] is
+  # already present in template. The writer must update the value
+  # in-place via the existing-section path (not via the new-section
+  # append, which would dup the section).
+  cat > "${TEMP_DIR}/template.conf" <<'EOF'
+[gui]
+mode = auto
+
+[stage:headless]
+gui.mode = off
+EOF
+  local -a _sections=("stage:headless") \
+    _keys=("stage:headless.gui.mode") \
+    _values=("force")
+  _write_setup_conf "${TEMP_DIR}/out.conf" "${TEMP_DIR}/template.conf" \
+    _sections _keys _values
+
+  run cat "${TEMP_DIR}/out.conf"
+  assert_success
+  # Updated value in-place
+  assert_output --partial "gui.mode = force"
+  # Section header appears exactly once (no duplicate appended at EOF)
+  run grep -c "^\[stage:headless\]$" "${TEMP_DIR}/out.conf"
+  assert_output "1"
+}


### PR DESCRIPTION
Closes #220.

## Summary

Generalizes #215's auto-emit so non-baseline Dockerfile stages can override top-level runtime config (gui / deploy / network / volumes / environment) on a per-stage basis instead of sharing devel's config.

Driving use case: NVIDIA Isaac Sim's three-stage shape — `devel` for interactive dev with X11, `headless` for WebRTC livestream that needs `network=bridge` + ports + GPU `video` capability + `gui=off`, `gui` for local-display that needs `gui=auto`. Previously all three stages shared one set of runtime knobs from top-level.

User flow:

```ini
# repo's setup.conf
[gui]
mode = auto

[network]
mode = host

[stage:headless]
gui.mode = off
network.mode = bridge
network.port_1 = 8080:80
deploy.gpu_capabilities = gpu compute utility graphics video
```

Or via `./setup_tui.sh` → Advanced → "Per-stage overrides" (entry only appears when Dockerfile has at least one non-baseline stage).

## Allowlist (v1)

| Section | Keys |
|---|---|
| `[deploy]` | `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime` |
| `[gui]` | `mode` |
| `[network]` | `mode`, `ipc`, `network_name`, `port_<N>`, `port_inherit` |
| `[security]` | `privileged` |
| `[volumes]` | `mount_<N>`, `mount_inherit` |
| `[environment]` | `env_<N>`, `env_inherit` |

Excluded: `[image_name]` (image tag is one per image), `apt_mirror_*` (build-time), other `[security]` keys (no driving use case yet).

List fields use **append-default**: stage's `mount_*` / `port_*` / `env_*` items are appended to top-level. `<list>_inherit = false` switches to replace mode (drop top-level entirely). Reverse toggle preserves stage's own entries in `setup.conf` so flipping back doesn't lose typed values.

## Implementation

### setup.sh

5 new helpers:
- `_parse_stage_sections` — extract `[stage:NAME]` headers from a setup.conf
- `_load_stage_overrides` — load one stage's keys/values via `_parse_ini_section`
- `_validate_stage_override_key` — allowlist gate (returns 0/1)
- `_resolve_stage_scalar` — stage value or fallback
- `_resolve_stage_list` — append-default + inherit-flag list resolver

`generate_compose_yaml` validates `[stage:*]` sections (sys/base/test → hard error, devel → reserved+WARN, foo-not-in-Dockerfile → WARN, disallowed key → WARN per-key) then for each non-baseline stage with overrides emits inline overrides on top of `extends: devel`. Stages without overrides keep the byte-for-byte zero-diff path from #215.

GUI changes force `environment:` + `volumes:` re-emit (compose extends's child-replaces-list semantics drop X11 baseline cleanly when `gui.mode = off`). GPU mode flip-on with new caps re-emits the `deploy:` block.

2 new 4-language i18n keys: `stage_unknown_referenced`, `stage_override_key_not_allowed`.

### _tui_conf.sh

`_write_setup_conf` extended to append NEW sections (track template sections, walk override keys for new-section order in user-input order, emit at EOF). Without this, the first time a user adds `[stage:headless]` via TUI Save the section would be silently dropped.

Reader (`_load_setup_conf_full`) already handled `[stage:*]` via generic `<section>.<key>` namespacing — no change needed.

### setup_tui.sh

New "Per-stage overrides" entry in Advanced menu, **conditional on Dockerfile having ≥1 non-baseline stage** — zero noise for the 17 existing downstream repos.

Submenu structure:
- Stage list (with override-count label per stage)
- Per-stage section picker: gui / deploy / network / volumes / environment
- Typed editors for scalars (radio for `gui.mode`, text input for the rest with empty=inherit)
- List editor for `mount_*` / `port_*` / `env_*` mirrors the existing top-level list editor + adds an inherit-toggle row

14 new 4-language i18n keys (per_stage.* + advanced.per_stage).

### `[stage:devel]` deferred to v2

Marked **reserved** with WARN. The devel block emits compose values as env-var refs (`${NETWORK_MODE}` / `${PRIVILEGED}` / `${IPC_MODE}` from `.env`), so applying `[stage:devel]` overrides cleanly requires either rewriting those refs to literals or threading override values through write_env. Non-trivial; revisit in v2 if a real use case surfaces. The 17 existing repos don't need it (they have only baseline stages).

### GPU-off-when-devel-on limitation

Documented as v1 limitation. Turning GPU off for a stage when `devel` has it on isn't representable via compose extends (no way to "remove" parent's `deploy:` block). The current code skips emitting `deploy:` for stages with `gpu.mode = off`, which means they inherit devel's GPU block. Workaround: set `[deploy] gpu_mode = off` at top-level and per-stage `gpu.mode = force` for the GPU-needing ones.

## Tests

**1011 pass / 0 fail** (+42 since v0.17.0):

| File | New | Coverage |
|---|---|---|
| `setup_spec.bats` | 27 | 20 helper unit + 7 compose-emit integration (zero-diff regression, `gui.mode=off` strips X11, `network.mode=bridge` + ports, `volumes.mount_inherit=false` replaces, orphan WARN, disallowed-key WARN, `[stage:sys]` hard-error) |
| `tui_spec.bats` | 5 | Stage round-trip via `_load_setup_conf_full` / `_write_setup_conf` (namespaced load, append new section, multi-section, full round-trip, in-place update) |
| `tui_flow.bats` | 10 | `_list_dockerfile_stages_available` / `_count_stage_overrides` / `_edit_stage_gui` / `_edit_stage_scalar` / `_edit_stage_list` (inherit toggle + add) |

ShellCheck clean.

## Doc surfaces

- `doc/test/TEST.md` — totals updated (969 → 1011), `setup_spec.bats` (232→259) + `tui_spec.bats` (92→97) + `tui_flow.bats` (53→63), 3 new category rows
- `doc/changelog/CHANGELOG.md` `[Unreleased]` — Added + Tests sections
- 4-language READMEs — new "Per-stage `setup.conf` overrides (#220)" subsection under "Adding extra stages (#215)" plus removal of #215's now-stale "Per-stage diff out-of-scope" bullet

## Out of scope (deferred per #220 design)

- `[stage:devel]` full implementation (reserved + WARN in v1; details above)
- GPU-off-when-devel-on per-stage (compose extends limitation; documented)
- TUI menu restructure (separate issue #221) — per-stage entry placed under Advanced for v1 since it's a power-user feature; #221 tracks whether it should be promoted to Main once user feedback comes in

## Test plan

- [ ] Self Test green (full Bats unit + integration suite + ShellCheck + Hadolint)
- [ ] Reviewer eyeballs `setup.sh` diff: 5 new helpers + validation pass + emit overrides
- [ ] Reviewer eyeballs `setup_tui.sh` diff: per-stage submenu navigation + i18n
- [ ] After merge: tag `v0.18.0-rc1` → real-world Isaac Sim validation → tag `v0.18.0` → fanout 17 repos via `/batch-template-upgrade`
