### PR TITLE
fix: Dockerfile.example runtime-test ARG word-split + USER root (v0.21.1)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`Dockerfile.example` runtime-test stage RUN line was buggy in
+  v0.21.0** (#243). Two issues:
+  - `RUN ${RUNTIME_SMOKE_CMD}` did Docker ARG substitution then
+    word-split the value: shell operators (`&&`, `||`, `;`) and
+    nested quotes were treated as literal arguments to the first
+    word. Concrete failure: with default
+    `bash -lc "whoami && bash --version && exit 0"`, `whoami`
+    received `--version` as an arg and printed its own version
+    info instead of running the chained commands. Fixed by
+    wrapping the ARG with `sh -c "${RUNTIME_SMOKE_CMD}"` so the
+    value reaches sh as a single string for normal parsing.
+  - `USER root` was the last `USER` in the Dockerfile (runtime-test
+    is ephemeral but hadolint can't know that), triggering hadolint
+    DL3002. Fixed by inheriting non-root USER from runtime;
+    downstream overrides that need root should prefix the smoke
+    command with `sudo`.
+  - Default ARG also simplified from
+    `bash -lc "whoami && bash --version && exit 0"` to
+    `whoami && bash --version` -- the `bash -lc` wrapper added a
+    login shell rc check but the nested quotes were the
+    word-split trigger. The simpler form keeps the USER + bash
+    + PATH coverage.
+
+  Discovered during sick_humble's manual v0.21.0 rollout. Three
+  new unit tests in `test/unit/template_spec.bats` (134 -> 137)
+  lock the fix: positive assertion for the `sh -c` wrapper, plus
+  regression guards for the bare `RUN ${ARG}` and `USER root`
+  forms. Total self-tests 1042 -> 1045.
+
 ## [v0.21.0] - 2026-05-08
 
 Promoted from `v0.21.0-rc2` (#245). Both RC tags' CI was green; no

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,13 +1,13 @@
 # TEST.md
 
-Template self-tests: **1042 tests** total (988 unit + 54 integration).
+Template self-tests: **1045 tests** total (991 unit + 54 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
 > `test/smoke/` are a separate suite that runs at Dockerfile `test`-stage
 > build time (via `./build.sh test`) inside both this repo and every
 > downstream repo, and are documented in [Smoke Tests](#smoke-tests)
-> below. They are **not** included in the 1042 figure because they are
+> below. They are **not** included in the 1045 figure because they are
 > build-time assertions, not self-tests.
 
 ## Test Files
@@ -277,7 +277,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `environment env_N supports multiple cross-references in one value (refs #236)` | multi-ref |
 | `environment env_N transitive cross-reference resolves through chain (refs #236)` | transitive |
 
-### test/unit/template_spec.bats (134)
+### test/unit/template_spec.bats (137)
 
 | Test | Description |
 |------|-------------|

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -218,14 +218,20 @@ RUN bats /smoke_test/
 # failure visibly in the GHA log.
 #
 # Default smoke command is generic install-check (USER set + bash on
-# PATH + login shell rc files don't error). Override per repo via
-# `build_args: RUNTIME_SMOKE_CMD=<command>` to test domain binaries.
+# PATH). Override per repo via `build_args: RUNTIME_SMOKE_CMD=<command>`
+# to test domain binaries.
 #
 # Constraint: command must be CLI-only -- no GUI tools that init
 # QApplication / OGRE on `--version` / `--help` (rqt, rviz2,
 # gazebo-classic). Prefer `<binary> --help`, `command -v <binary>`,
 # package manager queries (`ros2 pkg list | grep ...`, `rospack
 # find ...`) over invoking the GUI binary itself.
+#
+# `sh -c` wrapper required: `RUN ${ARG}` does word-splitting on the
+# substituted value and treats shell operators (&&, ||, etc.) as
+# literal arguments to the first word. Wrapping with
+# `sh -c "${RUNTIME_SMOKE_CMD}"` passes the value as a single string
+# for sh to parse, preserving operators and nested quotes.
 #
 # Only enable when the runtime stage above is also enabled. The
 # `if: build_runtime` gate in build-worker.yaml mirrors this -- if
@@ -235,6 +241,7 @@ RUN bats /smoke_test/
 #
 # FROM runtime AS runtime-test
 #
-# ARG RUNTIME_SMOKE_CMD='bash -lc "whoami && bash --version && exit 0"'
-# USER root
-# RUN ${RUNTIME_SMOKE_CMD}
+# ARG RUNTIME_SMOKE_CMD='whoami && bash --version'
+# # Inherit USER from runtime (non-root). install-check doesn't need
+# # privilege; if downstream override needs root, prefix with sudo.
+# RUN sh -c "${RUNTIME_SMOKE_CMD}"

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -988,6 +988,59 @@ EOF
 }
 
 # ════════════════════════════════════════════════════════════════════
+# Dockerfile.example: runtime-test stage syntax (#243 / v0.21.1 fix)
+#
+# v0.21.0 shipped the runtime-test block with `RUN ${RUNTIME_SMOKE_CMD}`
+# and `USER root`. Both were buggy:
+#   1. Bare `RUN ${ARG}` word-splits the substituted value: shell
+#      operators (&&, ||) and nested quotes get treated as literal
+#      args to the first command. Concrete failure: with default
+#      ARG `bash -lc "whoami && bash --version && exit 0"`, bash
+#      tokenized as `whoami '&&' bash '--version'` and whoami saw
+#      `--version` as an arg, printing its own version info instead
+#      of running the chain. Discovered during sick_humble's manual
+#      v0.21.0 rollout.
+#   2. `USER root` triggered hadolint DL3002 (last USER should not
+#      be root). runtime-test is ephemeral, but hadolint can't
+#      know that; the lint failure was real.
+#
+# v0.21.1 fix: drop USER root (inherit non-root from runtime), and
+# wrap the ARG in `sh -c "..."` so the value is passed as a single
+# string for sh to parse. The grep tests below lock both invariants
+# so the bug can't regress.
+# ════════════════════════════════════════════════════════════════════
+
+@test "Dockerfile.example runtime-test uses sh -c wrapper (regression: v0.21.0 ARG word-split bug)" {
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  # The runtime-test block is commented out (opt-in for repos with a
+  # runtime stage). The RUN line in the comment must use sh -c.
+  run grep -E '^# RUN sh -c "\$\{RUNTIME_SMOKE_CMD\}"$' "${_df}"
+  assert_success
+}
+
+@test "Dockerfile.example runtime-test does NOT use bare RUN \${RUNTIME_SMOKE_CMD} (v0.21.0 bug regression guard)" {
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  # Regression guard: bare form word-splits operators / nested quotes.
+  run grep -E '^# RUN \$\{RUNTIME_SMOKE_CMD\}$' "${_df}"
+  [ "${status}" -ne 0 ] || [ -z "${output}" ]
+}
+
+@test "Dockerfile.example runtime-test does NOT set USER root (DL3002 regression guard)" {
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  # Hadolint DL3002 fires on `USER root` if it ends up the last USER
+  # in the Dockerfile. runtime-test inherits non-root from runtime;
+  # leave it that way. Downstream override via sudo if privileged
+  # smoke is genuinely needed.
+  #
+  # Match the commented-out form in Dockerfile.example.
+  run grep -E '^# USER root$' "${_df}"
+  [ "${status}" -ne 0 ] || [ -z "${output}" ]
+}
+
+# ════════════════════════════════════════════════════════════════════
 # Dockerfile.example: ENV alignment with downstream fleet (#210)
 #
 # All 17 hand-written downstream Dockerfiles declare ENV TZ +


### PR DESCRIPTION
## Summary

Fixes the v0.21.0 `Dockerfile.example` runtime-test stage bug
discovered during `app/sick_humble`'s manual rollout.

Two bugs in the v0.21.0 example block, both regressed silently
because nothing in template's `Self Test` actually built
`target: runtime-test`:

1. **`RUN ${RUNTIME_SMOKE_CMD}` word-split shell metacharacters.**
   With default `bash -lc "whoami && bash --version && exit 0"`,
   bash tokenized the substituted value as
   `whoami '&&' bash '--version'` -- `whoami` got `--version` as
   an arg (printing its own version output) instead of `&&`
   acting as a shell operator chaining to `bash --version`.
2. **`USER root` was the last `USER` in the Dockerfile**, tripping
   hadolint DL3002. runtime-test is ephemeral but hadolint can't
   know that.

## Fix

- `RUN ${RUNTIME_SMOKE_CMD}` -> `RUN sh -c "${RUNTIME_SMOKE_CMD}"`.
  The wrapper passes the substituted value as a single string for
  sh to parse, preserving operators (`&&`, `||`, `;`) and nested
  quotes.
- Drop `USER root`. runtime-test inherits non-root from runtime;
  downstream override that needs privilege should prefix the smoke
  command with `sudo`.
- Default ARG simplified to `whoami && bash --version` (drops the
  `bash -lc` wrapper that triggered the nested-quote
  word-split). USER + bash + PATH coverage retained.

## Test coverage

3 new unit tests in `test/unit/template_spec.bats` (134 -> 137):

- Positive: `^# RUN sh -c "\${RUNTIME_SMOKE_CMD}"$` present in
  Dockerfile.example.
- Regression guard: bare `^# RUN \${RUNTIME_SMOKE_CMD}$` absent.
- Regression guard: `^# USER root$` absent in runtime-test block.

These are static greps. They catch this specific bug class but
don't actually exercise `docker buildx build --target runtime-test`.
The broader behavioural coverage gap is filed as #249.

## Test plan

- [x] `make -f Makefile.ci test`: **1045 / 1045 green** locally
      (was 1042; +3 new template_spec tests).
- [x] Manual validation: `docker buildx build --target
      runtime-test` against `app/sick_humble` carrying the v0.21.1
      runtime-test block builds successfully. Trace shows
      `+ sh -c 'whoami && bash --version'` (single-string arg,
      operators parsed, exit 0).
- [ ] CI green on this PR.
- [ ] After merge: tag `v0.21.1` and verify Self Test +
      release-test-tools workflows.
- [ ] After tag CI green: 13-repo rollout wave targets `v0.21.1`
      directly (skips the buggy v0.21.0 intermediate).

## Coordination notes

- v0.21.0 stable shipped with the buggy form. Downstream that
  copied the v0.21.0 `Dockerfile.example` runtime-test block
  verbatim hits the bug at first `target: runtime-test` build.
  The rollout wave should target v0.21.1.
- #249 tracks the broader behavioural integration coverage gap
  (parameter-variation matrix for build-worker.yaml inputs +
  runtime_smoke_cmd ARG + setup.conf knobs). Not blocking
  v0.21.1; the fix here is the immediate band-aid + static
  regression guards.

## Related

- Closes (relates to) #243 v0.21.0 implementation
- #249 follow-up: behavioural integration coverage matrix
- Builds on: #244 (the runtime-test stage framework)
