### PR TITLE
feat(workflows): add publish-worker.yaml reusable workflow (opt-in, GHCR push)

### DIFF
--- a/.github/workflows/publish-worker.yaml
+++ b/.github/workflows/publish-worker.yaml
@@ -1,0 +1,278 @@
+name: Publish Docker Image
+
+# Reusable workflow that pushes a downstream repo's Dockerfile target
+# stage to a container registry (default: GHCR) on tag push.
+#
+# Opt-in: callers explicitly add a `call-publish` job to their main.yaml
+# that references this workflow. Existing repos that don't reference it
+# are unaffected.
+#
+# Typical use case: foundational image repos (`ros_distro`,
+# `ros2_distro`) that other repos consume via Docker `FROM`. App repos
+# (urg_node, realsense, sick) that want to inherit from those bases use
+# `FROM ghcr.io/<org>/ros_distro:vX.Y.Z-<variant>` in their own
+# Dockerfile.
+#
+# Tag scheme:
+#   ${registry}/${owner}/${image_name}:${GITHUB_REF_NAME}${tag_suffix}
+#
+# When `is_latest: true`, also pushes:
+#   ${registry}/${owner}/${image_name}:latest${tag_suffix}
+#
+# So a v0.1.0 release of ros_distro with the matrix below produces:
+#   ghcr.io/<org>/ros_distro:v0.1.0-noetic-desktop-full   (latest entry)
+#   ghcr.io/<org>/ros_distro:latest-noetic-desktop-full   (latest entry)
+#   ghcr.io/<org>/ros_distro:v0.1.0-noetic-ros-base
+#   ghcr.io/<org>/ros_distro:v0.1.0-kinetic-desktop-full
+#   ghcr.io/<org>/ros_distro:v0.1.0-kinetic-ros-base
+#
+# The reused inputs (build_args / context_path / dockerfile_path /
+# build_contexts / platforms / test_tools_version) mirror
+# build-worker.yaml so callers can share matrix definitions across
+# build + publish jobs.
+
+on:
+  workflow_call:
+    inputs:
+      image_name:
+        required: true
+        type: string
+        description: |
+          Image repository name on the registry, without the registry /
+          owner prefix (e.g. `ros_distro`). The full image reference
+          becomes `${registry}/${owner}/${image_name}`.
+      tag_suffix:
+        required: false
+        type: string
+        default: ""
+        description: |
+          String appended to both `:${version}` and `:latest` tags.
+          Convention: `-<matrix-entry-name>` so each variant lands on
+          its own tag (e.g. `-noetic-desktop-full`). Empty default =
+          bare `:${version}` / `:latest` tags (single-variant repos).
+      is_latest:
+        required: false
+        type: boolean
+        default: false
+        description: |
+          When true, also push `:latest${tag_suffix}` alongside
+          `:${version}${tag_suffix}`. Multi-variant repos should set
+          this to `true` only on the canonical default variant
+          (typically osrf desktop-full) so downstream `:latest-...`
+          consumers point at the variant the maintainer recommends.
+      registry:
+        required: false
+        type: string
+        default: "ghcr.io"
+        description: |
+          Container registry hostname. Default `ghcr.io` uses
+          GITHUB_TOKEN for auth (no extra secrets needed). For Docker
+          Hub set `docker.io` and ensure the caller passes
+          `secrets: inherit` so DOCKERHUB_USERNAME / DOCKERHUB_TOKEN
+          can be picked up via `secrets.*` -- this workflow itself
+          only handles GHCR auth in MVP; Docker Hub auth via
+          alternative secrets is a follow-up.
+      target:
+        required: false
+        type: string
+        default: "devel"
+        description: |
+          Dockerfile target stage to publish. Default `devel` makes
+          this image suitable as a `FROM` base for downstream app
+          repos (full dev environment baked in). Set to `runtime` to
+          publish the slim production image instead.
+      build_args:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Multi-line KEY=VALUE build args, same shape as
+          build-worker.yaml. Typically the caller passes
+          `BASE_IMAGE=<upstream>` here per matrix entry.
+      platforms:
+        required: false
+        type: string
+        default: "linux/amd64"
+        description: |
+          Comma-separated target platforms (same parser as
+          build-worker.yaml). Each platform is published as a separate
+          manifest entry inside the same image tag, so consumers can
+          `docker pull` the tag and get the right arch automatically.
+
+          MVP supports linux/amd64 + linux/arm64 (publishes a multi-arch
+          manifest list). osrf/ros: variants are amd64-only, so callers
+          publishing osrf-based variants should leave this at the
+          default. ros: variants on linux/arm64 publish via native
+          arm64 runners (no QEMU emulation).
+      context_path:
+        required: false
+        type: string
+        default: "."
+        description: |
+          Build context (mirrors build-worker.yaml). Defaults to repo
+          root.
+      dockerfile_path:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Optional explicit Dockerfile path. Empty defers to
+          `<context_path>/Dockerfile`.
+      build_contexts:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Optional newline-separated `<name>=<location>` pairs (mirrors
+          build-worker.yaml). Forwarded to docker/build-push-action's
+          build-contexts.
+      test_tools_version:
+        required: false
+        type: string
+        default: "latest"
+        description: |
+          Tag of `ghcr.io/ycpss91255-docker/test-tools:<tag>`. The
+          downstream Dockerfile reads this as a build-arg even when
+          publishing the devel/runtime stage (the test stage is
+          declared FROM ${TEST_TOOLS_IMAGE} for the lint pass);
+          callers should pin to the template release they upgraded
+          from for reproducibility.
+
+jobs:
+  # ────────────────────────────────────────────────────────────────
+  # Same matrix-shaping logic as build-worker.yaml so the published
+  # tags align with the build matrix the caller already runs.
+  # ────────────────────────────────────────────────────────────────
+  compute-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        env:
+          PLATFORMS: ${{ inputs.platforms }}
+        run: |
+          items=""
+          IFS=',' read -ra plats <<< "${PLATFORMS}"
+          for p in "${plats[@]}"; do
+            p="$(echo "${p}" | tr -d '[:space:]')"
+            case "${p}" in
+              linux/amd64)
+                items+='{"platform":"linux/amd64","runner":"ubuntu-latest","hardware":"x86_64"},'
+                ;;
+              linux/arm64)
+                items+='{"platform":"linux/arm64","runner":"ubuntu-24.04-arm","hardware":"aarch64"},'
+                ;;
+              "")
+                continue
+                ;;
+              *)
+                echo "::error::Unsupported platform '${p}'. Supported: linux/amd64, linux/arm64"
+                exit 1
+                ;;
+            esac
+          done
+          if [ -z "${items}" ]; then
+            echo "::error::No valid platforms found in '${PLATFORMS}'"
+            exit 1
+          fi
+          json="{\"include\":[${items%,}]}"
+          echo "matrix=${json}" >> "${GITHUB_OUTPUT}"
+
+  # ────────────────────────────────────────────────────────────────
+  # Build + push per-platform image. Each platform's image gets the
+  # full set of computed tags; docker/build-push-action with multiple
+  # tags on a single push call writes one manifest containing all of
+  # them.
+  #
+  # When the caller's matrix has multiple platforms, the per-platform
+  # outputs end up in separate "tag-platform" image entries on the
+  # registry; the manifest-list aggregation step below stitches them
+  # into a single multi-arch manifest under each final tag.
+  # ────────────────────────────────────────────────────────────────
+  publish:
+    needs: compute-matrix
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest_amd64: ${{ steps.export.outputs.digest_amd64 }}
+      digest_arm64: ${{ steps.export.outputs.digest_arm64 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to ${{ inputs.registry }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags
+        id: tags
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          OWNER: ${{ github.repository_owner }}
+          IMAGE: ${{ inputs.image_name }}
+          REF: ${{ github.ref_name }}
+          SUFFIX: ${{ inputs.tag_suffix }}
+          IS_LATEST: ${{ inputs.is_latest }}
+        run: |
+          base="${REGISTRY}/${OWNER}/${IMAGE}"
+          version_tag="${base}:${REF}${SUFFIX}"
+          tags="${version_tag}"
+          if [ "${IS_LATEST}" = "true" ]; then
+            tags="${tags}"$'\n'"${base}:latest${SUFFIX}"
+          fi
+          # Multiline output via heredoc form
+          {
+            echo "tags<<TAGS_EOF"
+            printf '%s\n' "${tags}"
+            echo "TAGS_EOF"
+          } >> "${GITHUB_OUTPUT}"
+          echo "Computed tags:"
+          printf '  %s\n' "${tags}"
+
+      - name: Generate .env
+        run: |
+          cat > .env << EOF
+          USER_NAME=ci
+          USER_GROUP=ci
+          USER_UID=1000
+          USER_GID=1000
+          HARDWARE=${{ matrix.hardware }}
+          DOCKER_HUB_USER=ci
+          GPU_ENABLED=false
+          IMAGE_NAME=${{ inputs.image_name }}
+          WS_PATH=/tmp/workspace
+          EOF
+          mkdir -p /tmp/workspace
+
+      - name: Build and push (${{ matrix.platform }})
+        id: push
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.context_path }}
+          file: ${{ inputs.dockerfile_path || format('{0}/Dockerfile', inputs.context_path) }}
+          build-contexts: ${{ inputs.build_contexts }}
+          target: ${{ inputs.target }}
+          platforms: ${{ matrix.platform }}
+          push: true
+          provenance: false
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            USER_NAME=ci
+            USER_GROUP=ci
+            USER_UID=1000
+            USER_GID=1000
+            HARDWARE=${{ matrix.hardware }}
+            TEST_TOOLS_IMAGE=ghcr.io/ycpss91255-docker/test-tools:${{ inputs.test_tools_version }}
+            ${{ inputs.build_args }}

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ graph TB
         smoke["test/smoke/<br/>script_help.bats<br/>display_env.bats"]
         config["config/<br/>bashrc / tmux / terminator / pip"]
         mgmt["script/docker/<br/>build.sh / run.sh / exec.sh / stop.sh / setup.sh"]
-        workflows["Reusable Workflows<br/>build-worker.yaml<br/>release-worker.yaml"]
+        workflows["Reusable Workflows<br/>build-worker.yaml<br/>release-worker.yaml<br/>publish-worker.yaml (opt-in)"]
     end
 
     subgraph consumer["Docker Repo (e.g. ros_noetic)"]
@@ -565,6 +565,68 @@ jobs:
 | `archive_name_prefix` | string | yes | - | Archive name prefix |
 | `extra_files` | string | no | `""` | Space-separated extra files |
 
+### publish-worker.yaml inputs (opt-in, foundational image repos)
+
+Pushes a Dockerfile target stage to a container registry on tag push.
+Opt-in: only repos that consume this workflow publish images (default
+template flow stays test-only). Typical use case: foundational image
+repos (`ros_distro`, `ros2_distro`) that other repos consume via
+Docker `FROM`.
+
+| Input | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `image_name` | string | yes | - | Image repo name on the registry (e.g. `ros_distro`); full ref becomes `${registry}/${owner}/${image_name}` |
+| `tag_suffix` | string | no | `""` | Appended to both `:${version}` and `:latest` tags. Convention: `-<matrix-entry-name>` so each variant lands on its own tag |
+| `is_latest` | boolean | no | `false` | When true, also pushes `:latest${tag_suffix}` alongside `:${version}${tag_suffix}`. Multi-variant repos set this only on the canonical default variant |
+| `registry` | string | no | `"ghcr.io"` | Container registry hostname. GHCR uses GITHUB_TOKEN auth automatically |
+| `target` | string | no | `"devel"` | Dockerfile target stage to publish. `devel` for app-base usage; `runtime` for production images |
+| `build_args` | string | no | `""` | Multi-line KEY=VALUE build args (same shape as build-worker) |
+| `platforms` | string | no | `"linux/amd64"` | Comma-separated target platforms; multi-arch publishes a single multi-arch manifest under each tag |
+| `context_path` | string | no | `"."` | Build context (mirrors build-worker) |
+| `dockerfile_path` | string | no | `""` | Optional explicit Dockerfile path |
+| `build_contexts` | string | no | `""` | Optional newline-separated `<name>=<location>` build contexts |
+| `test_tools_version` | string | no | `"latest"` | `ghcr.io/.../test-tools:<tag>` build-arg (pin to your template release for reproducibility) |
+
+Caller example (foundational multi-variant repo):
+
+```yaml
+# .github/workflows/main.yaml
+jobs:
+  call-publish:
+    needs: ci-passed
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        target:
+          - { name: 'noetic-desktop-full',  base: 'osrf/ros:noetic-desktop-full-focal',   is_latest: true }
+          - { name: 'noetic-ros-base',      base: 'ros:noetic-ros-base-focal',            is_latest: false }
+          - { name: 'kinetic-desktop-full', base: 'osrf/ros:kinetic-desktop-full-xenial', is_latest: false }
+          - { name: 'kinetic-ros-base',     base: 'ros:kinetic-ros-base-xenial',          is_latest: false }
+    uses: ycpss91255-docker/template/.github/workflows/publish-worker.yaml@vX.Y.Z
+    with:
+      image_name: ros_distro
+      tag_suffix: "-${{ matrix.target.name }}"
+      is_latest: ${{ matrix.target.is_latest }}
+      target: devel
+      build_args: |
+        BASE_IMAGE=${{ matrix.target.base }}
+```
+
+After a `v0.1.0` tag push, the matrix above yields:
+
+```
+ghcr.io/<org>/ros_distro:v0.1.0-noetic-desktop-full
+ghcr.io/<org>/ros_distro:latest-noetic-desktop-full   # is_latest = true
+ghcr.io/<org>/ros_distro:v0.1.0-noetic-ros-base
+ghcr.io/<org>/ros_distro:v0.1.0-kinetic-desktop-full
+ghcr.io/<org>/ros_distro:v0.1.0-kinetic-ros-base
+```
+
+Downstream app repos (e.g. `urg_node`) then `FROM ghcr.io/<org>/ros_distro:v0.1.0-humble-desktop-full` in their own Dockerfile, dropping the duplicated sys / base / devel layers.
+
 ## Running Template Tests
 
 Using `Makefile.ci` (from template root):
@@ -647,8 +709,10 @@ template/
 ├── codecov.yml
 ├── .github/workflows/
 │   ├── self-test.yaml                # Template CI
-│   ├── build-worker.yaml             # Reusable build workflow
-│   └── release-worker.yaml           # Reusable release workflow
+│   ├── build-worker.yaml             # Reusable build + smoke-test workflow
+│   ├── release-worker.yaml           # Reusable release (source archive) workflow
+│   ├── publish-worker.yaml           # Reusable image publish workflow (opt-in; pushes to GHCR)
+│   └── release-test-tools.yaml       # Template's own test-tools image release
 ├── doc/
 │   ├── readme/                       # README translations (zh-TW / zh-CN / ja)
 │   ├── test/TEST.md                  # Test catalog (spec tables)

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`publish-worker.yaml` reusable workflow** (#232). Opt-in
+  workflow_call entry point that pushes a Dockerfile target stage
+  (default `devel`) to a container registry (default `ghcr.io`) on
+  tag push. Inputs mirror `build-worker.yaml` (`image_name`,
+  `build_args`, `context_path`, `dockerfile_path`, `build_contexts`,
+  `platforms`, `test_tools_version`) plus publish-specific knobs
+  (`tag_suffix`, `is_latest`, `registry`, `target`). Default behavior
+  for existing repos is unchanged: only repos that explicitly add a
+  `call-publish` job in their `main.yaml` publish images. Designed
+  for foundational image repos (`ros_distro`, `ros2_distro`) so app
+  repos can `FROM ghcr.io/<org>/ros_distro:vX.Y.Z-<variant>` instead
+  of duplicating sys / base / devel layers per repo. Auth uses
+  `GITHUB_TOKEN` for GHCR; multi-arch via `platforms: linux/amd64,linux/arm64`
+  publishes a single multi-arch manifest list under each tag.
+  Documented under "CI Reusable Workflows" in template README with
+  full input table and caller example.
+
 ## [v0.19.0] - 2026-05-07
 
 Promoted from `v0.19.0-rc1` (#228) — RC tag CI was green; no fixups needed.


### PR DESCRIPTION
## Summary

Add `publish-worker.yaml` reusable workflow as the foundation for app-pair
repos (urg_node, realsense, sick) that will inherit from a shipped
`ros_distro` / `ros2_distro` image via Docker FROM, instead of duplicating
sys/base/devel layers.

Closes #232.

## What changed

- New file `.github/workflows/publish-worker.yaml` — workflow_call-only
  reusable workflow. Pushes a Dockerfile target stage (default `devel`)
  to a container registry (default `ghcr.io`) on tag push.
- README "CI Reusable Workflows" section: full input table + caller
  example for `ros_distro`-style multi-variant matrix; tree section
  updated to list the new workflow alongside build-worker and
  release-worker.
- CHANGELOG `[Unreleased]` entry summarizing the feature, default-off
  behavior, and intended consumers.

## Default behavior

**Unchanged for existing repos.** This is opt-in: a repo only publishes
images if it explicitly adds a `call-publish` job in its `main.yaml`
that references `publish-worker.yaml`. The 13 existing downstream repos
do nothing different.

## Inputs

Mirrors `build-worker.yaml` (`image_name`, `build_args`, `context_path`,
`dockerfile_path`, `build_contexts`, `platforms`, `test_tools_version`)
plus publish-specific knobs:

| Input | Default | Purpose |
|---|---|---|
| `tag_suffix` | `""` | Appended to `:${version}` and `:latest`; convention is `-<matrix-entry-name>` |
| `is_latest` | `false` | When true, also pushes `:latest${tag_suffix}` (matrix repos set true only on canonical default variant) |
| `registry` | `"ghcr.io"` | Auth via `GITHUB_TOKEN` automatic for GHCR |
| `target` | `"devel"` | Dockerfile target stage; `devel` for app-base usage |

Full table in README.

## Test plan

- [x] YAML syntax valid (`python3 yaml.safe_load`).
- [x] `make -f Makefile.ci test` green locally (54/54 unit + integration).
- [x] Workflow file matches build-worker.yaml conventions (input shapes,
      compute-matrix logic, runner labels).
- [ ] CI green on this PR.
- [ ] **End-to-end integration verified by the rollout step 2** in
      issue #232: after merge + `template@v0.20.0` tag, `ros_distro` /
      `ros2_distro` opt in via `call-publish` job and tag `v0.1.1` to
      trigger first publish; verify GHCR has the 4-per-repo variant
      tags. (Reusable workflow can't self-test from a `workflow_call`
      consumer; integration is gated on a downstream caller exercising
      it.)

## Rollout (per #232)

1. **This PR** -> tag `template@v0.20.0`.
2. `ros_distro` + `ros2_distro` -> bump template subtree, add
   `call-publish` job, tag `v0.1.1`. Verify GHCR has the 4 variant
   tags per repo.
3. New `app/urg_node` repo (issue ycpss91255-docker/urg_node_humble#33)
   uses `FROM ghcr.io/<org>/ros_distro:v0.1.1-humble-desktop-jammy` as
   base. Drops the duplicated sys/base/devel layers.
4. Repeat for `realsense` and `sick` once urg_node validates the
   pattern.
