### PR TITLE
feat(setup_tui): restructure main menu + add Runtime/Mounts/Features sub-menus (#221)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,16 @@ network.port_1 = 8080:80
 deploy.gpu_capabilities = gpu compute utility graphics video
 ```
 
-Use `./setup_tui.sh` → Advanced → "Per-stage overrides" for an
-interactive editor; the entry only appears when your Dockerfile has at
-least one non-baseline stage.
+Use `./setup_tui.sh` for an interactive editor:
+
+- **Advanced → Per-stage overrides**: drills straight into the editor.
+  The entry only appears when your Dockerfile has at least one
+  non-baseline stage.
+- **Features → Per-stage overrides** (#221): always-visible
+  discoverability surface that lists conditional / power-user
+  features. When the precondition is met it acts as a shortcut into
+  the same editor; when not, it pops a msgbox explaining how to
+  enable.
 
 Allowlist (v1 — keys that can be overridden per-stage):
 
@@ -326,7 +333,24 @@ is copied to the repo and the detected workspace is written to
 
 ### Interactive TUI
 
-`./setup_tui.sh` opens the main menu and lets you edit values across all sections; the backend is `dialog` or `whiptail` (when both are missing it prints a `sudo apt install dialog` hint and exits). Cancel / Esc leaves without saving; saving auto-invokes `setup.sh` to regenerate `.env` + `compose.yaml`.
+`./setup_tui.sh` opens the main menu. The backend is `dialog` or `whiptail` (when both are missing it prints a `sudo apt install dialog` hint and exits). Cancel / Esc leaves without saving; saving auto-invokes `setup.sh` to regenerate `.env` + `compose.yaml`.
+
+Main menu structure (#221):
+
+```
+Main
+├─ image            IMAGE_NAME detection rules
+├─ build            APT mirrors + Dockerfile build args
+├─ Runtime  ──→     network / deploy (GPU) / gui / environment
+├─ Mounts   ──→     volumes / devices / tmpfs
+├─ Advanced ──→     security / additional_contexts
+│                   / per_stage (conditional) / Reset
+├─ Features         conditional / power-user features index
+│                   (today: per_stage status row)
+└─ Save & Exit
+```
+
+`./setup_tui.sh <section>` still drills directly into a section editor (e.g. `./setup_tui.sh volumes`), bypassing the main menu.
 
 ### When setup.sh runs
 

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`setup_tui.sh` main menu restructured into 5 grouped entries + `Features` discoverability surface** (#221). Top-level main now shows `image`, `build`, `runtime`, `mounts`, `advanced`, `features`, `Save & Exit` — replacing the previous flat list of 5 runtime/mount sections + `advanced` mixed at the same level. `runtime` (network / GPU / display / env vars) and `mounts` (volumes / devices / tmpfs) are sub-menu groupers; `image` and `build` get promoted from Advanced because they are commonly tweaked when wiring a new repo. Advanced is slimmed to truly-advanced knobs (security, named build contexts, conditional per-stage overrides, Reset). The new `features` entry is permanently visible and lists conditional / power-user features with a status row (today: `Per-stage overrides — enabled (N stages)` when a non-baseline `FROM ... AS <name>` exists, otherwise `— hidden (no non-baseline stages)`); clicking the disabled row pops a msgbox explaining how to enable, clicking the enabled row drills into the same editor as the conditional Advanced entry. No semantic change to any underlying section editor — every existing `_edit_section_*` is reachable via the new layout.
+
+### Added
+- 12 i18n keys × 4 languages for the new menu structure: `main.runtime` / `main.mounts` / `main.features`, `runtime.title` / `.menu` / `.back`, `mounts.title` / `.menu` / `.back`, `features.title` / `.menu` / `.back`, `features.per_stage_enabled` / `features.per_stage_hidden` / `features.per_stage_hidden_info`.
+
 ## [v0.18.2] - 2026-05-07
 
 Patch release that ships **the correct `.version` metadata** for the work that landed under the v0.18.0 / v0.18.1 git tags. Both prior tags shipped without the standard `chore: release` step, so their tagged commits still carried `.version = v0.17.0`. Downstream consumers ended up with a stale `template/.version` after `make upgrade`, which made `make upgrade-check` perpetually report "upgrade available". Functionally those tags were correct (workflows, scripts, tests all matched their version), but the metadata file lied.

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -225,9 +225,15 @@ network.port_1 = 8080:80
 deploy.gpu_capabilities = gpu compute utility graphics video
 ```
 
-`./setup_tui.sh` → Advanced → 「Per-stage overrides」でも対話的に
-編集できます。このメニューは Dockerfile に少なくとも 1 つの
-非 baseline stage がある場合のみ表示されます。
+`./setup_tui.sh` でも対話的に編集できます：
+
+- **Advanced → Per-stage overrides**：直接エディタへ。このエントリ
+  は Dockerfile に少なくとも 1 つの非 baseline stage がある場合の
+  み表示されます。
+- **Features → Per-stage overrides**（#221）：常時表示の機能一覧
+  入口。条件を満たしている時はクリックで上記 Advanced と同じ
+  エディタへ、満たしていない時は有効化方法を説明する msgbox を
+  表示します。
 
 Override 可能な key (v1)：
 
@@ -321,11 +327,28 @@ template ファイルが repo にコピーされ、検出された workspace が
 
 ### インタラクティブ TUI
 
-`./setup_tui.sh` はメインメニューを開き、6 つの section すべての値を
-編集できます。バックエンドは `dialog` または `whiptail`（どちらも
-無い場合は `sudo apt install dialog` のヒントを表示して終了）。
-Cancel / Esc で保存せず退出；保存後は自動的に `setup.sh` を呼び
-出して `.env` + `compose.yaml` を再生成します。
+`./setup_tui.sh` はメインメニューを開きます。バックエンドは
+`dialog` または `whiptail`（どちらも無い場合は `sudo apt install
+dialog` のヒントを表示して終了）。Cancel / Esc で保存せず退出；
+保存後は自動的に `setup.sh` を呼び出して `.env` + `compose.yaml`
+を再生成します。
+
+メインメニュー構造（#221）：
+
+```
+Main
+├─ image            IMAGE_NAME 検出ルール
+├─ build            APT mirrors + Dockerfile build args
+├─ Runtime  ──→     network / deploy（GPU）/ gui / environment
+├─ Mounts   ──→     volumes / devices / tmpfs
+├─ Advanced ──→     security / additional_contexts
+│                   / per_stage（条件付き）/ Reset
+├─ Features         条件付き / 上級者向け機能の一覧（per_stage の状態を含む）
+└─ Save & Exit
+```
+
+`./setup_tui.sh <section>` は引き続き任意の section エディタへ
+直接ジャンプできます（例：`./setup_tui.sh volumes`）。
 
 ### setup.sh の実行タイミング
 

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -220,9 +220,13 @@ network.port_1 = 8080:80
 deploy.gpu_capabilities = gpu compute utility graphics video
 ```
 
-也可以用 `./setup_tui.sh` → Advanced → 「Per-stage overrides」走
-交互式编辑；该 entry 仅在 Dockerfile 有至少一个非 baseline stage
-时才显示。
+也可以用 `./setup_tui.sh` 走交互式编辑：
+
+- **Advanced → Per-stage overrides**：直接进编辑器；该 entry 仅
+  在 Dockerfile 有至少一个非 baseline stage 时才显示。
+- **Features → Per-stage overrides**（#221）：永久可见的功能总
+  览入口；条件已满足时点击等同上述 Advanced 路径，未满足时会
+  弹 msgbox 说明如何启用。
 
 允许 override 的 key（v1）：
 
@@ -310,10 +314,27 @@ template；没写的 section 则吃 template 默认。
 
 ### 交互式 TUI
 
-`./setup_tui.sh` 打开主菜单，可编辑 6 个 section 的所有值，底层是
-`dialog` 或 `whiptail`（两者都缺时会打印 `sudo apt install dialog`
-提示并退出）。按 Cancel / Esc 不存档离开；存档后会自动调用
-`setup.sh` 重新生成 `.env` + `compose.yaml`。
+`./setup_tui.sh` 打开主菜单。底层是 `dialog` 或 `whiptail`（两者
+都缺时会打印 `sudo apt install dialog` 提示并退出）。按 Cancel /
+Esc 不存档离开；存档后会自动调用 `setup.sh` 重新生成 `.env` +
+`compose.yaml`。
+
+主菜单结构（#221）：
+
+```
+Main
+├─ image            IMAGE_NAME 检测规则
+├─ build            APT mirrors + Dockerfile build args
+├─ Runtime  ──→     network / deploy（GPU）/ gui / environment
+├─ Mounts   ──→     volumes / devices / tmpfs
+├─ Advanced ──→     security / additional_contexts
+│                   / per_stage（条件式）/ Reset
+├─ Features         条件式 / 进阶使用功能总览（含 per_stage 状态）
+└─ Save & Exit
+```
+
+`./setup_tui.sh <section>` 仍可直接跳到任意 section 的编辑器
+（如 `./setup_tui.sh volumes`），不必走主菜单。
 
 ### setup.sh 什么时候运行
 

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -220,9 +220,13 @@ network.port_1 = 8080:80
 deploy.gpu_capabilities = gpu compute utility graphics video
 ```
 
-也可以用 `./setup_tui.sh` → Advanced → 「Per-stage overrides」走互動
-式編輯；該 entry 只在 Dockerfile 有至少一個非 baseline stage 時才會
-出現。
+也可以用 `./setup_tui.sh` 走互動式編輯：
+
+- **Advanced → Per-stage overrides**：直接進編輯器；該 entry 只在
+  Dockerfile 有至少一個非 baseline stage 時才會出現。
+- **Features → Per-stage overrides**（#221）：永久可見的功能總覽
+  入口；條件已滿足時點下去等同上述 Advanced 路徑，未滿足時會跳
+  msgbox 說明如何啟用。
 
 允許 override 的 key（v1）：
 
@@ -310,10 +314,27 @@ template；沒寫的 section 則吃 template 預設。
 
 ### 互動式 TUI
 
-`./setup_tui.sh` 開啟主選單，可編輯 6 個 section 全部的值，底層是
-`dialog` 或 `whiptail`（兩者都缺時會印出 `sudo apt install dialog`
-提示並退出）。按 Cancel / Esc 不存檔離開；存檔後會自動呼叫
-`setup.sh` 重新產生 `.env` + `compose.yaml`。
+`./setup_tui.sh` 開啟主選單。底層是 `dialog` 或 `whiptail`（兩者都
+缺時會印出 `sudo apt install dialog` 提示並退出）。按 Cancel / Esc
+不存檔離開；存檔後會自動呼叫 `setup.sh` 重新產生 `.env` +
+`compose.yaml`。
+
+主選單結構（#221）：
+
+```
+Main
+├─ image            IMAGE_NAME 偵測規則
+├─ build            APT mirrors + Dockerfile build args
+├─ Runtime  ──→     network / deploy（GPU）/ gui / environment
+├─ Mounts   ──→     volumes / devices / tmpfs
+├─ Advanced ──→     security / additional_contexts
+│                   / per_stage（條件式）/ Reset
+├─ Features         條件式 / 進階使用功能總覽（含 per_stage 狀態）
+└─ Save & Exit
+```
+
+`./setup_tui.sh <section>` 仍可直接跳到任意 section 的編輯器
+（如 `./setup_tui.sh volumes`），不必走主選單。
 
 ### setup.sh 什麼時候跑
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1012 tests** total (958 unit + 54 integration).
+Template self-tests: **1043 tests** total (989 unit + 54 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -121,7 +121,7 @@ a canned response; exercised with `TUI_STUB_RESPONSE` / `TUI_STUB_EXIT`.
 | `_tui_msgbox` / `_tui_yesno` (correct flags, propagates exit code) | 2 |
 | whiptail flag-spelling translation (#136: `--ok-button` / `--cancel-button` instead of `--*-label`, no `--extra-button`) + Save-button unification (#178: dialog also drops `--extra-button`) | 6 |
 
-### test/unit/tui_flow.bats (63)
+### test/unit/tui_flow.bats (94)
 
 Interactive-flow tests for `setup_tui.sh` (#189). Sources `setup_tui.sh`
 directly and overrides `_tui_menu` / `_tui_select` / `_tui_inputbox` /
@@ -147,6 +147,7 @@ target areas the issue body called out.
 | `_edit_section_deploy` (off short-circuits — only writes gpu_mode) | 1 |
 | Multi-section dispatch from main menu (network → host → save) | 1 |
 | Per-stage UI #220 (`_list_dockerfile_stages_available` from-Dockerfile + baseline filter, `_count_stage_overrides` OVR+CURRENT dedup + empty skip, `_edit_stage_gui` mode + __inherit, `_edit_stage_scalar` write + empty-clears, `_edit_stage_list` inherit toggle + add) | 10 |
+| Menu restructure #221 (i18n keys for main.runtime/mounts/features × 4 langs; `_render_runtime_menu` / `_render_mounts_menu` / `_render_features_menu` function existence; main-menu dispatch for image/build/runtime/mounts/features + bare network/deploy/gui/volumes/environment no longer dispatch from main; Runtime sub-menu dispatch for network/deploy/gui/environment + __back/Cancel; Mounts sub-menu dispatch for volumes/devices/tmpfs + __back/Cancel; Features sub-menu __back, per_stage enabled enters editor, per_stage hidden shows msgbox without entering editor; Advanced sub-menu image/build/devices/tmpfs entries removed, security still dispatches) | 31 |
 
 ### test/unit/build_worker_yaml_spec.bats (15)
 

--- a/script/docker/setup_tui.sh
+++ b/script/docker/setup_tui.sh
@@ -51,6 +51,21 @@ _TUI_MSG_EN[main.advanced]="Advanced"
 _TUI_MSG_EN[main.save]="Save & Exit"
 _TUI_MSG_EN[main.security]="privileged / cap_add / security_opt"
 _TUI_MSG_EN[main.additional_contexts]="Named build contexts (build.additional_contexts)"
+_TUI_MSG_EN[main.runtime]="Runtime (network / GPU / display / env)"
+_TUI_MSG_EN[main.mounts]="Mounts (volumes / devices / tmpfs)"
+_TUI_MSG_EN[main.features]="Features (conditional / power-user)"
+_TUI_MSG_EN[runtime.title]="Runtime"
+_TUI_MSG_EN[runtime.menu]="Select a runtime section"
+_TUI_MSG_EN[runtime.back]="Back to main menu"
+_TUI_MSG_EN[mounts.title]="Mounts"
+_TUI_MSG_EN[mounts.menu]="Select a mount section"
+_TUI_MSG_EN[mounts.back]="Back to main menu"
+_TUI_MSG_EN[features.title]="Features"
+_TUI_MSG_EN[features.menu]="Conditional / power-user features"
+_TUI_MSG_EN[features.back]="Back to main menu"
+_TUI_MSG_EN[features.per_stage_enabled]="Per-stage overrides — enabled (%s stages)"
+_TUI_MSG_EN[features.per_stage_hidden]="Per-stage overrides — hidden (no non-baseline stages)"
+_TUI_MSG_EN[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\nStatus: hidden\nReason: Dockerfile defines no non-baseline stage (sys, base, devel,\n        test are reserved baseline names).\n\nEnable: add `FROM ... AS <stage>` for any custom name, then return\n        to this menu — the entry will activate automatically.'
 _TUI_MSG_EN[advanced.title]="Advanced"
 _TUI_MSG_EN[advanced.menu]="Select an advanced section"
 _TUI_MSG_EN[advanced.back]="Back to main menu"
@@ -227,6 +242,21 @@ _TUI_MSG_ZH_TW[main.advanced]="進階"
 _TUI_MSG_ZH_TW[main.save]="儲存並結束"
 _TUI_MSG_ZH_TW[main.security]="privileged／cap_add／security_opt"
 _TUI_MSG_ZH_TW[main.additional_contexts]="具名 build context（build.additional_contexts）"
+_TUI_MSG_ZH_TW[main.runtime]="執行時期（網路／GPU／顯示／環境變數）"
+_TUI_MSG_ZH_TW[main.mounts]="掛載（volumes／devices／tmpfs）"
+_TUI_MSG_ZH_TW[main.features]="功能（條件式／進階使用）"
+_TUI_MSG_ZH_TW[runtime.title]="執行時期"
+_TUI_MSG_ZH_TW[runtime.menu]="選擇執行時期區段"
+_TUI_MSG_ZH_TW[runtime.back]="回主選單"
+_TUI_MSG_ZH_TW[mounts.title]="掛載"
+_TUI_MSG_ZH_TW[mounts.menu]="選擇掛載區段"
+_TUI_MSG_ZH_TW[mounts.back]="回主選單"
+_TUI_MSG_ZH_TW[features.title]="功能"
+_TUI_MSG_ZH_TW[features.menu]="條件式／進階使用功能"
+_TUI_MSG_ZH_TW[features.back]="回主選單"
+_TUI_MSG_ZH_TW[features.per_stage_enabled]="Per-stage overrides — 已啟用（%s 個 stage）"
+_TUI_MSG_ZH_TW[features.per_stage_hidden]="Per-stage overrides — 隱藏（無非 baseline stage）"
+_TUI_MSG_ZH_TW[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\n狀態：隱藏\n原因：Dockerfile 沒有非 baseline stage（sys、base、devel、test\n      為保留的 baseline 名稱）。\n\n啟用方式：在 Dockerfile 加上 `FROM ... AS <stage>`（任意自訂\n         名稱），再回到此選單，項目會自動啟用。'
 _TUI_MSG_ZH_TW[advanced.title]="Advanced"
 _TUI_MSG_ZH_TW[advanced.menu]="選擇進階區段"
 _TUI_MSG_ZH_TW[advanced.back]="回主選單"
@@ -401,6 +431,21 @@ _TUI_MSG_ZH_CN[main.advanced]="进阶"
 _TUI_MSG_ZH_CN[main.save]="保存并退出"
 _TUI_MSG_ZH_CN[main.security]="privileged／cap_add／security_opt"
 _TUI_MSG_ZH_CN[main.additional_contexts]="具名 build context（build.additional_contexts）"
+_TUI_MSG_ZH_CN[main.runtime]="运行时（网络／GPU／显示／环境变量）"
+_TUI_MSG_ZH_CN[main.mounts]="挂载（volumes／devices／tmpfs）"
+_TUI_MSG_ZH_CN[main.features]="功能（条件式／进阶使用）"
+_TUI_MSG_ZH_CN[runtime.title]="运行时"
+_TUI_MSG_ZH_CN[runtime.menu]="选择运行时区段"
+_TUI_MSG_ZH_CN[runtime.back]="回主菜单"
+_TUI_MSG_ZH_CN[mounts.title]="挂载"
+_TUI_MSG_ZH_CN[mounts.menu]="选择挂载区段"
+_TUI_MSG_ZH_CN[mounts.back]="回主菜单"
+_TUI_MSG_ZH_CN[features.title]="功能"
+_TUI_MSG_ZH_CN[features.menu]="条件式／进阶使用功能"
+_TUI_MSG_ZH_CN[features.back]="回主菜单"
+_TUI_MSG_ZH_CN[features.per_stage_enabled]="Per-stage overrides — 已启用（%s 个 stage）"
+_TUI_MSG_ZH_CN[features.per_stage_hidden]="Per-stage overrides — 隐藏（无非 baseline stage）"
+_TUI_MSG_ZH_CN[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\n状态：隐藏\n原因：Dockerfile 没有非 baseline stage（sys、base、devel、test\n      为保留的 baseline 名称）。\n\n启用方式：在 Dockerfile 加上 `FROM ... AS <stage>`（任意自定\n         名称），再回到此菜单，项目会自动启用。'
 _TUI_MSG_ZH_CN[advanced.title]="Advanced"
 _TUI_MSG_ZH_CN[advanced.menu]="选择进阶区段"
 _TUI_MSG_ZH_CN[advanced.back]="回主菜单"
@@ -570,6 +615,21 @@ _TUI_MSG_JA[main.advanced]="詳細"
 _TUI_MSG_JA[main.save]="保存して終了"
 _TUI_MSG_JA[main.security]="privileged／cap_add／security_opt"
 _TUI_MSG_JA[main.additional_contexts]="名前付き build context（build.additional_contexts）"
+_TUI_MSG_JA[main.runtime]="ランタイム（ネットワーク／GPU／表示／環境変数）"
+_TUI_MSG_JA[main.mounts]="マウント（volumes／devices／tmpfs）"
+_TUI_MSG_JA[main.features]="機能（条件付き／上級者向け）"
+_TUI_MSG_JA[runtime.title]="ランタイム"
+_TUI_MSG_JA[runtime.menu]="ランタイムセクションを選択"
+_TUI_MSG_JA[runtime.back]="メインメニューへ戻る"
+_TUI_MSG_JA[mounts.title]="マウント"
+_TUI_MSG_JA[mounts.menu]="マウントセクションを選択"
+_TUI_MSG_JA[mounts.back]="メインメニューへ戻る"
+_TUI_MSG_JA[features.title]="機能"
+_TUI_MSG_JA[features.menu]="条件付き／上級者向け機能"
+_TUI_MSG_JA[features.back]="メインメニューへ戻る"
+_TUI_MSG_JA[features.per_stage_enabled]="Per-stage overrides — 有効（%s ステージ）"
+_TUI_MSG_JA[features.per_stage_hidden]="Per-stage overrides — 非表示（非ベースライン stage なし）"
+_TUI_MSG_JA[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\nステータス：非表示\n理由：Dockerfile に非ベースライン stage がありません（sys、base、\n      devel、test はベースラインの予約名です）。\n\n有効化：Dockerfile に `FROM ... AS <stage>` を追加（任意のカスタム名）\n        してからこのメニューに戻ると、項目が自動的に有効になります。'
 _TUI_MSG_JA[advanced.title]="Advanced"
 _TUI_MSG_JA[advanced.menu]="Advanced セクションを選択"
 _TUI_MSG_JA[advanced.back]="メインメニューへ戻る"
@@ -1936,22 +1996,31 @@ _render_main_menu() {
   # screenshots / docs. Standardizing on a synthetic `__save` entry
   # gives identical layout regardless of backend; the small extra
   # navigation step on dialog is acceptable for the consistency win.
+  # Main menu structure (#221):
+  #   image / build           — top-level (frequently tweaked when wiring a repo)
+  #   runtime / mounts        — sub-menu groupers (lifecycle-stage groupings)
+  #   advanced                — power-user sections (security / contexts / per-stage)
+  #   features                — discoverability for conditional / power-user features
+  #   Save & Exit             — synthetic entry, see #178 note above
   while :; do
     local _choice _rc
     _choice="$(_tui_menu "$(_tui_msg title)" "$(_tui_msg main.prompt)" \
-      network     "$(_tui_msg main.network)" \
-      deploy      "$(_tui_msg main.deploy)" \
-      gui         "$(_tui_msg main.gui)" \
-      volumes     "$(_tui_msg main.volumes)" \
-      environment "$(_tui_msg main.environment)" \
-      advanced    "$(_tui_msg main.advanced)" \
-      __save      "$(_tui_msg main.save)")"
+      image     "$(_tui_msg main.image)" \
+      build     "$(_tui_msg main.build)" \
+      runtime   "$(_tui_msg main.runtime)" \
+      mounts    "$(_tui_msg main.mounts)" \
+      advanced  "$(_tui_msg main.advanced)" \
+      features  "$(_tui_msg main.features)" \
+      __save    "$(_tui_msg main.save)")"
     _rc=$?
     case "${_rc}" in
       0)
         case "${_choice}" in
-          network|deploy|gui|volumes|environment) "_edit_section_${_choice}" ;;
+          image|build) "_edit_section_${_choice}" ;;
+          runtime)  _render_runtime_menu ;;
+          mounts)   _render_mounts_menu ;;
           advanced) _render_advanced_menu ;;
+          features) _render_features_menu ;;
           __save)   TUI_OK_LABEL=""; TUI_CANCEL_LABEL=""; return 0 ;;
           "")       TUI_OK_LABEL=""; TUI_CANCEL_LABEL=""; return 1 ;;
         esac
@@ -1961,19 +2030,100 @@ _render_main_menu() {
   done
 }
 
-_render_advanced_menu() {
+_render_runtime_menu() {
+  # Runtime grouper (#221): network / GPU / display / env vars — all
+  # the things that take effect when the container actually runs.
   while :; do
     local _choice
-    # Per-stage entry is only shown when the Dockerfile has at least
-    # one non-baseline stage (#220). Zero-noise for the 17 existing
-    # downstream repos that ship with only baseline stages.
+    _choice="$(_tui_menu "$(_tui_msg runtime.title)" "$(_tui_msg runtime.menu)" \
+      network     "$(_tui_msg main.network)" \
+      deploy      "$(_tui_msg main.deploy)" \
+      gui         "$(_tui_msg main.gui)" \
+      environment "$(_tui_msg main.environment)" \
+      __back      "$(_tui_msg runtime.back)")" || break
+    case "${_choice}" in
+      network|deploy|gui|environment) "_edit_section_${_choice}" ;;
+      __back|"") break ;;
+    esac
+  done
+}
+
+_render_mounts_menu() {
+  # Mounts grouper (#221): volumes / devices / tmpfs — host->container
+  # resource bindings.
+  while :; do
+    local _choice
+    _choice="$(_tui_menu "$(_tui_msg mounts.title)" "$(_tui_msg mounts.menu)" \
+      volumes "$(_tui_msg main.volumes)" \
+      devices "$(_tui_msg main.devices)" \
+      tmpfs   "$(_tui_msg main.tmpfs)" \
+      __back  "$(_tui_msg mounts.back)")" || break
+    case "${_choice}" in
+      volumes|devices|tmpfs) "_edit_section_${_choice}" ;;
+      __back|"") break ;;
+    esac
+  done
+}
+
+# _render_features_menu [base_path]
+#
+# Always-visible discoverability surface for conditional / power-user
+# features (#221 acceptance for the third sub-question of the issue).
+# Each feature row shows current status — "enabled (N ...)" when the
+# preconditions are satisfied, "hidden (...)" when not. Clicking a
+# disabled row pops an msgbox explaining how to enable; clicking an
+# enabled row drills into the same editor the conditional Advanced
+# entry uses (per_stage is the only such feature today).
+#
+# The optional base_path arg threads through to the
+# _list_dockerfile_stages_available probe (FILE_PATH is readonly, so
+# tests pass an alternate base_path here to stage a fake Dockerfile).
+# shellcheck disable=SC2120  # production callers pass no args; tests pass base_path
+_render_features_menu() {
+  local _base_path="${1:-}"
+  while :; do
+    local _choice
+    local -a _stages=()
+    if [[ -n "${_base_path}" ]]; then
+      _list_dockerfile_stages_available _stages "${_base_path}"
+    else
+      _list_dockerfile_stages_available _stages
+    fi
+    local _per_stage_label
+    if (( ${#_stages[@]} > 0 )); then
+      # shellcheck disable=SC2059  # format string sourced from our own i18n table
+      printf -v _per_stage_label "$(_tui_msg features.per_stage_enabled)" "${#_stages[@]}"
+    else
+      _per_stage_label="$(_tui_msg features.per_stage_hidden)"
+    fi
+    _choice="$(_tui_menu "$(_tui_msg features.title)" "$(_tui_msg features.menu)" \
+      per_stage "${_per_stage_label}" \
+      __back    "$(_tui_msg features.back)")" || break
+    case "${_choice}" in
+      per_stage)
+        if (( ${#_stages[@]} > 0 )); then
+          _edit_section_per_stage
+        else
+          _tui_msgbox "$(_tui_msg features.title)" \
+            "$(_tui_msg features.per_stage_hidden_info)"
+        fi
+        ;;
+      __back|"") break ;;
+    esac
+  done
+}
+
+_render_advanced_menu() {
+  # Slimmed for #221: image / build promoted to main; devices / tmpfs
+  # moved to Mounts. What's left here is truly advanced — security
+  # capabilities, named build contexts, per-stage overrides (still
+  # conditional so 17 baseline-only repos see no noise here; Features
+  # menu surfaces it for everyone), and Reset.
+  while :; do
+    local _choice
     local -a _stages_check=()
     _list_dockerfile_stages_available _stages_check
     local -a _menu_args=(
-      image                "$(_tui_msg main.image)"
-      build                "$(_tui_msg main.build)"
-      devices              "$(_tui_msg main.devices)"
-      tmpfs                "$(_tui_msg main.tmpfs)"
       security             "$(_tui_msg main.security)"
       additional_contexts  "$(_tui_msg main.additional_contexts)"
     )
@@ -1987,7 +2137,7 @@ _render_advanced_menu() {
     _choice="$(_tui_menu "$(_tui_msg advanced.title)" "$(_tui_msg advanced.menu)" \
       "${_menu_args[@]}")" || break
     case "${_choice}" in
-      image|build|devices|tmpfs|security|additional_contexts) "_edit_section_${_choice}" ;;
+      security|additional_contexts) "_edit_section_${_choice}" ;;
       per_stage) _edit_section_per_stage ;;
       reset)    _do_reset ;;
       __back|"") break ;;

--- a/test/unit/tui_flow.bats
+++ b/test/unit/tui_flow.bats
@@ -158,10 +158,10 @@ EOF
 }
 
 @test "_render_main_menu: navigates into _edit_section_<choice> then Save" {
-  # First menu pick = network (dispatches into _edit_section_network),
-  # which immediately consumes the next two _tui_select responses
-  # (mode + ipc) to set them. Second pop after that = __save → exit.
-  queue "0|network" "0|host" "0|host" "0|__save"
+  # Post-#221: image is now a top-level main entry. Click image →
+  # _edit_section_image opens its rule-list menu (back immediately) →
+  # main loop pops __save → exit.
+  queue "0|image" "0|back" "0|__save"
   run _render_main_menu
   assert_success
 }
@@ -674,4 +674,269 @@ _make_dockerfile_with_stages() {
     echo "got: '$(ovr_get stage:headless.volumes.mount_1 || echo MISSING)'"
     return 1
   }
+}
+
+# ════════════════════════════════════════════════════════════════════
+# #221: Menu restructure — Runtime / Mounts / Features sub-menus
+#
+# Promotes image + build to top-level main, regroups runtime concerns
+# (network/deploy/gui/environment) under Runtime, regroups mount
+# concerns (volumes/devices/tmpfs) under Mounts, and adds a Features
+# entry that exposes conditional/power-user features even when their
+# enabling preconditions are not met (per-stage overrides being the
+# first such feature). Advanced sub-menu is slimmed to truly-advanced
+# entries: security, additional_contexts, per_stage (conditional),
+# Reset to defaults.
+# ════════════════════════════════════════════════════════════════════
+
+# i18n keys for new top-level entries
+
+@test "i18n: main.runtime key exists across all 4 languages" {
+  [[ -n "${_TUI_MSG_EN[main.runtime]:-}" ]]
+  [[ -n "${_TUI_MSG_ZH_TW[main.runtime]:-}" ]]
+  [[ -n "${_TUI_MSG_ZH_CN[main.runtime]:-}" ]]
+  [[ -n "${_TUI_MSG_JA[main.runtime]:-}" ]]
+}
+
+@test "i18n: main.mounts key exists across all 4 languages" {
+  [[ -n "${_TUI_MSG_EN[main.mounts]:-}" ]]
+  [[ -n "${_TUI_MSG_ZH_TW[main.mounts]:-}" ]]
+  [[ -n "${_TUI_MSG_ZH_CN[main.mounts]:-}" ]]
+  [[ -n "${_TUI_MSG_JA[main.mounts]:-}" ]]
+}
+
+@test "i18n: main.features key exists across all 4 languages" {
+  [[ -n "${_TUI_MSG_EN[main.features]:-}" ]]
+  [[ -n "${_TUI_MSG_ZH_TW[main.features]:-}" ]]
+  [[ -n "${_TUI_MSG_ZH_CN[main.features]:-}" ]]
+  [[ -n "${_TUI_MSG_JA[main.features]:-}" ]]
+}
+
+# New sub-menu function existence
+
+@test "_render_runtime_menu function is defined" {
+  [[ "$(type -t _render_runtime_menu)" == "function" ]]
+}
+
+@test "_render_mounts_menu function is defined" {
+  [[ "$(type -t _render_mounts_menu)" == "function" ]]
+}
+
+@test "_render_features_menu function is defined" {
+  [[ "$(type -t _render_features_menu)" == "function" ]]
+}
+
+# Main menu dispatch — image + build promoted to top level
+
+@test "_render_main_menu: image choice dispatches to _edit_section_image" {
+  local _called=0
+  _edit_section_image() { _called=1; }
+  queue "0|image" "0|__save"
+  _render_main_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_main_menu: build choice dispatches to _edit_section_build" {
+  local _called=0
+  _edit_section_build() { _called=1; }
+  queue "0|build" "0|__save"
+  _render_main_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_main_menu: runtime choice dispatches to _render_runtime_menu" {
+  local _called=0
+  _render_runtime_menu() { _called=1; }
+  queue "0|runtime" "0|__save"
+  _render_main_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_main_menu: mounts choice dispatches to _render_mounts_menu" {
+  local _called=0
+  _render_mounts_menu() { _called=1; }
+  queue "0|mounts" "0|__save"
+  _render_main_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_main_menu: features choice dispatches to _render_features_menu" {
+  local _called=0
+  _render_features_menu() { _called=1; }
+  queue "0|features" "0|__save"
+  _render_main_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_main_menu: bare network/deploy/gui/volumes/environment no longer dispatch from main" {
+  # Post-#221 these live under Runtime / Mounts sub-menus. If a stale
+  # script keys them, no editor opens (no case branch matches), and
+  # the main loop simply continues until __save / Cancel.
+  local _net=0 _gui=0 _vol=0
+  _edit_section_network() { _net=1; }
+  _edit_section_gui()     { _gui=1; }
+  _edit_section_volumes() { _vol=1; }
+  queue "0|network" "0|gui" "0|volumes" "0|__save"
+  _render_main_menu
+  [[ "${_net}" -eq 0 && "${_gui}" -eq 0 && "${_vol}" -eq 0 ]]
+}
+
+# Runtime sub-menu
+
+@test "_render_runtime_menu: __back exits with 0" {
+  queue "0|__back"
+  run _render_runtime_menu
+  assert_success
+}
+
+@test "_render_runtime_menu: Cancel (rc!=0) exits via break" {
+  queue "1|"
+  run _render_runtime_menu
+  assert_success
+}
+
+@test "_render_runtime_menu: network choice dispatches to _edit_section_network" {
+  local _called=0
+  _edit_section_network() { _called=1; }
+  queue "0|network" "0|__back"
+  _render_runtime_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_runtime_menu: deploy choice dispatches to _edit_section_deploy" {
+  local _called=0
+  _edit_section_deploy() { _called=1; }
+  queue "0|deploy" "0|__back"
+  _render_runtime_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_runtime_menu: gui choice dispatches to _edit_section_gui" {
+  local _called=0
+  _edit_section_gui() { _called=1; }
+  queue "0|gui" "0|__back"
+  _render_runtime_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_runtime_menu: environment choice dispatches to _edit_section_environment" {
+  local _called=0
+  _edit_section_environment() { _called=1; }
+  queue "0|environment" "0|__back"
+  _render_runtime_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+# Mounts sub-menu
+
+@test "_render_mounts_menu: __back exits with 0" {
+  queue "0|__back"
+  run _render_mounts_menu
+  assert_success
+}
+
+@test "_render_mounts_menu: Cancel (rc!=0) exits via break" {
+  queue "1|"
+  run _render_mounts_menu
+  assert_success
+}
+
+@test "_render_mounts_menu: volumes choice dispatches to _edit_section_volumes" {
+  local _called=0
+  _edit_section_volumes() { _called=1; }
+  queue "0|volumes" "0|__back"
+  _render_mounts_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_mounts_menu: devices choice dispatches to _edit_section_devices" {
+  local _called=0
+  _edit_section_devices() { _called=1; }
+  queue "0|devices" "0|__back"
+  _render_mounts_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_mounts_menu: tmpfs choice dispatches to _edit_section_tmpfs" {
+  local _called=0
+  _edit_section_tmpfs() { _called=1; }
+  queue "0|tmpfs" "0|__back"
+  _render_mounts_menu
+  [[ "${_called}" -eq 1 ]]
+}
+
+# Features sub-menu — conditional discoverability (#221 acceptance)
+
+@test "_render_features_menu: __back exits with 0" {
+  queue "0|__back"
+  run _render_features_menu
+  assert_success
+}
+
+@test "_render_features_menu: per_stage entry enters editor when stages exist" {
+  # When non-baseline stages are present, clicking per_stage opens
+  # _edit_section_per_stage (the existing editor — same entry point as
+  # the conditional Advanced entry).
+  local _base _called=0
+  _base="$(_make_dockerfile_with_stages headless)"
+  _edit_section_per_stage() { _called=1; }
+  queue "0|per_stage" "0|__back"
+  _render_features_menu "${_base}"
+  [[ "${_called}" -eq 1 ]]
+}
+
+@test "_render_features_menu: per_stage entry shows info msgbox + does NOT enter editor when no stages" {
+  # When no non-baseline stages exist, clicking per_stage shows an
+  # explanatory msgbox + returns; editor must not be entered.
+  local _base _editor=0 _msgbox=0
+  _base="$(_make_dockerfile_with_stages)"
+  _edit_section_per_stage() { _editor=1; }
+  _tui_msgbox() { _msgbox=1; return 0; }
+  export -f _tui_msgbox
+  queue "0|per_stage" "0|__back"
+  _render_features_menu "${_base}"
+  [[ "${_editor}" -eq 0 ]]
+  [[ "${_msgbox}" -eq 1 ]]
+}
+
+# Advanced sub-menu — image/build/devices/tmpfs moved out (#221)
+
+@test "_render_advanced_menu: image entry no longer dispatches" {
+  local _called=0
+  _edit_section_image() { _called=1; }
+  queue "0|image" "0|__back"
+  _render_advanced_menu
+  [[ "${_called}" -eq 0 ]]
+}
+
+@test "_render_advanced_menu: build entry no longer dispatches" {
+  local _called=0
+  _edit_section_build() { _called=1; }
+  queue "0|build" "0|__back"
+  _render_advanced_menu
+  [[ "${_called}" -eq 0 ]]
+}
+
+@test "_render_advanced_menu: devices entry no longer dispatches" {
+  local _called=0
+  _edit_section_devices() { _called=1; }
+  queue "0|devices" "0|__back"
+  _render_advanced_menu
+  [[ "${_called}" -eq 0 ]]
+}
+
+@test "_render_advanced_menu: tmpfs entry no longer dispatches" {
+  local _called=0
+  _edit_section_tmpfs() { _called=1; }
+  queue "0|tmpfs" "0|__back"
+  _render_advanced_menu
+  [[ "${_called}" -eq 0 ]]
+}
+
+@test "_render_advanced_menu: security still dispatches" {
+  local _called=0
+  _edit_section_security() { _called=1; }
+  queue "0|security" "0|__back"
+  _render_advanced_menu
+  [[ "${_called}" -eq 1 ]]
 }


### PR DESCRIPTION
## Summary

Restructure `setup_tui.sh` main menu per #221:

- Promote `image` and `build` to top-level main entries (commonly tweaked when wiring a new repo).
- Group runtime concerns (`network` / `deploy` / `gui` / `environment`) under a new `Runtime` sub-menu.
- Group mount concerns (`volumes` / `devices` / `tmpfs`) under a new `Mounts` sub-menu.
- Slim Advanced to truly-advanced knobs only: `security`, `additional_contexts`, conditional `per_stage`, Reset.
- Add a permanent `Features` entry that lists conditional / power-user features with their current status — today only `Per-stage overrides` (`enabled (N stages)` when at least one non-baseline stage exists, otherwise `hidden (no non-baseline stages)`). Clicking the disabled row pops a msgbox explaining how to enable; clicking the enabled row drills into the same editor as the conditional Advanced entry.

This addresses all three sub-questions in #221:

1. Main menu shape — image/build promoted, network/etc. regrouped.
2. Main / Advanced split preserved (no flat list); Advanced is now actually advanced.
3. Conditional discoverability — Features menu permanently surfaces what `per_stage` is, what its status is, and how to enable it when hidden.

No semantic change to any underlying section editor — every existing `_edit_section_*` function is reachable via the new layout.

## What changed

- `script/docker/setup_tui.sh`:
  - Rewrote `_render_main_menu` (image / build / runtime / mounts / advanced / features / Save & Exit).
  - Added `_render_runtime_menu`, `_render_mounts_menu`, `_render_features_menu`.
  - Slimmed `_render_advanced_menu` (image / build / devices / tmpfs branches removed; security / additional_contexts / per_stage (conditional) / reset stay).
  - Added 12 new i18n keys × 4 languages (en / zh-TW / zh-CN / ja).
- `test/unit/tui_flow.bats`: +31 tests covering i18n key existence, new sub-menu function existence, main-menu dispatch contracts, sub-menu dispatch contracts, Features behavior (enabled vs hidden), Advanced slimming.
- `doc/test/TEST.md`: tui_flow row count 63 → 94; total 1012 → 1043.
- `doc/changelog/CHANGELOG.md`: new `[Unreleased]` entry under Changed + Added.
- 4-language READMEs: Interactive TUI section now shows the new menu tree; the per-stage paragraph mentions both the Advanced entry and the new Features entry.

Closes #221.

## Test plan

- [x] `make -f Makefile.ci test` green locally — 1043 ok / 0 fail.
- [x] ShellCheck + Hadolint clean (handled by the test harness).
- [x] All 4 i18n languages have entries for the new keys (verified by `i18n: main.runtime / main.mounts / main.features key exists across all 4 languages` tests).
- [x] Existing tests (`_render_advanced_menu: __back / Cancel / additional_contexts dispatch`, `_load_current`, all the `_edit_*` editors, the per-stage UI tests from #220) remain green.
- [ ] CI Self Test passes on the PR (this run).
