### PR TITLE
fix(setup): expand ${KEY} cross-refs in [environment] env_N (closes #236)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`setup.conf [environment] env_N` cross-reference now expands**
+  (#236). When a later `env_N` value references an earlier sibling KEY
+  via `${KEY}`, `setup.sh` now substitutes the earlier sibling's value
+  before emitting to `compose.yaml`. Previously the literal `${KEY}`
+  shipped to compose, and compose's own `${VAR}` substitution does NOT
+  consult sibling environment entries -- the container saw the
+  unexpanded form (e.g. `LD_LIBRARY_PATH=/foo//lib` after declaring
+  `ROS_DISTRO=humble` and `LD_LIBRARY_PATH=/foo/${ROS_DISTRO}/lib`).
+  Order-sensitive: forward references and unknown names stay literal
+  so compose's substitution layer (`.env` / shell env) gets a chance
+  at file-load time. Transitive references resolve through the chain
+  (env_3 sees the fully-expanded env_2). Implementation: new
+  `_expand_env_cross_refs` helper called from `generate_compose_yaml`
+  before the env block emits. 5 new unit tests in
+  `test/unit/compose_gen_spec.bats` cover basic / forward / unknown /
+  multi-ref / transitive cases.
+
 ## [v0.20.0] - 2026-05-08
 
 Promoted from `v0.20.0-rc1` (#234) — RC tag CI was green; no fixups needed.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1043 tests** total (989 unit + 54 integration).
+Template self-tests: **1048 tests** total (994 unit + 54 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -238,7 +238,7 @@ Chinese / Simplified Chinese / Japanese translations of the
 no-instances message, `--all` multi-project teardown loop, and
 fallback `_detect_lang` branches.
 
-### test/unit/compose_gen_spec.bats (45)
+### test/unit/compose_gen_spec.bats (50)
 
 Covers `generate_compose_yaml` conditional output: AUTO-GENERATED
 header, baseline workspace volume, network/ipc/privileged env-var
@@ -269,6 +269,11 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `runtime service appears between devel and test blocks` | ordering |
 | `runtime detection is robust against weird whitespace` | regex tolerance |
 | `runtime detection ignores non-runtime stage names` | strict match |
+| `environment env_N expands ${VAR} cross-reference to earlier sibling (refs #236)` | basic cross-ref |
+| `environment env_N forward reference is left literal (refs #236)` | order-sensitive |
+| `environment env_N unknown ${VAR} is left literal (refs #236)` | unknown stays literal |
+| `environment env_N supports multiple cross-references in one value (refs #236)` | multi-ref |
+| `environment env_N transitive cross-reference resolves through chain (refs #236)` | transitive |
 
 ### test/unit/template_spec.bats (134)
 

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -1151,6 +1151,48 @@ _resolve_stage_list() {
 #     `network_mode: ${NETWORK_MODE}`.
 # IPC/privileged always read from env var refs; .env provides values.
 # ════════════════════════════════════════════════════════════════════
+
+# _expand_env_cross_refs <input-newline-list> <output-array-name>
+#
+# Reads `KEY=VALUE` entries (one per line, blank lines skipped) and
+# substitutes `${KEY}` references in each value with the value of an
+# earlier-seen sibling KEY. Order-sensitive: forward references (a value
+# referencing a sibling not yet parsed) survive as the literal `${VAR}`,
+# as do unknown references with no matching sibling -- compose.yaml's
+# own substitution layer (.env / shell env) gets a chance at file-load
+# time, surfacing genuinely undefined names visibly rather than silently
+# substituting empty.
+#
+# Resolves issue #236: previously, sibling cross-references in
+# `[environment] env_N` were emitted literally and compose's `${VAR}`
+# substitution does NOT consult sibling environment entries -- so e.g.
+#   env_1 = ROS_DISTRO=humble
+#   env_2 = LD_LIBRARY_PATH=/foo/${ROS_DISTRO}/lib
+# would ship `LD_LIBRARY_PATH=/foo//lib` to the container.
+_expand_env_cross_refs() {
+  local _input="$1"
+  local -n _expand_out_arr="$2"
+  _expand_out_arr=()
+  declare -A _seen=()
+  local _line _k _v _ref_k _ref_v _expanded
+  while IFS= read -r _line; do
+    [[ -z "${_line}" ]] && continue
+    _k="${_line%%=*}"
+    _v="${_line#*=}"
+    _expanded="${_v}"
+    # Substitute every ${ref_k} found in _v against earlier siblings.
+    # Multiple-pass not needed because _seen already holds fully-expanded
+    # values from prior iterations (transitive references resolve through
+    # the chain naturally).
+    for _ref_k in "${!_seen[@]}"; do
+      _ref_v="${_seen[${_ref_k}]}"
+      _expanded="${_expanded//\$\{${_ref_k}\}/${_ref_v}}"
+    done
+    _seen["${_k}"]="${_expanded}"
+    _expand_out_arr+=("${_k}=${_expanded}")
+  done <<< "${_input}"
+}
+
 generate_compose_yaml() {
   local _out="${1:?}"
   local _name="${2:?}"
@@ -1407,11 +1449,17 @@ YAML
 YAML
       fi
       if [[ -n "${_env_str}" ]]; then
+        # Expand `${KEY}` cross-references against earlier siblings so
+        # the emitted compose.yaml carries the user's intent verbatim
+        # (compose's own substitution layer does NOT see sibling env
+        # entries -- refs #236).
+        local -a _env_expanded=()
+        _expand_env_cross_refs "${_env_str}" _env_expanded
         local _ev
-        while IFS= read -r _ev; do
+        for _ev in "${_env_expanded[@]}"; do
           [[ -z "${_ev}" ]] && continue
           echo "      - ${_ev}"
-        done <<< "${_env_str}"
+        done
       fi
     fi
     # ports: only emitted when network_mode=bridge (ignored under host)

--- a/test/unit/compose_gen_spec.bats
+++ b/test/unit/compose_gen_spec.bats
@@ -131,6 +131,81 @@ teardown() {
   assert_success
 }
 
+@test "environment env_N expands \${VAR} cross-reference to earlier sibling (refs #236)" {
+  # When a later env_N value references an earlier sibling KEY via
+  # `\${KEY}`, the emitted compose.yaml line should contain the earlier
+  # sibling's value, not a literal `\${KEY}` (which compose's own var
+  # substitution does NOT resolve from sibling environment entries).
+  local _extras=()
+  local _env
+  printf -v _env '%s\n%s' "ROS_DISTRO=humble" "LD_LIBRARY_PATH=/foo/\${ROS_DISTRO}/lib"
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "" "${_env}" "" "" "" "host" "host"
+  run grep -F -- '- LD_LIBRARY_PATH=/foo/humble/lib' "${COMPOSE_OUT}"
+  assert_success
+  refute grep -F -- '${ROS_DISTRO}' "${COMPOSE_OUT}"
+}
+
+@test "environment env_N forward reference is left literal (refs #236)" {
+  # Order-sensitive: a value that references a LATER sibling cannot be
+  # expanded (the sibling hasn't been parsed yet). The literal `\${VAR}`
+  # survives so compose.yaml's own substitution gets a chance from
+  # `.env` / shell env, and an unintended footgun surfaces visibly.
+  local _extras=()
+  local _env
+  printf -v _env '%s\n%s' "LD_LIBRARY_PATH=/foo/\${ROS_DISTRO}/lib" "ROS_DISTRO=humble"
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "" "${_env}" "" "" "" "host" "host"
+  run grep -F -- '- LD_LIBRARY_PATH=/foo/${ROS_DISTRO}/lib' "${COMPOSE_OUT}"
+  assert_success
+  run grep -F -- '- ROS_DISTRO=humble' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "environment env_N unknown \${VAR} is left literal (refs #236)" {
+  # When `\${VAR}` references a name with no matching sibling, leave it
+  # as a literal in compose.yaml. compose's own substitution (from
+  # `.env` / shell env) gets a chance at file-load; if that also fails
+  # the user sees an explicit error, not a silent empty replacement.
+  local _extras=()
+  local _env
+  printf -v _env '%s' "PATH_PREFIX=/foo/\${UNDEFINED_VAR}/bar"
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "" "${_env}" "" "" "" "host" "host"
+  run grep -F -- '- PATH_PREFIX=/foo/${UNDEFINED_VAR}/bar' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "environment env_N supports multiple cross-references in one value (refs #236)" {
+  local _extras=()
+  local _env
+  printf -v _env '%s\n%s\n%s' \
+    "ROS_DISTRO=humble" \
+    "ARCH=aarch64" \
+    "PLUGIN_PATH=/opt/\${ROS_DISTRO}/lib/\${ARCH}"
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "" "${_env}" "" "" "" "host" "host"
+  run grep -F -- '- PLUGIN_PATH=/opt/humble/lib/aarch64' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "environment env_N transitive cross-reference resolves through chain (refs #236)" {
+  # If env_2 references env_1, and env_3 references env_2, env_3 should
+  # see the FULLY expanded env_2 (not a chain that needs more expansion).
+  local _extras=()
+  local _env
+  printf -v _env '%s\n%s\n%s' \
+    "ROOT=/opt" \
+    "BASE=\${ROOT}/ros" \
+    "INCLUDE=\${BASE}/include"
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "" "${_env}" "" "" "" "host" "host"
+  run grep -F -- '- BASE=/opt/ros' "${COMPOSE_OUT}"
+  assert_success
+  run grep -F -- '- INCLUDE=/opt/ros/include' "${COMPOSE_OUT}"
+  assert_success
+}
+
 @test "generate_compose_yaml emits tmpfs block from tmpfs_ list" {
   local _extras=()
   local _tmpfs


### PR DESCRIPTION
## Summary

`setup.sh` now expands `${KEY}` cross-references between sibling
`[environment] env_N` entries before emitting them into
`compose.yaml`'s `environment:` block. Previously the literal `${KEY}`
shipped through, and compose's own `${VAR}` substitution does NOT see
sibling environment entries -- so e.g. declaring

```ini
[environment]
env_1 = ROS_DISTRO=humble
env_2 = LD_LIBRARY_PATH=/foo/${ROS_DISTRO}/lib
```

ended up with `LD_LIBRARY_PATH=/foo//lib` inside the container.

Closes #236.

## Implementation

- New `_expand_env_cross_refs` helper in `script/docker/setup.sh`:
  reads `KEY=VALUE` entries one per line, builds a key→value map of
  seen entries, substitutes `${KEY}` against earlier siblings using
  bash parameter expansion `${var//pattern/replacement}`. Order-sensitive:
  forward references stay literal, unknown names stay literal.
- `generate_compose_yaml`'s env emit block calls the helper before
  echoing each `- KEY=VALUE` line.
- Transitive chains resolve naturally: each iteration's expanded value
  goes into the seen-map, so the next iteration's lookup gets the
  fully-resolved form.

## Test plan

- [x] 5 new unit tests in `test/unit/compose_gen_spec.bats`:
  - `expands ${VAR} cross-reference to earlier sibling` (the headline #236 case)
  - `forward reference is left literal` (order-sensitive)
  - `unknown ${VAR} is left literal` (compose's substitution gets a chance)
  - `supports multiple cross-references in one value` (multi-ref per value)
  - `transitive cross-reference resolves through chain` (env_3 sees fully-expanded env_2)
- [x] `make -f Makefile.ci test` green: 1048/1048 (was 1043, +5 new).
- [x] ShellCheck clean.
- [x] Existing env emit test still passes (no regression on the
      no-cross-ref path).
- [x] CHANGELOG `[Unreleased]` Fixed entry.
- [x] TEST.md count updated (1043 -> 1048; compose_gen_spec.bats 45 -> 50).
- [ ] CI green on this PR.
