### PR TITLE
feat(build-worker): runtime-test stage smoke + devel-base/devel-test rename (closes #243)

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -206,7 +206,7 @@ jobs:
           EOF
           mkdir -p /tmp/workspace
 
-      - name: Build test stage (includes smoke tests)
+      - name: Build devel-test stage (includes lint + bats smoke)
         # The downstream Dockerfile consumes TEST_TOOLS_IMAGE as the
         # source of `COPY --from=${TEST_TOOLS_IMAGE}`; buildx auto-pulls
         # the image from GHCR on `COPY --from=<name:tag>` when the tag
@@ -222,12 +222,18 @@ jobs:
         # cutting their own release should pin explicitly for
         # reproducibility (the earlier GITHUB_WORKFLOW_REF auto-parse
         # was wrong: that ref is the caller's own tag, not template's).
+        #
+        # Stage rename note (#243): target was `test` prior to v0.21.0;
+        # renamed to `devel-test` for symmetry with the new
+        # `runtime-test` stage. Downstream Dockerfiles must rename
+        # `FROM devel AS test` -> `FROM devel AS devel-test` to keep
+        # CI green after upgrading to template v0.21.0+.
         uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.context_path }}
           file: ${{ inputs.dockerfile_path || format('{0}/Dockerfile', inputs.context_path) }}
           build-contexts: ${{ inputs.build_contexts }}
-          target: test
+          target: devel-test
           platforms: ${{ matrix.platform }}
           push: false
           build-args: |
@@ -254,6 +260,37 @@ jobs:
             USER_UID=1000
             USER_GID=1000
             HARDWARE=${{ matrix.hardware }}
+            ${{ inputs.build_args }}
+
+      - name: Build runtime-test stage (install check)
+        # Mirrors the devel-test pattern (#243): ephemeral stage
+        # FROM runtime, runs an inline `RUN <smoke>` so build failure
+        # surfaces a smoke failure. Default smoke is generic
+        # install-check (whoami + bash --version); downstream override
+        # via `build_args: RUNTIME_SMOKE_CMD=<command>` to test domain
+        # binaries.
+        #
+        # Constraint: smoke command must be CLI-only -- no GUI tools
+        # that init QApplication / OGRE on `--version` / `--help`
+        # (rqt, rviz2, gazebo-classic). Prefer `<binary> --help`,
+        # `command -v <binary>`, package manager queries.
+        #
+        # Gated by `inputs.build_runtime` so agent/* repos with no
+        # runtime stage skip cleanly.
+        if: ${{ inputs.build_runtime }}
+        uses: docker/build-push-action@v7
+        with:
+          context: ${{ inputs.context_path }}
+          file: ${{ inputs.dockerfile_path || format('{0}/Dockerfile', inputs.context_path) }}
+          build-contexts: ${{ inputs.build_contexts }}
+          target: runtime-test
+          platforms: ${{ matrix.platform }}
+          push: false
+          build-args: |
+            USER_NAME=ci
+            USER_GROUP=ci
+            USER_UID=1000
+            USER_GID=1000
             ${{ inputs.build_args }}
 
       - name: Build runtime stage

--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ Notes:
 #### Adding extra stages (#215)
 
 Any `FROM <base> AS <stage>` outside the baseline blocklist
-`{sys, base, devel, test}` is auto-emitted as a compose service that
+`{sys, devel-base, devel, devel-test, runtime-test}` (legacy
+`{base, test}` also accepted during the v0.21.x transition) is
+auto-emitted as a compose service that
 `extends: devel` (inherits volumes / network / GPU / GUI / cap_add /
 additional_contexts) and overrides only `build.target` / `image` /
 `container_name` / `stdin_open` / `tty` / `profiles`. Use case:
@@ -201,9 +203,11 @@ Constraints:
 - Stage names must match `^[a-z][a-z0-9_-]*$` — uppercase / leading
   digit / dot etc. are rejected (WARN + skip; the rest of the parse
   continues).
-- Names colliding with the baseline (`sys` / `base` / `devel` / `test`)
-  are a hard error from `setup.sh apply`. So are names colliding with
-  the template-controlled image-tag namespace (`latest`, `v[0-9]*`).
+- Names colliding with the baseline (`sys` / `devel-base` / `devel`
+  / `devel-test` / `runtime-test`, plus legacy aliases `base` / `test`
+  during the v0.21.x transition) are a hard error from `setup.sh
+  apply`. So are names colliding with the template-controlled
+  image-tag namespace (`latest`, `v[0-9]*`).
 - Adding / removing a stage triggers `setup.sh check-drift` (via
   `SETUP_DOCKERFILE_HASH` in `.env`), so wrappers auto-regenerate
   `compose.yaml` on the next invocation. Unrelated `RUN apt-get
@@ -368,8 +372,9 @@ every build or launch:
 
 > **Fresh-clone lint coverage (#216)**: `./run.sh` on a clone with no
 > image cached locally triggers Compose's auto-build, which only walks
-> `target: devel` (or whatever `-t` says) and **skips** the `target:
-> test` stage that runs ShellCheck / Hadolint / Bats smoke. `run.sh`
+> `target: devel` (or whatever `-t` says) and **skips** the
+> `target: devel-test` stage that runs ShellCheck / Hadolint / Bats
+> smoke (pre-#243 this stage was named `test`). `run.sh`
 > prints an informational `[run] INFO:` block when this is about to
 > happen (TTY only). Pass `--build` to pre-flight `./build.sh test`
 > first if you want full local-CI parity in one command:
@@ -663,7 +668,7 @@ template/
 │       └── ci.sh                     # CI pipeline (local + remote)
 ├── dockerfile/
 │   ├── Dockerfile.test-tools         # Pre-built lint/test tools image
-│   └── Dockerfile.example            # Dockerfile template for new repos (sys → base → devel → test → [runtime])
+│   └── Dockerfile.example            # Dockerfile template for new repos (sys → devel-base → devel → devel-test → [runtime-base → runtime → runtime-test])
 ├── setup.conf                        # Single runtime config (per-repo override mirror: <repo>/setup.conf)
 ├── config/                           # Container-internal shell/tool configs
 │   ├── image_name.conf               # Default IMAGE_NAME detection rules

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`runtime-test` stage in `Dockerfile.example`** (#243). New
+  ephemeral stage `FROM runtime AS runtime-test` mirrors the
+  existing devel-test pattern. Body is `ARG RUNTIME_SMOKE_CMD='bash
+  -lc "whoami && bash --version && exit 0"'` + `USER root` + `RUN
+  ${RUNTIME_SMOKE_CMD}`. Closes the runtime stage's behavioural
+  validation gap surfaced during the v0.21.0 stage-coverage audit.
+  Default smoke is install-check style (USER set + bash on PATH +
+  login shell rc files don't error); downstream override per repo
+  via `build_args: RUNTIME_SMOKE_CMD=<command>` to test domain
+  binaries. Constraint: smoke command must be CLI-only — no GUI
+  binaries that initialize Qt / OGRE on `--version` or `--help`.
+- **`build-worker.yaml` runtime-test build step**. New step `Build
+  runtime-test stage (install check)` after the devel build, gated
+  on `inputs.build_runtime` so agent/* repos (no runtime) skip
+  cleanly. Builds `target: runtime-test`; failure of the inline
+  `RUN ${RUNTIME_SMOKE_CMD}` in the Dockerfile surfaces as a build
+  error in the GHA log.
+- 4 new tests in `test/unit/build_worker_yaml_spec.bats` locking
+  the new step's shape (target name, build_runtime gate). 1 new
+  test in `test/unit/setup_spec.bats` confirming
+  `_parse_dockerfile_stages` correctly filters the new baseline
+  names.
+
+### Changed
+- **BREAKING for downstream Dockerfiles**: stage rename for
+  symmetry with the new runtime-test stage (#243):
+  - `FROM sys AS base` -> `FROM sys AS devel-base`
+  - `FROM devel AS test` -> `FROM devel AS devel-test`
+  Downstream repos must rename these in their own root `Dockerfile`
+  the same PR they upgrade their `template/` subtree to v0.21.0+,
+  otherwise CI's new `target: devel-test` / `target: runtime-test`
+  build steps will fail because the stages don't exist in their
+  Dockerfile yet. The `runtime-base` stage keeps its name (it's
+  load-bearing for the lean runtime image; pairs symmetrically
+  with the renamed `devel-base`).
+- **`build-worker.yaml`** CI target: `target: test` ->
+  `target: devel-test` (mirrors the Dockerfile rename above).
+  Workflow callers don't need to change anything in their
+  `main.yaml`; the change is in the workflow itself. Downstream
+  repos just need to keep their `main.yaml` `@tag` reference up
+  to date and rename their own Dockerfile stages (see above).
+- **`setup.sh` baseline blocklist** widened to recognise both the
+  new and legacy stage names during the v0.21.x transition: `{sys,
+  devel-base, devel, devel-test, runtime-test}` are the
+  forward-looking baseline; `{base, test}` remain accepted so
+  un-renamed downstream Dockerfiles don't accidentally emit `base`
+  / `test` as compose services. Legacy aliases will be removed in
+  a future major release once all downstream repos have renamed.
+- **TUI per-stage messages** updated in 4 languages (en / zh-TW /
+  zh-CN / ja) to surface the new baseline names.
+- **Test count**: total 1037 -> 1042 (+1 setup_spec, +4
+  build_worker_yaml_spec). Unit 983 -> 988; integration unchanged
+  at 54.
+
 ## [v0.21.0-rc1] - 2026-05-08
 
 Release Candidate for v0.21.0. Single change: ROS-specific content

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -160,7 +160,8 @@ flowchart LR
 
 #### 追加ステージの追加（#215）
 
-baseline blocklist `{sys, base, devel, test}` 以外の
+baseline blocklist `{sys, devel-base, devel, devel-test,
+runtime-test}` 以外の（v0.21.x 移行期間中は旧名 `{base, test}` も受付）
 `FROM <base> AS <stage>` は、自動的に compose サービスとして
 emit されます — `extends: devel`（volumes / network / GPU / GUI /
 cap_add / additional_contexts を継承）し、`build.target` /
@@ -193,9 +194,11 @@ ENTRYPOINT ["/isaac-sim/runapp.sh"]
 - Stage 名は `^[a-z][a-z0-9_-]*$` に一致する必要があり、大文字
   / 数字始まり / ピリオドなどは拒否されます（WARN + skip、
   他の stage は解析を続行）。
-- baseline（`sys` / `base` / `devel` / `test`）と衝突する場合は
-  `setup.sh apply` が hard error で exit 1。template が管理する
-  image tag namespace（`latest`、`v[0-9]*`）との衝突も hard error。
+- baseline（`sys` / `devel-base` / `devel` / `devel-test` /
+  `runtime-test`、v0.21.x 移行期間中は旧名 `base` / `test` も衝突
+  対象）と衝突する場合は `setup.sh apply` が hard error で exit 1。
+  template が管理する image tag namespace（`latest`、`v[0-9]*`）と
+  の衝突も hard error。
 - Stage の追加 / 削除は `setup.sh check-drift` をトリガーします
   （`.env` 内の `SETUP_DOCKERFILE_HASH` 経由）。次回 wrapper 起動
   時に自動的に `compose.yaml` を再生成します。`RUN apt-get install`
@@ -369,8 +372,9 @@ Main
 > **Fresh-clone の lint カバレッジ（#216）**：image がローカルに
 > キャッシュされていない `./run.sh` は Compose auto-build を起動
 > しますが、auto-build は **`target: devel`**（または `-t` で指定
-> された target）のみをビルドし、`target: test` レイヤの
-> ShellCheck / Hadolint / Bats smoke はスキップされます。`run.sh`
+> された target）のみをビルドし、`target: devel-test`（pre-#243 は
+> `test`）レイヤの ShellCheck / Hadolint / Bats smoke はスキップ
+> されます。`run.sh`
 > はこの状況を検知し、`compose up` の前に `[run] INFO:` ブロック
 > を表示します（TTY 環境のみ）。CI と同じ完全な検証を 1 コマンド
 > で実行したい場合は `--build` フラグを付けてください：
@@ -606,7 +610,7 @@ template/
 │       └── ci.sh                     # CI パイプライン（ローカル + リモート）
 ├── dockerfile/
 │   ├── Dockerfile.test-tools         # プリビルド lint/test ツール image
-│   └── Dockerfile.example            # 新 repo の Dockerfile テンプレート（sys → base → devel → test → [runtime]）
+│   └── Dockerfile.example            # 新 repo の Dockerfile テンプレート（sys → devel-base → devel → devel-test → [runtime-base → runtime → runtime-test]）
 ├── setup.conf                        # 単一ランタイム設定（repo 上書き: <repo>/setup.conf）
 ├── config/                           # コンテナ内部のシェル / ツール設定
 │   ├── image_name.conf               # デフォルト IMAGE_NAME 検出ルール

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -159,7 +159,8 @@ flowchart LR
 
 #### 添加额外 stage（#215）
 
-任何在 baseline blocklist `{sys, base, devel, test}` 之外的
+任何在 baseline blocklist `{sys, devel-base, devel, devel-test,
+runtime-test}` 之外的（v0.21.x 过渡期同时接受旧名 `{base, test}`）
 `FROM <base> AS <stage>`，会被自动 emit 成一个 compose 服务 —
 `extends: devel`（继承 volumes / network / GPU / GUI / cap_add /
 additional_contexts），仅 override `build.target` / `image` /
@@ -190,9 +191,10 @@ ENTRYPOINT ["/isaac-sim/runapp.sh"]
 
 - Stage 名必须符合 `^[a-z][a-z0-9_-]*$` — 大写 / 数字开头 / 点号
   等会被拒（WARN + 跳过，其他 stage 继续解析）。
-- 撞到 baseline（`sys` / `base` / `devel` / `test`）`setup.sh apply`
-  hard error 退出 1。撞到 template 控制的 image tag namespace
-  （`latest`、`v[0-9]*`）也是 hard error。
+- 撞到 baseline（`sys` / `devel-base` / `devel` / `devel-test` /
+  `runtime-test`，v0.21.x 过渡期亦同时接受旧名 `base` / `test`）
+  `setup.sh apply` hard error 退出 1。撞到 template 控制的 image
+  tag namespace（`latest`、`v[0-9]*`）也是 hard error。
 - 添加 / 移除 stage 会触发 `setup.sh check-drift`（通过 `.env` 内
   的 `SETUP_DOCKERFILE_HASH`），下次 wrapper 跑会自动 regen
   `compose.yaml`。其他 `RUN apt-get install` 等修改**不会**触发 drift。
@@ -350,8 +352,9 @@ Main
 
 > **Fresh-clone lint 覆盖率（#216）**：`./run.sh` 在本机没 image
 > cached 时会走 Compose auto-build — 但 auto-build **只 build
-> `target: devel`**（或 `-t` 指定的 target），会跳过 `target: test`
-> 那层的 ShellCheck / Hadolint / Bats smoke。`run.sh` 检测到这个情况
+> `target: devel`**（或 `-t` 指定的 target），会跳过 `target:
+> devel-test`（pre-#243 该 stage 名为 `test`）那层的 ShellCheck /
+> Hadolint / Bats smoke。`run.sh` 检测到这个情况
 > 会在 `compose up` 前打印一段 `[run] INFO:` 提示（只在 TTY 环境）。
 > 想要一次取得跟 CI 同样的完整验证，加 `--build` flag：
 >
@@ -580,7 +583,7 @@ template/
 │       └── ci.sh                     # CI pipeline（本地 + 远端）
 ├── dockerfile/
 │   ├── Dockerfile.test-tools         # 预构建 lint/测试工具 image
-│   └── Dockerfile.example            # 新 repo 的 Dockerfile 模板（sys → base → devel → test → [runtime]）
+│   └── Dockerfile.example            # 新 repo 的 Dockerfile 模板（sys → devel-base → devel → devel-test → [runtime-base → runtime → runtime-test]）
 ├── setup.conf                        # 单一 runtime 配置（per-repo override: <repo>/setup.conf）
 ├── config/                           # Container 内部 shell / 工具配置
 │   ├── image_name.conf               # 默认 IMAGE_NAME 检测规则

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -159,7 +159,8 @@ flowchart LR
 
 #### 新增額外 stage（#215）
 
-任何在 baseline blocklist `{sys, base, devel, test}` 之外的
+任何在 baseline blocklist `{sys, devel-base, devel, devel-test,
+runtime-test}` 之外的（v0.21.x 過渡期同時接受舊名 `{base, test}`）
 `FROM <base> AS <stage>`，會被自動 emit 成一個 compose 服務 —
 `extends: devel`（繼承 volumes / network / GPU / GUI / cap_add /
 additional_contexts），只 override `build.target` / `image` /
@@ -190,9 +191,10 @@ ENTRYPOINT ["/isaac-sim/runapp.sh"]
 
 - Stage 名必須符合 `^[a-z][a-z0-9_-]*$` — 大寫 / 數字開頭 / 點號
   等會被拒（WARN + 跳過，其他 stage 繼續解析）。
-- 撞到 baseline（`sys` / `base` / `devel` / `test`）`setup.sh apply`
-  hard error 退出 1。撞到 template 控制的 image tag namespace
-  （`latest`、`v[0-9]*`）也是 hard error。
+- 撞到 baseline（`sys` / `devel-base` / `devel` / `devel-test` /
+  `runtime-test`，v0.21.x 過渡期亦同時接受舊名 `base` / `test`）
+  `setup.sh apply` hard error 退出 1。撞到 template 控制的 image
+  tag namespace（`latest`、`v[0-9]*`）也是 hard error。
 - 加 / 移 stage 會觸發 `setup.sh check-drift`（透過 `.env` 內的
   `SETUP_DOCKERFILE_HASH`），下次 wrapper 跑會自動 regen
   `compose.yaml`。其他 `RUN apt-get install` 等修改**不會**觸發 drift。
@@ -350,8 +352,9 @@ Main
 
 > **Fresh-clone lint 覆蓋率（#216）**：`./run.sh` 在本機沒 image
 > cached 時會走 Compose auto-build — 但 auto-build **只 build
-> `target: devel`**（或 `-t` 指定的 target），會跳過 `target: test`
-> 那層的 ShellCheck / Hadolint / Bats smoke。`run.sh` 偵測到這個情況
+> `target: devel`**（或 `-t` 指定的 target），會跳過 `target:
+> devel-test`（pre-#243 該 stage 名為 `test`）那層的 ShellCheck /
+> Hadolint / Bats smoke。`run.sh` 偵測到這個情況
 > 會在 `compose up` 前印一段 `[run] INFO:` 提醒（只在 TTY 環境）。
 > 想要一次取得跟 CI 同樣的完整驗證，加 `--build` flag：
 >
@@ -580,7 +583,7 @@ template/
 │       └── ci.sh                     # CI pipeline（本地 + 遠端）
 ├── dockerfile/
 │   ├── Dockerfile.test-tools         # 預建置 lint/測試工具 image
-│   └── Dockerfile.example            # 新 repo 的 Dockerfile 範本（sys → base → devel → test → [runtime]）
+│   └── Dockerfile.example            # 新 repo 的 Dockerfile 範本（sys → devel-base → devel → devel-test → [runtime-base → runtime → runtime-test]）
 ├── setup.conf                        # 單一 runtime 配置（per-repo override: <repo>/setup.conf）
 ├── config/                           # Container 內部 shell / 工具設定
 │   ├── image_name.conf               # 預設 IMAGE_NAME 偵測規則

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,13 +1,13 @@
 # TEST.md
 
-Template self-tests: **1037 tests** total (983 unit + 54 integration).
+Template self-tests: **1042 tests** total (988 unit + 54 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
 > `test/smoke/` are a separate suite that runs at Dockerfile `test`-stage
 > build time (via `./build.sh test`) inside both this repo and every
 > downstream repo, and are documented in [Smoke Tests](#smoke-tests)
-> below. They are **not** included in the 1037 figure because they are
+> below. They are **not** included in the 1042 figure because they are
 > build-time assertions, not self-tests.
 
 ## Test Files
@@ -45,7 +45,7 @@ Template self-tests: **1037 tests** total (983 unit + 54 integration).
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
 | `_print_config_summary warns when setup.conf exists but has no [section] headers` | #157 empty-conf hint on build/run summary |
 
-### test/unit/setup_spec.bats (260)
+### test/unit/setup_spec.bats (261)
 
 Covers core detection (user/hardware/docker/GPU/GUI), the INI parser
 (`_parse_ini_section`), setup.conf section merging (`_load_setup_conf`
@@ -149,26 +149,28 @@ target areas the issue body called out.
 | Per-stage UI #220 (`_list_dockerfile_stages_available` from-Dockerfile + baseline filter, `_count_stage_overrides` OVR+CURRENT dedup + empty skip, `_edit_stage_gui` mode + __inherit, `_edit_stage_scalar` write + empty-clears, `_edit_stage_list` inherit toggle + add) | 10 |
 | Menu restructure #221 (i18n keys for main.runtime/mounts/features × 4 langs; `_render_runtime_menu` / `_render_mounts_menu` / `_render_features_menu` function existence; main-menu dispatch for image/build/runtime/mounts/features + bare network/deploy/gui/volumes/environment no longer dispatch from main; Runtime sub-menu dispatch for network/deploy/gui/environment + __back/Cancel; Mounts sub-menu dispatch for volumes/devices/tmpfs + __back/Cancel; Features sub-menu __back, per_stage enabled enters editor, per_stage hidden shows msgbox without entering editor; Advanced sub-menu image/build/devices/tmpfs entries removed, security still dispatches) | 31 |
 
-### test/unit/build_worker_yaml_spec.bats (15)
+### test/unit/build_worker_yaml_spec.bats (19)
 
-Structural assertions for `.github/workflows/build-worker.yaml` (#195).
-Reusable workflows are not exec'd by these tests; instead grep
-patterns lock the YAML invariants — `context_path` / `dockerfile_path`
-inputs declared with the right defaults, all 3 `docker/build-push-action`
-steps forwarding those inputs, and no leftover `context: .` /
-`file: ./Dockerfile` literals.
+Structural assertions for `.github/workflows/build-worker.yaml` (#195
++ #243). Reusable workflows are not exec'd by these tests; instead
+grep patterns lock the YAML invariants — `context_path` /
+`dockerfile_path` inputs declared with the right defaults, all 4
+`docker/build-push-action` steps (devel-test / devel / runtime-test /
+runtime after #243) forwarding those inputs, and no leftover
+`context: .` / `file: ./Dockerfile` literals.
 
 | Category | Tests |
 |----------|-------|
 | `inputs.context_path` declared with `default: "."` | 1 |
 | `inputs.dockerfile_path` declared with `default: ""` | 1 |
-| 3 build steps reference `inputs.context_path` | 1 |
-| 3 build steps reference `inputs.dockerfile_path` with `format()` fallback | 1 |
+| 4 build steps reference `inputs.context_path` (#243 added runtime-test) | 1 |
+| 4 build steps reference `inputs.dockerfile_path` with `format()` fallback | 1 |
 | No leftover `context: .` literals | 1 |
 | No leftover `file: ./Dockerfile` literals | 1 |
 | Default values together preserve repo-root-Dockerfile callers | 1 |
-| User build-args use long form matching Dockerfile.example sys stage (#198: USER_NAME / USER_GROUP / USER_UID / USER_GID across 3 build steps + no short-form regression) | 5 |
-| `build_contexts` input forwards to docker/build-push-action `build-contexts:` (#207: input declared with empty default, 3 build steps forward, default preserves zero-diff) | 3 |
+| User build-args use long form matching Dockerfile.example sys stage (#198: USER_NAME / USER_GROUP / USER_UID / USER_GID across 4 build steps + no short-form regression) | 5 |
+| `build_contexts` input forwards to docker/build-push-action `build-contexts:` (#207: input declared with empty default, 4 build steps forward, default preserves zero-diff) | 3 |
+| #243 stage rename + runtime-test smoke: `target: devel-test` (renamed from `test`), no leftover `target: test`, `target: runtime-test` exists, runtime-test gated on `inputs.build_runtime` (>=2 occurrences shared with runtime gate) | 4 |
 
 ### test/unit/build_sh_spec.bats (35)
 

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -10,22 +10,29 @@
 # isolation that broke the old test-tools:local CI pattern.
 #
 # Stages:
-#   sys     - User/group, locale, timezone
-#   base    - Development tools and packages
-#   devel   - Application-specific tools + entrypoint
-#   test    - Lint + smoke test (ephemeral, discarded after build)
-#   runtime - Minimal runtime image (optional)
+#   sys           - User/group, locale, timezone
+#   devel-base    - Development tools and packages
+#   devel         - Application-specific tools + entrypoint
+#   devel-test    - Lint + bats smoke test (ephemeral, discarded after build)
+#   runtime-base  - Minimal runtime base (sudo + tini), optional
+#   runtime       - Minimal runtime image (optional)
+#   runtime-test  - Runtime install-check smoke (ephemeral, optional)
 #
 # Adding extra stages (#215): any `FROM <base> AS <stage>` outside the
-# baseline blocklist {sys, base, devel, test} is auto-emitted as a
-# compose service that extends `devel` (inherits volumes / network /
-# GPU / GUI / cap_add / additional_contexts) and overrides only
-# build.target / image / container_name / stdin_open / tty / profiles.
-# Stage names must match `^[a-z][a-z0-9_-]*$` and must not collide
-# with `latest` / `v[0-9]*` (reserved release tag namespace). Use case:
-# entrypoint variants like `headless` + `gui` for the same baseline.
-# No setup.conf change needed; run any wrapper to regenerate
-# compose.yaml, then `./run.sh -t <stage>`.
+# baseline blocklist {sys, devel-base, devel, devel-test, runtime-test}
+# is auto-emitted as a compose service that extends `devel` (inherits
+# volumes / network / GPU / GUI / cap_add / additional_contexts) and
+# overrides only build.target / image / container_name / stdin_open /
+# tty / profiles. Stage names must match `^[a-z][a-z0-9_-]*$` and must
+# not collide with `latest` / `v[0-9]*` (reserved release tag
+# namespace). Use case: entrypoint variants like `headless` + `gui`
+# for the same baseline. No setup.conf change needed; run any wrapper
+# to regenerate compose.yaml, then `./run.sh -t <stage>`.
+#
+# Backward-compat: the legacy stage names `base` and `test` are still
+# accepted by the blocklist during the v0.21.x transition (downstream
+# Dockerfiles renamed to `devel-base` / `devel-test` over a coordinated
+# rollout). They will be removed from the blocklist in a future major.
 
 ARG BASE_IMAGE="ubuntu:24.04"
 ARG TEST_TOOLS_IMAGE="test-tools:local"
@@ -75,8 +82,8 @@ RUN if getent group "${USER_GID}" >/dev/null; then \
     fi && \
     echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
-############################## base ##############################
-FROM sys AS base
+############################## devel-base ##############################
+FROM sys AS devel-base
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -98,7 +105,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 ############################## devel ##############################
-FROM base AS devel
+FROM devel-base AS devel
 
 ARG USER="${USER_NAME}"
 ARG GROUP="${USER_GROUP}"
@@ -139,11 +146,11 @@ EXPOSE 22
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["bash"]
 
-############################## test ##############################
+############################## devel-test ##############################
 # Resolves to test-tools:local (local build.sh) or ghcr.io/.../test-tools:vX.Y.Z (CI).
 FROM ${TEST_TOOLS_IMAGE} AS test-tools-stage
 
-FROM devel AS test
+FROM devel AS devel-test
 
 USER root
 
@@ -203,3 +210,31 @@ RUN bats /smoke_test/
 # WORKDIR "${HOME}/work"
 # ENTRYPOINT ["/entrypoint.sh"]
 # CMD ["bash"]
+
+############################## runtime-test (optional) ##############################
+# Install-check smoke for the runtime image. Mirrors `FROM devel AS
+# devel-test` -- ephemeral stage, build-only, never pushed. CI builds
+# this target after `target: runtime`; build failure surfaces a smoke
+# failure visibly in the GHA log.
+#
+# Default smoke command is generic install-check (USER set + bash on
+# PATH + login shell rc files don't error). Override per repo via
+# `build_args: RUNTIME_SMOKE_CMD=<command>` to test domain binaries.
+#
+# Constraint: command must be CLI-only -- no GUI tools that init
+# QApplication / OGRE on `--version` / `--help` (rqt, rviz2,
+# gazebo-classic). Prefer `<binary> --help`, `command -v <binary>`,
+# package manager queries (`ros2 pkg list | grep ...`, `rospack
+# find ...`) over invoking the GUI binary itself.
+#
+# Only enable when the runtime stage above is also enabled. The
+# `if: build_runtime` gate in build-worker.yaml mirrors this -- if
+# your repo doesn't ship a runtime stage, leave both runtime and
+# runtime-test commented out and set `build_runtime: false` in
+# main.yaml.
+#
+# FROM runtime AS runtime-test
+#
+# ARG RUNTIME_SMOKE_CMD='bash -lc "whoami && bash --version && exit 0"'
+# USER root
+# RUN ${RUNTIME_SMOKE_CMD}

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -331,7 +331,8 @@ main() {
   # ── #216: soft guard for the auto-build path ──
   # Compose's auto-build (when image is missing locally) only walks
   # `target: devel` (or whatever -t says) and silently skips the
-  # `target: test` stage that runs ShellCheck / Hadolint / Bats smoke.
+  # `target: devel-test` stage that runs ShellCheck / Hadolint / Bats
+  # smoke. (Pre-#243 this stage was named `test`.)
   # On a fresh clone this means new contributors who reach for
   # ./run.sh first land in a working dev container without ever
   # hitting the lint/smoke gates that ./build.sh test enforces.

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -846,8 +846,13 @@ _compute_conf_hash() {
 # Returns:
 #   0 — valid; auto-emit as compose service
 #   1 — invalid format (caller WARNs + skips, continues parsing other stages)
-#   2 — collides with template-managed baseline {sys, base, devel, test};
-#       hard error (caller exits non-zero)
+#   2 — collides with template-managed baseline
+#       {sys, devel-base, devel, devel-test, runtime-test}; hard error
+#       (caller exits non-zero). For backward compatibility during the
+#       v0.21.x transition the legacy names {base, test} are also
+#       accepted as baseline (downstream Dockerfiles renamed to
+#       devel-base / devel-test over a coordinated rollout); they will
+#       be removed from the blocklist in a future major release.
 #   3 — collides with template-controlled image-tag namespace
 #       ({latest} | v[0-9]*); hard error
 #
@@ -864,8 +869,11 @@ _validate_stage_name() {
   # collision.
 
   # 1. baseline collision (template-managed stages)
+  #    Forward-looking: sys / devel-base / devel / devel-test / runtime-test
+  #    Legacy (backward-compat during v0.21.x transition): base / test
   case "${_stage}" in
-    sys|base|devel|test) return 2 ;;
+    sys|devel-base|devel|devel-test|runtime-test) return 2 ;;
+    base|test) return 2 ;;
   esac
   # 2. reserved tag namespace (template-controlled tag slots)
   case "${_stage}" in
@@ -880,8 +888,10 @@ _validate_stage_name() {
 # _parse_dockerfile_stages <dockerfile_path>
 #
 # Reads `^FROM <base> AS <stage>` lines from the Dockerfile, dedups,
-# filters out the baseline blocklist {sys, base, devel, test}, and
-# echoes the surviving stages one per line preserving file order.
+# filters out the baseline blocklist {sys, devel-base, devel,
+# devel-test, runtime-test} (plus the legacy {base, test} accepted
+# during the v0.21.x transition), and echoes the surviving stages
+# one per line preserving file order.
 #
 # Match rules:
 #   - Line must start with `FROM` (case-sensitive — Docker spec is
@@ -905,7 +915,8 @@ _parse_dockerfile_stages() {
     [[ "${_line}" =~ ^FROM[[:space:]]+[^[:space:]#]+[[:space:]]+AS[[:space:]]+([^[:space:]#]+)[[:space:]]*$ ]] || continue
     _stage="${BASH_REMATCH[1]}"
     case "${_stage}" in
-      sys|base|devel|test) continue ;;
+      sys|devel-base|devel|devel-test|runtime-test) continue ;;
+      base|test) continue ;;
     esac
     case "${_seen}" in
       *" ${_stage} "*) continue ;;  # already emitted (dedup)
@@ -1258,7 +1269,7 @@ generate_compose_yaml() {
   # need `runtime: nvidia` at service level to bypass the modern
   # --gpus flow (which `deploy.resources.reservations.devices`
   # translates to). Empty = omit so Docker uses the default runc.
-  # Only emitted for the devel service; test doesn't run.
+  # Only emitted for the devel service; devel-test doesn't run.
   _emit_runtime_line() {
     [[ -z "${_runtime}" ]] && return 0
     printf '    runtime: %s\n' "${_runtime}"
@@ -1858,7 +1869,7 @@ YAML
     build:
       context: .
       dockerfile: Dockerfile
-      target: test
+      target: devel-test
 YAML
     _emit_additional_contexts_block
     _emit_build_network_line

--- a/script/docker/setup_tui.sh
+++ b/script/docker/setup_tui.sh
@@ -65,7 +65,7 @@ _TUI_MSG_EN[features.menu]="Conditional / power-user features"
 _TUI_MSG_EN[features.back]="Back to main menu"
 _TUI_MSG_EN[features.per_stage_enabled]="Per-stage overrides — enabled (%s stages)"
 _TUI_MSG_EN[features.per_stage_hidden]="Per-stage overrides — hidden (no non-baseline stages)"
-_TUI_MSG_EN[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\nStatus: hidden\nReason: Dockerfile defines no non-baseline stage (sys, base, devel,\n        test are reserved baseline names).\n\nEnable: add `FROM ... AS <stage>` for any custom name, then return\n        to this menu — the entry will activate automatically.'
+_TUI_MSG_EN[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\nStatus: hidden\nReason: Dockerfile defines no non-baseline stage (sys, devel-base,\n        devel, devel-test, runtime-test are reserved baseline names;\n        legacy base / test still accepted during v0.21.x transition).\n\nEnable: add `FROM ... AS <stage>` for any custom name, then return\n        to this menu — the entry will activate automatically.'
 _TUI_MSG_EN[advanced.title]="Advanced"
 _TUI_MSG_EN[advanced.menu]="Select an advanced section"
 _TUI_MSG_EN[advanced.back]="Back to main menu"
@@ -73,7 +73,7 @@ _TUI_MSG_EN[advanced.reset]="Reset to defaults"
 _TUI_MSG_EN[advanced.per_stage]="Per-stage overrides (#220)"
 _TUI_MSG_EN[per_stage.title]="Per-stage overrides"
 _TUI_MSG_EN[per_stage.menu]="Pick a stage to edit, or Back"
-_TUI_MSG_EN[per_stage.empty]=$'No non-baseline stages found in Dockerfile.\n\nPer-stage overrides apply to `FROM ... AS <name>` stages outside\nthe baseline blocklist {sys, base, devel, test}. Add a stage to your\nDockerfile first, then return here to override its runtime config.'
+_TUI_MSG_EN[per_stage.empty]=$'No non-baseline stages found in Dockerfile.\n\nPer-stage overrides apply to `FROM ... AS <name>` stages outside\nthe baseline blocklist {sys, devel-base, devel, devel-test,\nruntime-test} (legacy {base, test} also accepted during v0.21.x\ntransition). Add a stage to your Dockerfile first, then return here\nto override its runtime config.'
 _TUI_MSG_EN[per_stage.back]="Back"
 _TUI_MSG_EN[per_stage.overrides_set]="overrides set"
 _TUI_MSG_EN[per_stage.inherits_all]="(inherits all)"
@@ -256,7 +256,7 @@ _TUI_MSG_ZH_TW[features.menu]="條件式／進階使用功能"
 _TUI_MSG_ZH_TW[features.back]="回主選單"
 _TUI_MSG_ZH_TW[features.per_stage_enabled]="Per-stage overrides — 已啟用（%s 個 stage）"
 _TUI_MSG_ZH_TW[features.per_stage_hidden]="Per-stage overrides — 隱藏（無非 baseline stage）"
-_TUI_MSG_ZH_TW[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\n狀態：隱藏\n原因：Dockerfile 沒有非 baseline stage（sys、base、devel、test\n      為保留的 baseline 名稱）。\n\n啟用方式：在 Dockerfile 加上 `FROM ... AS <stage>`（任意自訂\n         名稱），再回到此選單，項目會自動啟用。'
+_TUI_MSG_ZH_TW[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\n狀態：隱藏\n原因：Dockerfile 沒有非 baseline stage（sys、devel-base、devel、\n      devel-test、runtime-test 為保留的 baseline 名稱；舊名 base、\n      test 在 v0.21.x 過渡期仍被接受）。\n\n啟用方式：在 Dockerfile 加上 `FROM ... AS <stage>`（任意自訂\n         名稱），再回到此選單，項目會自動啟用。'
 _TUI_MSG_ZH_TW[advanced.title]="Advanced"
 _TUI_MSG_ZH_TW[advanced.menu]="選擇進階區段"
 _TUI_MSG_ZH_TW[advanced.back]="回主選單"
@@ -264,7 +264,7 @@ _TUI_MSG_ZH_TW[advanced.reset]="重置為預設值"
 _TUI_MSG_ZH_TW[advanced.per_stage]="Per-stage overrides (#220)"
 _TUI_MSG_ZH_TW[per_stage.title]="Per-stage overrides"
 _TUI_MSG_ZH_TW[per_stage.menu]="選擇要編輯的 stage，或返回"
-_TUI_MSG_ZH_TW[per_stage.empty]=$'Dockerfile 中沒有非 baseline 的 stage。\n\nPer-stage overrides 套用於 baseline {sys, base, devel, test} 以外的\n`FROM ... AS <name>` stage。請先在 Dockerfile 中加入額外 stage，\n再回來這裡 override 該 stage 的 runtime 設定。'
+_TUI_MSG_ZH_TW[per_stage.empty]=$'Dockerfile 中沒有非 baseline 的 stage。\n\nPer-stage overrides 套用於 baseline {sys, devel-base, devel,\ndevel-test, runtime-test}（v0.21.x 過渡期同時接受舊名 {base, test}）\n以外的 `FROM ... AS <name>` stage。請先在 Dockerfile 中加入額外\nstage，再回來這裡 override 該 stage 的 runtime 設定。'
 _TUI_MSG_ZH_TW[per_stage.back]="返回"
 _TUI_MSG_ZH_TW[per_stage.overrides_set]="個 override"
 _TUI_MSG_ZH_TW[per_stage.inherits_all]="(全部繼承)"
@@ -445,7 +445,7 @@ _TUI_MSG_ZH_CN[features.menu]="条件式／进阶使用功能"
 _TUI_MSG_ZH_CN[features.back]="回主菜单"
 _TUI_MSG_ZH_CN[features.per_stage_enabled]="Per-stage overrides — 已启用（%s 个 stage）"
 _TUI_MSG_ZH_CN[features.per_stage_hidden]="Per-stage overrides — 隐藏（无非 baseline stage）"
-_TUI_MSG_ZH_CN[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\n状态：隐藏\n原因：Dockerfile 没有非 baseline stage（sys、base、devel、test\n      为保留的 baseline 名称）。\n\n启用方式：在 Dockerfile 加上 `FROM ... AS <stage>`（任意自定\n         名称），再回到此菜单，项目会自动启用。'
+_TUI_MSG_ZH_CN[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\n状态：隐藏\n原因：Dockerfile 没有非 baseline stage（sys、devel-base、devel、\n      devel-test、runtime-test 为保留的 baseline 名称；旧名 base、\n      test 在 v0.21.x 过渡期仍被接受）。\n\n启用方式：在 Dockerfile 加上 `FROM ... AS <stage>`（任意自定\n         名称），再回到此菜单，项目会自动启用。'
 _TUI_MSG_ZH_CN[advanced.title]="Advanced"
 _TUI_MSG_ZH_CN[advanced.menu]="选择进阶区段"
 _TUI_MSG_ZH_CN[advanced.back]="回主菜单"
@@ -453,7 +453,7 @@ _TUI_MSG_ZH_CN[advanced.reset]="重置为默认值"
 _TUI_MSG_ZH_CN[advanced.per_stage]="Per-stage overrides (#220)"
 _TUI_MSG_ZH_CN[per_stage.title]="Per-stage overrides"
 _TUI_MSG_ZH_CN[per_stage.menu]="选择要编辑的 stage，或返回"
-_TUI_MSG_ZH_CN[per_stage.empty]=$'Dockerfile 中没有非 baseline 的 stage。\n\nPer-stage overrides 应用于 baseline {sys, base, devel, test} 以外的\n`FROM ... AS <name>` stage。请先在 Dockerfile 中加入额外 stage，\n再回来这里 override 该 stage 的 runtime 设定。'
+_TUI_MSG_ZH_CN[per_stage.empty]=$'Dockerfile 中没有非 baseline 的 stage。\n\nPer-stage overrides 应用于 baseline {sys, devel-base, devel,\ndevel-test, runtime-test}（v0.21.x 过渡期同时接受旧名 {base, test}）\n以外的 `FROM ... AS <name>` stage。请先在 Dockerfile 中加入额外\nstage，再回来这里 override 该 stage 的 runtime 设定。'
 _TUI_MSG_ZH_CN[per_stage.back]="返回"
 _TUI_MSG_ZH_CN[per_stage.overrides_set]="个 override"
 _TUI_MSG_ZH_CN[per_stage.inherits_all]="(全部继承)"
@@ -629,7 +629,7 @@ _TUI_MSG_JA[features.menu]="条件付き／上級者向け機能"
 _TUI_MSG_JA[features.back]="メインメニューへ戻る"
 _TUI_MSG_JA[features.per_stage_enabled]="Per-stage overrides — 有効（%s ステージ）"
 _TUI_MSG_JA[features.per_stage_hidden]="Per-stage overrides — 非表示（非ベースライン stage なし）"
-_TUI_MSG_JA[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\nステータス：非表示\n理由：Dockerfile に非ベースライン stage がありません（sys、base、\n      devel、test はベースラインの予約名です）。\n\n有効化：Dockerfile に `FROM ... AS <stage>` を追加（任意のカスタム名）\n        してからこのメニューに戻ると、項目が自動的に有効になります。'
+_TUI_MSG_JA[features.per_stage_hidden_info]=$'Per-stage overrides (#220)\n\nステータス：非表示\n理由：Dockerfile に非ベースライン stage がありません（sys、devel-base、\n      devel、devel-test、runtime-test はベースラインの予約名です；\n      旧名 base / test も v0.21.x 移行期間中は受け付けます）。\n\n有効化：Dockerfile に `FROM ... AS <stage>` を追加（任意のカスタム名）\n        してからこのメニューに戻ると、項目が自動的に有効になります。'
 _TUI_MSG_JA[advanced.title]="Advanced"
 _TUI_MSG_JA[advanced.menu]="Advanced セクションを選択"
 _TUI_MSG_JA[advanced.back]="メインメニューへ戻る"
@@ -637,7 +637,7 @@ _TUI_MSG_JA[advanced.reset]="デフォルトにリセット"
 _TUI_MSG_JA[advanced.per_stage]="Per-stage overrides (#220)"
 _TUI_MSG_JA[per_stage.title]="Per-stage overrides"
 _TUI_MSG_JA[per_stage.menu]="編集する stage を選択するか、戻る"
-_TUI_MSG_JA[per_stage.empty]=$'Dockerfile に非 baseline の stage がありません。\n\nPer-stage overrides は baseline {sys, base, devel, test} 以外の\n`FROM ... AS <name>` stage に適用されます。先に Dockerfile に\nstage を追加してから、このメニューで runtime 設定を override してください。'
+_TUI_MSG_JA[per_stage.empty]=$'Dockerfile に非 baseline の stage がありません。\n\nPer-stage overrides は baseline {sys, devel-base, devel, devel-test,\nruntime-test}（v0.21.x 移行期間中は旧名 {base, test} も受け付け）以外\nの `FROM ... AS <name>` stage に適用されます。先に Dockerfile に\nstage を追加してから、このメニューで runtime 設定を override\nしてください。'
 _TUI_MSG_JA[per_stage.back]="戻る"
 _TUI_MSG_JA[per_stage.overrides_set]="件の override"
 _TUI_MSG_JA[per_stage.inherits_all]="(すべて継承)"
@@ -1675,7 +1675,8 @@ _list_dockerfile_stages_available() {
     [[ "${_line}" =~ ^FROM[[:space:]]+[^[:space:]#]+[[:space:]]+AS[[:space:]]+([^[:space:]#]+)[[:space:]]*$ ]] || continue
     _stage="${BASH_REMATCH[1]}"
     case "${_stage}" in
-      sys|base|devel|test) continue ;;
+      sys|devel-base|devel|devel-test|runtime-test) continue ;;
+      base|test) continue ;;
     esac
     case "${_seen}" in
       *" ${_stage} "*) continue ;;

--- a/test/unit/build_worker_yaml_spec.bats
+++ b/test/unit/build_worker_yaml_spec.bats
@@ -39,24 +39,25 @@ setup() {
 
 # ── Build steps forward both inputs (#195) ────────────────────────────
 
-@test "build-worker.yaml: 3 build steps all reference inputs.context_path" {
-  # Three `docker/build-push-action` calls — test/devel/runtime stages.
-  # Each must read context from the new input; `context: .` would
-  # silently work for repo-root-Dockerfile callers but break the
-  # nested-Dockerfile use case the issue body documented.
+@test "build-worker.yaml: 4 build steps all reference inputs.context_path (#243 added runtime-test)" {
+  # Four `docker/build-push-action` calls after #243:
+  # devel-test / devel / runtime-test / runtime stages. Each must read
+  # context from the new input; `context: .` would silently work for
+  # repo-root-Dockerfile callers but break the nested-Dockerfile use
+  # case the #195 issue body documented.
   run grep -c 'context: ${{ inputs.context_path }}' "${WF}"
   assert_success
-  assert_output "3"
+  assert_output "4"
 }
 
-@test "build-worker.yaml: 3 build steps all forward inputs.dockerfile_path with format() fallback" {
+@test "build-worker.yaml: 4 build steps all forward inputs.dockerfile_path with format() fallback" {
   # The `||` short-circuit means an empty dockerfile_path falls back
   # to `<context_path>/Dockerfile`, matching docker/build-push-action's
   # implicit default. Override path lets callers pin a non-standard
   # filename.
   run grep -c "file: \${{ inputs.dockerfile_path || format('{0}/Dockerfile', inputs.context_path) }}" "${WF}"
   assert_success
-  assert_output "3"
+  assert_output "4"
 }
 
 @test "build-worker.yaml: no leftover hardcoded 'context: .' lines" {
@@ -91,7 +92,7 @@ setup() {
 
 # ── User build-args alignment with Dockerfile.example (#198) ──────────
 
-@test "build-worker.yaml: 3 build steps pass USER_NAME=ci (long form, matching Dockerfile.example sys stage)" {
+@test "build-worker.yaml: 4 build steps pass USER_NAME=ci (long form, matching Dockerfile.example sys stage)" {
   # Pre-#198 the workflow passed `USER=ci` (short form) which the
   # Dockerfile only sees in the devel stage; the sys-stage useradd
   # reads USER_NAME and stuck on the default "user". The container
@@ -99,25 +100,25 @@ setup() {
   # any RUN that resolved the username.
   run grep -c '^            USER_NAME=ci$' "${WF}"
   assert_success
-  assert_output "3"
+  assert_output "4"
 }
 
-@test "build-worker.yaml: 3 build steps pass USER_GROUP=ci (long form)" {
+@test "build-worker.yaml: 4 build steps pass USER_GROUP=ci (long form)" {
   run grep -c '^            USER_GROUP=ci$' "${WF}"
   assert_success
-  assert_output "3"
+  assert_output "4"
 }
 
-@test "build-worker.yaml: 3 build steps pass USER_UID=1000 (long form)" {
+@test "build-worker.yaml: 4 build steps pass USER_UID=1000 (long form)" {
   run grep -c '^            USER_UID=1000$' "${WF}"
   assert_success
-  assert_output "3"
+  assert_output "4"
 }
 
-@test "build-worker.yaml: 3 build steps pass USER_GID=1000 (long form)" {
+@test "build-worker.yaml: 4 build steps pass USER_GID=1000 (long form)" {
   run grep -c '^            USER_GID=1000$' "${WF}"
   assert_success
-  assert_output "3"
+  assert_output "4"
 }
 
 @test "build-worker.yaml: no short-form USER=/GROUP=/UID=/GID= build-args (regression #198)" {
@@ -144,12 +145,43 @@ setup() {
   assert_output --partial 'default: ""'
 }
 
-@test "build-worker.yaml: 3 build steps forward inputs.build_contexts to docker/build-push-action build-contexts:" {
-  # Three docker/build-push-action calls (test/devel/runtime). Each
-  # must forward the input so named contexts work end-to-end in CI.
+@test "build-worker.yaml: 4 build steps forward inputs.build_contexts to docker/build-push-action build-contexts:" {
+  # Four docker/build-push-action calls after #243 (devel-test / devel
+  # / runtime-test / runtime). Each must forward the input so named
+  # contexts work end-to-end in CI.
   run grep -c '^          build-contexts: \${{ inputs.build_contexts }}$' "${WF}"
   assert_success
-  assert_output "3"
+  assert_output "4"
+}
+
+# ── #243: stage rename + runtime-test smoke step ──────────────────────
+
+@test "build-worker.yaml: devel-test build step uses target: devel-test (renamed from target: test)" {
+  # Pre-#243 the test stage was named `test`; renamed to `devel-test`
+  # for symmetry with the new `runtime-test` stage. The literal target
+  # line must reflect the new name.
+  run grep -E '^          target: devel-test$' "${WF}"
+  assert_success
+}
+
+@test "build-worker.yaml: no leftover target: test (the renamed stage)" {
+  # If we forget to update one of the build steps, this catches it.
+  run grep -E '^          target: test$' "${WF}"
+  [ "${status}" -ne 0 ] || [ -z "${output}" ]
+}
+
+@test "build-worker.yaml: runtime-test build step exists and uses target: runtime-test" {
+  run grep -E '^          target: runtime-test$' "${WF}"
+  assert_success
+}
+
+@test "build-worker.yaml: runtime-test build step is gated on inputs.build_runtime" {
+  # Same gate as the runtime stage build, so agent/* repos
+  # (build_runtime: false) skip both cleanly. Asserts the gate appears
+  # at least twice in the file (once for runtime-test, once for runtime).
+  run grep -c '^        if: ${{ inputs.build_runtime }}$' "${WF}"
+  assert_success
+  [[ "${output}" -ge 2 ]] || { echo "expected >=2 build_runtime gates, got ${output}"; return 1; }
 }
 
 @test "build-worker.yaml: build_contexts default preserves zero-diff for existing callers (#207)" {

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -2614,7 +2614,9 @@ EOF
 }
 
 @test "_validate_stage_name rejects baseline collision with exit 2 (HARD ERROR)" {
-  for _base in sys base devel test; do
+  # Forward-looking baseline + legacy aliases (kept during v0.21.x
+  # transition for backward compat with un-renamed downstream Dockerfiles).
+  for _base in sys devel-base devel devel-test runtime-test base test; do
     run _validate_stage_name "${_base}"
     [[ "${status}" -eq 2 ]] || { echo "expected 2 for '${_base}', got ${status}"; return 1; }
   done
@@ -2631,16 +2633,30 @@ EOF
 # _parse_dockerfile_stages (#215)
 #
 # Reads `^FROM\s+\S+\s+AS\s+<stage>` lines from a Dockerfile, dedups,
-# filters out the baseline blocklist {sys, base, devel, test}, and
-# echoes the surviving stages one per line.
+# filters out the baseline blocklist {sys, devel-base, devel,
+# devel-test, runtime-test} (plus legacy {base, test} during v0.21.x
+# transition), and echoes the surviving stages one per line.
 # ════════════════════════════════════════════════════════════════════
 
-@test "_parse_dockerfile_stages: returns nothing for Dockerfile with only baseline stages" {
+@test "_parse_dockerfile_stages: returns nothing for Dockerfile with only legacy baseline stages (backward compat)" {
   cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
 FROM ubuntu:24.04 AS sys
 FROM sys AS base
 FROM base AS devel
 FROM devel AS test
+EOF
+  run _parse_dockerfile_stages "${TEMP_DIR}/Dockerfile"
+  assert_success
+  assert_output ""
+}
+
+@test "_parse_dockerfile_stages: returns nothing for Dockerfile with only new baseline stages (#243)" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM ubuntu:24.04 AS sys
+FROM sys AS devel-base
+FROM devel-base AS devel
+FROM devel AS devel-test
+FROM runtime AS runtime-test
 EOF
   run _parse_dockerfile_stages "${TEMP_DIR}/Dockerfile"
   assert_success

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -940,12 +940,15 @@ EOF
   assert_output "0"
 }
 
-@test "build-worker.yaml: test build passes TEST_TOOLS_IMAGE from inputs" {
+@test "build-worker.yaml: devel-test build passes TEST_TOOLS_IMAGE from inputs" {
   local _yaml="/source/.github/workflows/build-worker.yaml"
   [[ -f "${_yaml}" ]] || skip "build-worker.yaml not present in /source"
+  # Pre-#243 the step was named "Build test stage"; renamed to
+  # "Build devel-test stage" for symmetry with the new runtime-test
+  # stage. The TEST_TOOLS_IMAGE plumbing didn't move.
   run awk '
-    /- name: Build test stage/ { inside = 1 }
-    inside && /^[[:space:]]*- name:/ && !/Build test stage/ { inside = 0 }
+    /- name: Build devel-test stage/ { inside = 1 }
+    inside && /^[[:space:]]*- name:/ && !/Build devel-test stage/ { inside = 0 }
     inside { print }
   ' "${_yaml}"
   assert_success


### PR DESCRIPTION
## Summary

Closes #243. Adds the runtime-test stage smoke framework for v0.21.0 and aligns baseline stage names with the new pattern.

Three coordinated changes (one PR for atomic rename + new stage + CI wiring):

1. **Stage rename** (BREAKING for downstream Dockerfiles)
   - `FROM sys AS base` -> `FROM sys AS devel-base`
   - `FROM devel AS test` -> `FROM devel AS devel-test`

   The `runtime-base` and `runtime` names stay; runtime-base now pairs symmetrically with the renamed `devel-base`, and `devel-test` pairs with the new `runtime-test`.

2. **Add `runtime-test` stage** (`FROM runtime AS runtime-test`)
   - `ARG RUNTIME_SMOKE_CMD='bash -lc "whoami && bash --version && exit 0"'`
   - `USER root` + `RUN ${RUNTIME_SMOKE_CMD}`
   - Mirrors the existing devel-test pattern: ephemeral, build-only, never pushed. Build failure surfaces a smoke failure visibly.
   - Default smoke is install-check style (USER + bash + login shell rc files don't error). Constraint: command must be CLI-only -- no GUI binaries that init Qt / OGRE on `--version` / `--help`. Downstream override per-repo via `build_args: RUNTIME_SMOKE_CMD=...`.

3. **Update `build-worker.yaml` CI targets**
   - `target: test` -> `target: devel-test`
   - New step `Build runtime-test stage (install check)` after the devel build, gated on `inputs.build_runtime` so agent/* repos (no runtime) skip cleanly.

## Design decisions (locked in #243)

7 decisions captured in the issue body and folded directly into this PR. Notable ones:

- **runtime-test approach over external `docker run`** — symmetric with the existing `FROM devel AS test` pattern, no `load: true` / GHA `runtime_smoke_cmd` input needed; just a Dockerfile ARG.
- **CLI-only smoke constraint** — `rqt --version` / `rviz2 --version` / `gazebo-classic --help` may init Qt / OGRE in headless CI and hang or fail. Issue body + Dockerfile.example header comment + CHANGELOG all document this.
- **runtime-base stays** — load-bearing for keeping the runtime image lean (skips `devel-base`'s dev tools).
- **Backward-compat blocklist** — `setup.sh` baseline blocklist accepts BOTH new and legacy names during the v0.21.x transition; downstream Dockerfiles still using `FROM sys AS base` won't accidentally emit `base` as a compose service. Legacy aliases removed in a future major.

See #243 body for the full design-decision table.

## Test plan

- [x] `make -f Makefile.ci test`: **1042 / 1042 green** locally (was 1037; +1 setup_spec for the new-name baseline coverage, +4 build_worker_yaml_spec for the new step assertions).
- [x] ShellCheck clean.
- [x] grep guard: `\b(ros|noetic|humble|kinetic|jazzy|catkin|colcon|rosversion)\b` returns 0 matches outside `doc/changelog/CHANGELOG.md` (no regression on the #240 / #241 ROS removal).
- [ ] CI green on this PR.
- [ ] After merge: tag `v0.21.0-rc2` on the merge commit and verify `Self Test` + `Release test-tools image to GHCR` workflows run cleanly.

## Migration coordination (out of scope for this PR)

- **13 downstream repos must rename** their local `Dockerfile` (`FROM sys AS base` -> `FROM sys AS devel-base`, `FROM devel AS test` -> `FROM devel AS devel-test`) the same PR they upgrade their `template/` subtree to v0.21.0+. Otherwise their CI's new `target: devel-test` / `target: runtime-test` build steps fail on target-not-found. Tracked as a coordinated rollout after `v0.21.0` stable lands; each rename PR is atomic (subtree pull + Dockerfile rename in one PR per repo).
- **9 repos with runtime stage may opt in** to the new `runtime-test` stage by adding a `FROM runtime AS runtime-test` block (per Dockerfile.example template) and passing `RUNTIME_SMOKE_CMD=<domain-specific>` via `build_args`. Tracked separately as Issue B in the v0.21.0 plan; opens after the rename rollout above completes.
- **`env/ros_distro#5` + `env/ros2_distro#5`** track absorbing the ROS bashrc helpers removed in #240 / #241; lands in the same release window as the rename rollout.

## Related

- Closes #243
- Builds on #240 / #241 (ROS removal in v0.21.0-rc1)
- Adjacent: ycpss91255-docker/docker_harness#46 (`wait-pr-ci` skill filter gap; same-week tooling cleanup)
- Adjacent (downstream): ycpss91255-docker/ros_distro#5, ycpss91255-docker/ros2_distro#5 (ROS bashrc absorption)
