### PR TITLE
fix(scripts): --help respects --lang regardless of argument order (#222)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`build.sh` / `run.sh` / `exec.sh` / `stop.sh` `--help` now respects `--lang` regardless of argument order** (#222). Previously `<script> --help --lang zh-TW` printed English usage because `usage()` exited via `-h|--help` before the main parse loop reached `--lang`. The reverse order (`--lang` first) worked. Fix: a one-pass scan in each `main()` resolves `--lang` (and via the existing `_sanitize_lang` machinery, `SETUP_LANG`) before the canonical parse loop runs, so both orderings produce the localised usage. Flag surface unchanged. 9 new smoke-test rows in `test/smoke/script_help.bats` (zh-TW / zh-CN / ja across the four scripts).
+
 ### Added
 - **Per-stage `setup.conf` overrides for runtime knobs** (#220). `[stage:<name>]` sections in `<repo>/setup.conf` override top-level settings on a per-stage basis when a corresponding `FROM ... AS <name>` stage exists in the Dockerfile (auto-emitted via #215). Driving use case: NVIDIA Isaac Sim's three-stage shape (`devel` for interactive dev with X11, `headless` for WebRTC livestream that needs `mode=bridge` + ports + GPU `video` capability + `gui=off`, `gui` for local-display that needs `gui=auto`) — previously all three stages shared one set of runtime knobs from top-level. Allowlist (v1):
   - `[deploy]` whole section: `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime`

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -3,11 +3,11 @@
 Template self-tests: **1011 tests** total (957 unit + 54 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
-> what runs in the `Self Test` CI job. The 27 shared smoke tests under
+> what runs in the `Self Test` CI job. The 36 shared smoke tests under
 > `test/smoke/` are a separate suite that runs at Dockerfile `test`-stage
 > build time (via `./build.sh test`) inside both this repo and every
 > downstream repo, and are documented in [Smoke Tests](#smoke-tests)
-> below. They are **not** included in the 969 figure because they are
+> below. They are **not** included in the 1011 figure because they are
 > build-time assertions, not self-tests.
 
 ## Test Files
@@ -756,12 +756,15 @@ so the shared specs and any per-repo `test/smoke/` overlay execute
 together. `display_env.bats` self-skips on headless repos by detecting
 the absence of GUI lines in the generated `compose.yaml`.
 
-### test/smoke/script_help.bats (16)
+### test/smoke/script_help.bats (25)
 
 Locks the `-h` / `--help` invariants on the four wrapper scripts
 (`build.sh` / `run.sh` / `exec.sh` / `stop.sh`) plus the `_LANG`
 auto-detection rules in `build.sh` (`LANG=zh_TW.UTF-8` → zh, `ja_JP`
-→ ja, `en_US` → en, `SETUP_LANG` overrides `LANG`).
+→ ja, `en_US` → en, `SETUP_LANG` overrides `LANG`) plus #222
+`--help` / `--lang` order independence (pre-pass scans for `--lang`
+before main parse so `<script> --help --lang zh-TW` produces zh-TW
+usage, not English).
 
 | Test | Description |
 |------|-------------|

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -144,6 +144,23 @@ EOF
 }
 
 main() {
+  # Pre-pass: scan for --lang so usage() (which exits via -h/--help)
+  # runs in the requested locale even when --help is the first arg.
+  # Issue #222 — without this, `build.sh --help --lang zh-TW` falls
+  # through usage() before the main loop reaches --lang and prints
+  # the default-locale usage. The main parse loop below stays
+  # unchanged so --lang's other side-effects (validation, error on
+  # missing value) still run on the canonical path.
+  local _i
+  for (( _i=1; _i<=$#; _i++ )); do
+    if [[ "${!_i}" == "--lang" ]]; then
+      local _next=$((_i+1))
+      _LANG="${!_next:-}"
+      _sanitize_lang _LANG "build"
+      break
+    fi
+  done
+
   local RUN_SETUP=false
   local RESET_CONF=false
   local ASSUME_YES=false

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -129,6 +129,19 @@ EOF
 }
 
 main() {
+  # Pre-pass: scan for --lang so usage() (which exits via -h/--help)
+  # runs in the requested locale even when --help is the first arg.
+  # See build.sh's main() for the full rationale (#222).
+  local _i
+  for (( _i=1; _i<=$#; _i++ )); do
+    if [[ "${!_i}" == "--lang" ]]; then
+      local _next=$((_i+1))
+      _LANG="${!_next:-}"
+      _sanitize_lang _LANG "exec"
+      break
+    fi
+  done
+
   local TARGET="devel"
   local INSTANCE=""
   DRY_RUN=false

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -186,6 +186,19 @@ _devel_cleanup() {
 }
 
 main() {
+  # Pre-pass: scan for --lang so usage() (which exits via -h/--help)
+  # runs in the requested locale even when --help is the first arg.
+  # See build.sh's main() for the full rationale (#222).
+  local _i
+  for (( _i=1; _i<=$#; _i++ )); do
+    if [[ "${!_i}" == "--lang" ]]; then
+      local _next=$((_i+1))
+      _LANG="${!_next:-}"
+      _sanitize_lang _LANG "run"
+      break
+    fi
+  done
+
   local RUN_SETUP=false
   local DETACH=false
   local PRE_BUILD=false

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -106,6 +106,19 @@ _down_one() {
 }
 
 main() {
+  # Pre-pass: scan for --lang so usage() (which exits via -h/--help)
+  # runs in the requested locale even when --help is the first arg.
+  # See build.sh's main() for the full rationale (#222).
+  local _i
+  for (( _i=1; _i<=$#; _i++ )); do
+    if [[ "${!_i}" == "--lang" ]]; then
+      local _next=$((_i+1))
+      _LANG="${!_next:-}"
+      _sanitize_lang _LANG "stop"
+      break
+    fi
+  done
+
   local INSTANCE=""
   local ALL_INSTANCES=false
   DRY_RUN=false

--- a/test/smoke/script_help.bats
+++ b/test/smoke/script_help.bats
@@ -97,3 +97,65 @@ setup() {
   assert_success
   assert_line --partial "用法:"
 }
+
+# -------------------- #222: --help / --lang argument order --------------------
+#
+# Pre-pass scans args for --lang before the main parse loop, so the
+# locale set by --lang takes effect even when --help comes first.
+# Without the fix, `<script> --help --lang zh-TW` printed English
+# because usage() exited before --lang was reached. Each pair below
+# asserts that BOTH orderings produce the same localised first line.
+
+@test "build.sh --help --lang zh-TW prints zh-TW usage (#222)" {
+  run bash /lint/build.sh --help --lang zh-TW
+  assert_success
+  assert_line --partial "用法:"
+}
+
+@test "build.sh --help --lang zh-CN prints zh-CN usage (#222)" {
+  run bash /lint/build.sh --help --lang zh-CN
+  assert_success
+  assert_line --partial "用法:"
+}
+
+@test "build.sh --help --lang ja prints ja usage (#222)" {
+  run bash /lint/build.sh --help --lang ja
+  assert_success
+  assert_line --partial "使用法:"
+}
+
+@test "run.sh --help --lang zh-TW prints zh-TW usage (#222)" {
+  run bash /lint/run.sh --help --lang zh-TW
+  assert_success
+  assert_line --partial "用法:"
+}
+
+@test "run.sh --help --lang ja prints ja usage (#222)" {
+  run bash /lint/run.sh --help --lang ja
+  assert_success
+  assert_line --partial "使用法:"
+}
+
+@test "exec.sh --help --lang zh-TW prints zh-TW usage (#222)" {
+  run bash /lint/exec.sh --help --lang zh-TW
+  assert_success
+  assert_line --partial "用法:"
+}
+
+@test "exec.sh --help --lang ja prints ja usage (#222)" {
+  run bash /lint/exec.sh --help --lang ja
+  assert_success
+  assert_line --partial "使用法:"
+}
+
+@test "stop.sh --help --lang zh-TW prints zh-TW usage (#222)" {
+  run bash /lint/stop.sh --help --lang zh-TW
+  assert_success
+  assert_line --partial "用法:"
+}
+
+@test "stop.sh --help --lang ja prints ja usage (#222)" {
+  run bash /lint/stop.sh --help --lang ja
+  assert_success
+  assert_line --partial "使用法:"
+}


### PR DESCRIPTION
Closes #222.

## Summary

`build.sh` / `run.sh` / `exec.sh` / `stop.sh` `--help` ignored `--lang` when `--help` came first in the argv:

- `./build.sh --help --lang zh-TW | head -1` printed the English `Usage:` line (bug).
- `./build.sh --lang zh-TW --help | head -1` printed the localised line (worked already).

Root cause: `usage()` exits via `-h|--help` at the top of each `case`, so the loop never reaches the later `--lang` arm.

## Fix

A one-pass scan in each `main()` resolves `--lang` (and via the existing `_sanitize_lang` machinery, `SETUP_LANG`) before the canonical parse loop runs. Per the issue body's proposal:

```bash
local _i
for (( _i=1; _i<=$#; _i++ )); do
  if [[ "${!_i}" == "--lang" ]]; then
    local _next=$((_i+1))
    _LANG="${!_next:-}"
    _sanitize_lang _LANG "build"
    break
  fi
done
```

Flag surface unchanged. The main parse loop is untouched, so `--lang`'s other side-effects (validation, error on missing value) still run on the canonical path. Both orderings now produce the localised first line, verified manually for `zh-TW` / `zh-CN` / `ja` across all four scripts.

## Tests

9 new smoke-test rows in `test/smoke/script_help.bats` covering `zh-TW` / `zh-CN` / `ja` across the four scripts (3 for build.sh, 2 each for run/exec/stop -- exec.sh and stop.sh share the same `ja` prefix as run.sh so a single per-script `ja` row plus `zh-TW` is sufficient coverage).

Existing 1011-test self-test suite (unit + integration) unchanged. ShellCheck clean.

## Out of scope (per issue)

- `setup.sh` has its own `--lang` parse and is invoked through `_run_interactive`, not as a user-facing entry point. Not affected.
- No CHANGELOG version-bump implication beyond a normal PATCH; flag surface unchanged.

## Test plan

- [ ] Self Test green (full Bats unit + integration suite + ShellCheck + Hadolint)
- [ ] Reviewer eyeballs the 4 script diffs (mechanical pre-pass insertion + one comment block per script)
- [ ] Reviewer eyeballs `script_help.bats` diff (9 new test cases following the existing per-script convention)
- [ ] After merge: lands on main before v0.18.0 stable tag, so the fix bundles into v0.18.0 along with #220
