### PR TITLE
feat(wrappers): -C / --chdir flag on build/run/exec/stop (closes docker_harness#53)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`-C <dir>` / `--chdir <dir>` flag on all four wrappers**
+  (`build.sh` / `run.sh` / `exec.sh` / `stop.sh`) — operate on the repo
+  at `<dir>` without changing the caller's cwd, mirroring `git -C` /
+  `make -C`. Closes docker_harness#53. The pre-pass overrides
+  `FILE_PATH` before `_lib.sh` is sourced, so `_lib.sh` lookup, `.env`
+  load, `setup.sh` invocation, and `compose.yaml` resolution all
+  honor the override. Critical for Claude Code's sandbox
+  `excludedCommands` matching: top-level token stays
+  `./build.sh ...` rather than `(cd <dir> && ...)` or
+  `bash -c "cd <dir> && ..."`, neither of which the bash AST parser
+  unwraps into the `./build.sh *` prefix. Must come before the
+  positional `TARGET` / `CMD`. Long form `--chdir` is also accepted.
+  Adds 20 unit tests across `build_sh_spec` / `run_sh_spec` /
+  `exec_sh_spec` / `stop_sh_spec`.
+
 ### Changed
 - License migrated from GPL-3.0 to Apache 2.0 (#246). Aligns with
   upstream `osrf/docker_images` and the rest of the

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1045 tests** total (991 unit + 54 integration).
+Template self-tests: **1065 tests** total (1011 unit + 54 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -172,7 +172,7 @@ runtime after #243) forwarding those inputs, and no leftover
 | `build_contexts` input forwards to docker/build-push-action `build-contexts:` (#207: input declared with empty default, 4 build steps forward, default preserves zero-diff) | 3 |
 | #243 stage rename + runtime-test smoke: `target: devel-test` (renamed from `test`), no leftover `target: test`, `target: runtime-test` exists, runtime-test gated on `inputs.build_runtime` (>=2 occurrences shared with runtime gate) | 4 |
 
-### test/unit/build_sh_spec.bats (35)
+### test/unit/build_sh_spec.bats (40)
 
 Unit tests for `build.sh` argument handling and control flow. Uses a
 sandbox tree mirroring the expected layout (build.sh + `template/` subtree
@@ -187,11 +187,15 @@ direct, not `setup_tui.sh`), defensive guard when setup produces no
 `.env`, TARGETARCH build-arg forwarding, `--no-cache`, `--clean-tools`,
 positional `TARGET`, `--lang` argument validation, fallback
 `_detect_lang` branches (zh_TW/zh_CN/ja), real (non-dry-run) docker
-build invocation, and **runtime log-line i18n** (bootstrap /
+build invocation, **runtime log-line i18n** (bootstrap /
 drift-regen / err_no_env messages translate in all four languages via
-the local `_msg()` table; English remains the default).
+the local `_msg()` table; English remains the default), and
+**`-C` / `--chdir` flag** (docker_harness#53: pre-pass overrides
+FILE_PATH to redirect the wrapper to a different repo, both short and
+long form, value-required and directory-existence guards, usage help
+mention).
 
-### test/unit/run_sh_spec.bats (41)
+### test/unit/run_sh_spec.bats (46)
 
 Unit tests for `run.sh`. Mirrors the build_sh_spec.bats harness;
 `docker ps` reads from a controllable stub file so tests can simulate
@@ -205,12 +209,14 @@ routing, `--instance`, already-running guard, Wayland xhost path,
 `--lang` / `--instance` argument validation, fallback `_detect_lang`
 branches, **runtime log-line i18n** (bootstrap + already-running
 error translate in all four languages via the local `_msg()` table),
-and **#216 auto-build soft guard / `--build` opt-in** (image
+**#216 auto-build soft guard / `--build` opt-in** (image
 present → silent, image absent + TTY → INFO, image absent + no TTY →
 silent, per-target image inspect, `--build` invokes `./build.sh test`
-before compose up, `--build` after check-drift).
+before compose up, `--build` after check-drift), and **`-C` / `--chdir`
+flag** (docker_harness#53: redirect FILE_PATH, short + long form,
+value-required and directory guards, usage help mention).
 
-### test/unit/exec_sh_spec.bats (18)
+### test/unit/exec_sh_spec.bats (23)
 
 Unit tests for `exec.sh` argument parsing, the container-running
 precheck, and i18n. Sandbox tree mirrors build_sh_spec.bats;
@@ -223,10 +229,13 @@ Covers: `--help` (en/zh/zh-CN/ja), `--lang` / `--target` / `--instance`
 value validation, English-default not-running error, Chinese /
 Simplified Chinese / Japanese not-running error text, instance-specific
 vs default start hints, `--dry-run` bypassing the guard, compose exec
-routing when container is running, and fallback `_detect_lang`
-branches when `template/` is absent.
+routing when container is running, fallback `_detect_lang`
+branches when `template/` is absent, and **`-C` / `--chdir` flag**
+(docker_harness#53: redirect FILE_PATH so .env / project name come
+from the alt repo, short + long form, value-required and directory
+guards, usage help mention).
 
-### test/unit/stop_sh_spec.bats (16)
+### test/unit/stop_sh_spec.bats (21)
 
 Unit tests for `stop.sh` argument parsing, the `--all` multi-instance
 teardown, and i18n. `docker ps -a` output is PATH-shimmed via
@@ -237,8 +246,11 @@ Covers: `--help` (en/zh/zh-CN/ja), `--lang` / `--instance` value
 validation, default teardown via `docker compose down`, named-instance
 suffix in project name, `--all` no-instances English message,
 Chinese / Simplified Chinese / Japanese translations of the
-no-instances message, `--all` multi-project teardown loop, and
-fallback `_detect_lang` branches.
+no-instances message, `--all` multi-project teardown loop, fallback
+`_detect_lang` branches, and **`-C` / `--chdir` flag**
+(docker_harness#53: redirect FILE_PATH so .env / project name come
+from the alt repo, short + long form, value-required and directory
+guards, usage help mention).
 
 ### test/unit/compose_gen_spec.bats (50)
 

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -3,7 +3,40 @@
 
 set -euo pipefail
 
+# Default FILE_PATH = the directory the wrapper symlink lives in (i.e.
+# the repo root in normal usage). `-C <dir>` / `--chdir <dir>` overrides
+# it so the wrapper operates on a different repo without changing the
+# caller's cwd. Critical for Claude Code's sandbox `excludedCommands`
+# matching: top-level command stays `./build.sh ...` rather than
+# `(cd <dir> && ...)` or `bash -c "cd <dir> && ..."`, neither of which
+# the bash AST parser unwraps into the `./build.sh *` prefix
+# (refs docker_harness#53). The pre-pass runs before _lib.sh is sourced
+# so all path-dependent operations (including the _lib.sh lookup) honor
+# the override.
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+_chdir_i=1
+while (( _chdir_i <= $# )); do
+  case "${!_chdir_i}" in
+    -C|--chdir)
+      _chdir_next=$((_chdir_i + 1))
+      if (( _chdir_next > $# )) || [[ -z "${!_chdir_next:-}" ]]; then
+        printf '[build] ERROR: -C/--chdir requires a value\n' >&2
+        exit 2
+      fi
+      _chdir_arg="${!_chdir_next}"
+      if [[ ! -d "${_chdir_arg}" ]]; then
+        printf '[build] ERROR: -C target is not a directory: %s\n' "${_chdir_arg}" >&2
+        exit 2
+      fi
+      FILE_PATH="$(cd -- "${_chdir_arg}" && pwd -P)"
+      _chdir_i=$((_chdir_next + 1))
+      ;;
+    *)
+      _chdir_i=$((_chdir_i + 1))
+      ;;
+  esac
+done
+unset _chdir_i _chdir_next _chdir_arg
 readonly FILE_PATH
 # _lib.sh lives at template/script/docker/_lib.sh in normal consumer
 # repos, OR alongside build.sh when the Dockerfile `test` stage COPYs
@@ -49,10 +82,13 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./build.sh [-h] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
+用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
 
 選項:
   -h, --help     顯示此說明
+  -C, --chdir DIR
+                 對 DIR 下的 repo 執行（不改變呼叫者 cwd），類似 git -C / make -C。
+                 須在其他選項與 TARGET 之前指定。
   -s, --setup    強制重跑 setup.sh 重新生成 .env + compose.yaml
                  （預設：.env 不存在時自動 bootstrap；存在時僅印 drift warning）
   --reset-conf   用 template 預設值覆蓋 setup.conf（先備份到 setup.conf.bak
@@ -71,10 +107,13 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./build.sh [-h] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
+用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
 
 选项:
   -h, --help     显示此说明
+  -C, --chdir DIR
+                 对 DIR 下的 repo 执行（不改变调用者 cwd），类似 git -C / make -C。
+                 须在其他选项与 TARGET 之前指定。
   -s, --setup    强制重跑 setup.sh 重新生成 .env + compose.yaml
                  （默认：.env 不存在时自动 bootstrap；存在时仅打印 drift warning）
   --reset-conf   用 template 默认值覆盖 setup.conf（先备份到 setup.conf.bak
@@ -93,10 +132,13 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./build.sh [-h] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
+使用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
 
 オプション:
   -h, --help     このヘルプを表示
+  -C, --chdir DIR
+                 DIR 配下の repo に対して実行（呼び出し側の cwd は変えない）。
+                 git -C / make -C と同様。他のオプションや TARGET より前に指定。
   -s, --setup    setup.sh を強制実行して .env + compose.yaml を再生成
                  （デフォルト：.env が無ければ自動 bootstrap、あれば drift warning のみ）
   --reset-conf   setup.conf をテンプレのデフォルトで上書き（setup.conf.bak
@@ -116,10 +158,14 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./build.sh [-h] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
+Usage: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [TARGET]
 
 Options:
   -h, --help     Show this help
+  -C, --chdir DIR
+                 Operate on the repo at DIR without changing the caller's cwd.
+                 Mirrors git -C / make -C. Must come before other options and
+                 the TARGET.
   -s, --setup    Force rerun setup.sh to regenerate .env + compose.yaml
                  (default: auto-bootstrap if .env missing; warn on drift if present)
   --reset-conf   Overwrite setup.conf with template defaults (backs up the
@@ -173,6 +219,13 @@ main() {
     case "$1" in
       -h|--help)
         usage
+        ;;
+      -C|--chdir)
+        # Already consumed by the file-scope pre-pass that overrides
+        # FILE_PATH; skip flag + value here. The pre-pass already
+        # validated DIR exists and "-C" has a value, so we can shift
+        # blindly.
+        shift 2
         ;;
       -s|--setup)
         RUN_SETUP=true

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -3,7 +3,33 @@
 
 set -euo pipefail
 
+# `-C <dir>` / `--chdir <dir>` pre-pass — see build.sh for the full
+# rationale (refs docker_harness#53). Override FILE_PATH before _lib.sh
+# is sourced so all path-dependent operations honor the target repo.
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+_chdir_i=1
+while (( _chdir_i <= $# )); do
+  case "${!_chdir_i}" in
+    -C|--chdir)
+      _chdir_next=$((_chdir_i + 1))
+      if (( _chdir_next > $# )) || [[ -z "${!_chdir_next:-}" ]]; then
+        printf '[exec] ERROR: -C/--chdir requires a value\n' >&2
+        exit 2
+      fi
+      _chdir_arg="${!_chdir_next}"
+      if [[ ! -d "${_chdir_arg}" ]]; then
+        printf '[exec] ERROR: -C target is not a directory: %s\n' "${_chdir_arg}" >&2
+        exit 2
+      fi
+      FILE_PATH="$(cd -- "${_chdir_arg}" && pwd -P)"
+      _chdir_i=$((_chdir_next + 1))
+      ;;
+    *)
+      _chdir_i=$((_chdir_i + 1))
+      ;;
+  esac
+done
+unset _chdir_i _chdir_next _chdir_arg
 readonly FILE_PATH
 # _lib.sh lookup: template/script/docker/_lib.sh in consumer repos, or
 # sibling _lib.sh in /lint/ (Dockerfile test stage). See build.sh.
@@ -42,10 +68,12 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
+用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
 
 選項:
   -h, --help        顯示此說明
+  -C, --chdir DIR   對 DIR 下的 repo 執行（不改變呼叫者 cwd），類似 git -C / make -C。
+                    須在 CMD 之前指定。
   -t, --target T    服務名稱（預設: devel）
   --instance NAME   進入命名 instance（預設為 default instance）
   --lang LANG       設定訊息語言（預設: en）
@@ -63,10 +91,12 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
+用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
 
 选项:
   -h, --help        显示此说明
+  -C, --chdir DIR   对 DIR 下的 repo 执行（不改变调用者 cwd），类似 git -C / make -C。
+                    须在 CMD 之前指定。
   -t, --target T    服务名称（默认: devel）
   --instance NAME   进入命名 instance（默认为 default instance）
   --lang LANG       设置消息语言（默认: en）
@@ -84,10 +114,12 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./exec.sh [-h] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
+使用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
 
 オプション:
   -h, --help        このヘルプを表示
+  -C, --chdir DIR   DIR 配下の repo に対して実行（呼び出し側の cwd は変えない）。
+                    git -C / make -C と同様。CMD の前に指定。
   -t, --target T    サービス名（デフォルト: devel）
   --instance NAME   名前付き instance に入る（デフォルトは default instance）
   --lang LANG       メッセージ言語を設定（デフォルト: en）
@@ -105,10 +137,12 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./exec.sh [-h] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
+Usage: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
 
 Options:
   -h, --help        Show this help
+  -C, --chdir DIR   Operate on the repo at DIR without changing the caller's
+                    cwd. Mirrors git -C / make -C. Must come before the CMD.
   -t, --target T    Service name (default: devel)
   --instance NAME   Enter a named instance (default: default instance)
   --lang LANG       Set message language (default: en)
@@ -150,6 +184,11 @@ main() {
     case "$1" in
       -h|--help)
         usage
+        ;;
+      -C|--chdir)
+        # Already consumed by the file-scope pre-pass that overrides
+        # FILE_PATH; skip flag + value here.
+        shift 2
         ;;
       -t|--target)
         TARGET="${2:?"--target requires a value"}"

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -3,7 +3,33 @@
 
 set -euo pipefail
 
+# `-C <dir>` / `--chdir <dir>` pre-pass — see build.sh for the full
+# rationale (refs docker_harness#53). Override FILE_PATH before _lib.sh
+# is sourced so all path-dependent operations honor the target repo.
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+_chdir_i=1
+while (( _chdir_i <= $# )); do
+  case "${!_chdir_i}" in
+    -C|--chdir)
+      _chdir_next=$((_chdir_i + 1))
+      if (( _chdir_next > $# )) || [[ -z "${!_chdir_next:-}" ]]; then
+        printf '[run] ERROR: -C/--chdir requires a value\n' >&2
+        exit 2
+      fi
+      _chdir_arg="${!_chdir_next}"
+      if [[ ! -d "${_chdir_arg}" ]]; then
+        printf '[run] ERROR: -C target is not a directory: %s\n' "${_chdir_arg}" >&2
+        exit 2
+      fi
+      FILE_PATH="$(cd -- "${_chdir_arg}" && pwd -P)"
+      _chdir_i=$((_chdir_next + 1))
+      ;;
+    *)
+      _chdir_i=$((_chdir_i + 1))
+      ;;
+  esac
+done
+unset _chdir_i _chdir_next _chdir_arg
 readonly FILE_PATH
 # _lib.sh lookup: template/script/docker/_lib.sh in consumer repos, or
 # sibling _lib.sh in /lint/ (Dockerfile test stage). See build.sh.
@@ -76,12 +102,14 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./run.sh [-h] [-d|--detach] [-s|--setup] [--build] [--dry-run]
+用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
               [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
               [-t|--target TARGET] [CMD...]
 
 選項:
   -h, --help        顯示此說明
+  -C, --chdir DIR   對 DIR 下的 repo 執行（不改變呼叫者 cwd）。須在 CMD 之前指定；
+                    若 CMD 中需要字面 -C，可用 -- 分隔。類似 git -C / make -C。
   -t, --target T    Compose service 名稱（預設: devel；例: runtime）
   -d, --detach      背景執行（docker compose up -d，不接受 CMD）
   -s, --setup       強制重跑 setup.sh 重新生成 .env + compose.yaml
@@ -100,12 +128,14 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./run.sh [-h] [-d|--detach] [-s|--setup] [--build] [--dry-run]
+用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
               [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
               [-t|--target TARGET] [CMD...]
 
 选项:
   -h, --help        显示此说明
+  -C, --chdir DIR   对 DIR 下的 repo 执行（不改变调用者 cwd）。须在 CMD 之前指定；
+                    若 CMD 中需要字面 -C，可用 -- 分隔。类似 git -C / make -C。
   -t, --target T    Compose service 名称（默认: devel；例: runtime）
   -d, --detach      后台运行（docker compose up -d，不接受 CMD）
   -s, --setup       强制重跑 setup.sh 重新生成 .env + compose.yaml
@@ -124,12 +154,15 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./run.sh [-h] [-d|--detach] [-s|--setup] [--build] [--dry-run]
+使用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
                [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
                [-t|--target TARGET] [CMD...]
 
 オプション:
   -h, --help        このヘルプを表示
+  -C, --chdir DIR   DIR 配下の repo に対して実行（呼び出し側の cwd は変えない）。
+                    CMD の前に指定。CMD に字面の -C が必要なら -- で区切る。
+                    git -C / make -C と同様。
   -t, --target T    Compose サービス名（デフォルト: devel；例: runtime）
   -d, --detach      バックグラウンド実行（docker compose up -d、CMD は受け付けない）
   -s, --setup       setup.sh を強制実行して .env + compose.yaml を再生成
@@ -149,12 +182,15 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./run.sh [-h] [-d|--detach] [-s|--setup] [--build] [--dry-run]
+Usage: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
                [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
                [-t|--target TARGET] [CMD...]
 
 Options:
   -h, --help        Show this help
+  -C, --chdir DIR   Operate on the repo at DIR without changing the caller's
+                    cwd. Must come before the CMD; use -- to separate if you
+                    need a literal -C inside CMD. Mirrors git -C / make -C.
   -t, --target T    Compose service name (default: devel; e.g. runtime)
   -d, --detach      Run in background (docker compose up -d; no CMD accepted)
   -s, --setup       Force rerun setup.sh to regenerate .env + compose.yaml
@@ -211,6 +247,12 @@ main() {
     case "$1" in
       -h|--help)
         usage
+        ;;
+      -C|--chdir)
+        # Already consumed by the file-scope pre-pass that overrides
+        # FILE_PATH; skip flag + value here. Pre-pass already validated
+        # DIR exists, so blind shift 2 is safe.
+        shift 2
         ;;
       -d|--detach)
         DETACH=true

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -3,7 +3,33 @@
 
 set -euo pipefail
 
+# `-C <dir>` / `--chdir <dir>` pre-pass — see build.sh for the full
+# rationale (refs docker_harness#53). Override FILE_PATH before _lib.sh
+# is sourced so all path-dependent operations honor the target repo.
 FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+_chdir_i=1
+while (( _chdir_i <= $# )); do
+  case "${!_chdir_i}" in
+    -C|--chdir)
+      _chdir_next=$((_chdir_i + 1))
+      if (( _chdir_next > $# )) || [[ -z "${!_chdir_next:-}" ]]; then
+        printf '[stop] ERROR: -C/--chdir requires a value\n' >&2
+        exit 2
+      fi
+      _chdir_arg="${!_chdir_next}"
+      if [[ ! -d "${_chdir_arg}" ]]; then
+        printf '[stop] ERROR: -C target is not a directory: %s\n' "${_chdir_arg}" >&2
+        exit 2
+      fi
+      FILE_PATH="$(cd -- "${_chdir_arg}" && pwd -P)"
+      _chdir_i=$((_chdir_next + 1))
+      ;;
+    *)
+      _chdir_i=$((_chdir_i + 1))
+      ;;
+  esac
+done
+unset _chdir_i _chdir_next _chdir_arg
 readonly FILE_PATH
 # _lib.sh lookup: template/script/docker/_lib.sh in consumer repos, or
 # sibling _lib.sh in /lint/ (Dockerfile test stage). See build.sh.
@@ -34,12 +60,13 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./stop.sh [-h] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
+用法: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
 
 停止並移除容器。預設只停止 default instance。
 
 選項:
   -h, --help        顯示此說明
+  -C, --chdir DIR   對 DIR 下的 repo 執行（不改變呼叫者 cwd），類似 git -C / make -C
   --instance NAME   只停止指定的命名 instance
   -a, --all         停止所有 instance（預設 + 全部命名 instance)
   --lang LANG       設定訊息語言（預設: en）
@@ -48,12 +75,13 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./stop.sh [-h] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
+用法: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
 
 停止并移除容器。默认只停止 default instance。
 
 选项:
   -h, --help        显示此说明
+  -C, --chdir DIR   对 DIR 下的 repo 执行（不改变调用者 cwd），类似 git -C / make -C
   --instance NAME   只停止指定的命名 instance
   -a, --all         停止所有 instance（默认 + 全部命名 instance)
   --lang LANG       设置消息语言（默认: en）
@@ -62,12 +90,13 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./stop.sh [-h] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
+使用法: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
 
 コンテナを停止・削除します。デフォルトは default instance のみ。
 
 オプション:
   -h, --help        このヘルプを表示
+  -C, --chdir DIR   DIR 配下の repo に対して実行（呼び出し側の cwd は変えない）
   --instance NAME   指定された名前付き instance のみ停止
   -a, --all         すべての instance を停止（デフォルト + 全名前付き instance）
   --lang LANG       メッセージ言語を設定（デフォルト: en）
@@ -76,12 +105,14 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./stop.sh [-h] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
+Usage: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
 
 Stop and remove containers. Default: stop only the default instance.
 
 Options:
   -h, --help        Show this help
+  -C, --chdir DIR   Operate on the repo at DIR without changing the caller's cwd
+                    (mirrors git -C / make -C)
   --instance NAME   Stop only the named instance
   -a, --all         Stop ALL instances (default + every named instance)
   --lang LANG       Set message language (default: en)
@@ -127,6 +158,13 @@ main() {
     case "$1" in
       -h|--help)
         usage
+        ;;
+      -C|--chdir)
+        # Already consumed by the file-scope pre-pass that overrides
+        # FILE_PATH; skip flag + value here. Without this branch the
+        # `*)` catch-all below would dump -C / DIR into PASSTHROUGH and
+        # docker compose down would reject them.
+        shift 2
         ;;
       --instance)
         INSTANCE="${2:?"--instance requires a value"}"

--- a/test/unit/build_sh_spec.bats
+++ b/test/unit/build_sh_spec.bats
@@ -542,3 +542,67 @@ EOS
   assert_success
   refute_output --partial "proceed?"
 }
+
+# ════════════════════════════════════════════════════════════════════
+# -C / --chdir flag (issue docker_harness#53)
+#
+# The pre-pass at file scope must override FILE_PATH so _lib.sh + setup.sh
+# + .env / compose.yaml all resolve against DIR instead of the wrapper's
+# symlink dir. Critical for Claude Code's sandbox excludedCommands match
+# (top-level token stays `./build.sh ...` rather than subshell / bash -c).
+# ════════════════════════════════════════════════════════════════════
+
+@test "build.sh -C <dir> redirects FILE_PATH to <dir>" {
+  # Build a second sandbox tree mirroring the primary one, then invoke
+  # the *primary* build.sh with -C pointing at the alt tree. The mock
+  # setup.sh stamps MOCK_SETUP_LOG with whatever --base-path it received,
+  # so the log proves which tree FILE_PATH resolved to.
+  local ALT="${TEMP_DIR}/alt"
+  mkdir -p "${ALT}/template/script/docker" "${ALT}/template/dockerfile"
+  cp /source/script/docker/_lib.sh "${ALT}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${ALT}/template/script/docker/i18n.sh"
+  cp "${SANDBOX}/template/script/docker/setup.sh" "${ALT}/template/script/docker/setup.sh"
+  chmod +x "${ALT}/template/script/docker/setup.sh"
+  touch "${ALT}/template/dockerfile/Dockerfile.test-tools"
+
+  run bash "${SANDBOX}/build.sh" -C "${ALT}" --dry-run
+  assert_success
+  assert [ -f "${MOCK_SETUP_LOG}" ]
+  run cat "${MOCK_SETUP_LOG}"
+  assert_output --partial "setup.sh invoked --base-path ${ALT}"
+  refute_output --partial "setup.sh invoked --base-path ${SANDBOX}"
+}
+
+@test "build.sh --chdir <dir> long form is equivalent to -C" {
+  local ALT="${TEMP_DIR}/alt2"
+  mkdir -p "${ALT}/template/script/docker" "${ALT}/template/dockerfile"
+  cp /source/script/docker/_lib.sh "${ALT}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${ALT}/template/script/docker/i18n.sh"
+  cp "${SANDBOX}/template/script/docker/setup.sh" "${ALT}/template/script/docker/setup.sh"
+  chmod +x "${ALT}/template/script/docker/setup.sh"
+  touch "${ALT}/template/dockerfile/Dockerfile.test-tools"
+
+  run bash "${SANDBOX}/build.sh" --chdir "${ALT}" --dry-run
+  assert_success
+  run cat "${MOCK_SETUP_LOG}"
+  assert_output --partial "setup.sh invoked --base-path ${ALT}"
+}
+
+@test "build.sh -C without a value exits 2" {
+  run bash "${SANDBOX}/build.sh" -C
+  assert_failure 2
+  assert_output --partial "requires a value"
+}
+
+@test "build.sh -C with a non-existent directory exits 2" {
+  run bash "${SANDBOX}/build.sh" -C /definitely/does/not/exist
+  assert_failure 2
+  assert_output --partial "not a directory"
+}
+
+@test "build.sh -C is mentioned in usage help" {
+  run bash "${SANDBOX}/build.sh" --help
+  assert_success
+  assert_output --partial "-C"
+  assert_output --partial "--chdir"
+}

--- a/test/unit/exec_sh_spec.bats
+++ b/test/unit/exec_sh_spec.bats
@@ -183,3 +183,69 @@ teardown() {
   assert_output --partial "使用法"
   rm -rf "${_tmp}"
 }
+
+# ════════════════════════════════════════════════════════════════════
+# -C / --chdir flag (issue docker_harness#53) — see build_sh_spec.
+# ════════════════════════════════════════════════════════════════════
+
+@test "exec.sh -C <dir> redirects FILE_PATH to <dir>" {
+  # Seed an alt sandbox with its own .env carrying a distinct IMAGE_NAME.
+  # When -C points there, exec.sh's docker exec invocation must reference
+  # the alt IMAGE_NAME, proving FILE_PATH was redirected.
+  local ALT="${TEMP_DIR}/alt"
+  mkdir -p "${ALT}/template/script/docker"
+  cp /source/script/docker/_lib.sh "${ALT}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${ALT}/template/script/docker/i18n.sh"
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=altimg"
+    echo "DOCKER_HUB_USER=altuser"
+  } > "${ALT}/.env"
+
+  # Make `docker ps` claim the alt container is running so exec proceeds.
+  echo "altuser-altimg" > "${DOCKER_PS_FILE}"
+
+  run bash "${SANDBOX}/exec.sh" -C "${ALT}" --dry-run
+  assert_success
+  # The compose project name is derived from DOCKER_HUB_USER + IMAGE_NAME
+  # in .env. If FILE_PATH still pointed at SANDBOX, project would say
+  # mockuser-mockimg.
+  assert_output --partial "altuser-altimg"
+  refute_output --partial "mockuser-mockimg"
+}
+
+@test "exec.sh --chdir <dir> long form is equivalent to -C" {
+  local ALT="${TEMP_DIR}/alt2"
+  mkdir -p "${ALT}/template/script/docker"
+  cp /source/script/docker/_lib.sh "${ALT}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${ALT}/template/script/docker/i18n.sh"
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=altimg2"
+    echo "DOCKER_HUB_USER=altuser2"
+  } > "${ALT}/.env"
+  echo "altuser2-altimg2" > "${DOCKER_PS_FILE}"
+
+  run bash "${SANDBOX}/exec.sh" --chdir "${ALT}" --dry-run
+  assert_success
+  assert_output --partial "altuser2-altimg2"
+}
+
+@test "exec.sh -C without a value exits 2" {
+  run bash "${SANDBOX}/exec.sh" -C
+  assert_failure 2
+  assert_output --partial "requires a value"
+}
+
+@test "exec.sh -C with a non-existent directory exits 2" {
+  run bash "${SANDBOX}/exec.sh" -C /definitely/does/not/exist
+  assert_failure 2
+  assert_output --partial "not a directory"
+}
+
+@test "exec.sh -C is mentioned in usage help" {
+  run bash "${SANDBOX}/exec.sh" --help
+  assert_success
+  assert_output --partial "-C"
+  assert_output --partial "--chdir"
+}

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -638,3 +638,56 @@ EOS
   # build-sh appears AFTER setup-check-drift (line ≥ 2)
   [[ "${output%%:*}" -ge 2 ]] || { echo "expected build-sh after check-drift, got: ${output}"; return 1; }
 }
+
+# ════════════════════════════════════════════════════════════════════
+# -C / --chdir flag (issue docker_harness#53) — see build_sh_spec for the
+# rationale; run.sh mirrors the build.sh pre-pass.
+# ════════════════════════════════════════════════════════════════════
+
+@test "run.sh -C <dir> redirects FILE_PATH to <dir>" {
+  local ALT="${TEMP_DIR}/alt"
+  mkdir -p "${ALT}/template/script/docker"
+  cp /source/script/docker/_lib.sh "${ALT}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${ALT}/template/script/docker/i18n.sh"
+  cp "${SANDBOX}/template/script/docker/setup.sh" "${ALT}/template/script/docker/setup.sh"
+  chmod +x "${ALT}/template/script/docker/setup.sh"
+
+  run bash "${SANDBOX}/run.sh" -C "${ALT}" --dry-run --detach
+  assert_success
+  assert [ -f "${MOCK_SETUP_LOG}" ]
+  run cat "${MOCK_SETUP_LOG}"
+  assert_output --partial "setup.sh invoked --base-path ${ALT}"
+}
+
+@test "run.sh --chdir <dir> long form is equivalent to -C" {
+  local ALT="${TEMP_DIR}/alt2"
+  mkdir -p "${ALT}/template/script/docker"
+  cp /source/script/docker/_lib.sh "${ALT}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${ALT}/template/script/docker/i18n.sh"
+  cp "${SANDBOX}/template/script/docker/setup.sh" "${ALT}/template/script/docker/setup.sh"
+  chmod +x "${ALT}/template/script/docker/setup.sh"
+
+  run bash "${SANDBOX}/run.sh" --chdir "${ALT}" --dry-run --detach
+  assert_success
+  run cat "${MOCK_SETUP_LOG}"
+  assert_output --partial "setup.sh invoked --base-path ${ALT}"
+}
+
+@test "run.sh -C without a value exits 2" {
+  run bash "${SANDBOX}/run.sh" -C
+  assert_failure 2
+  assert_output --partial "requires a value"
+}
+
+@test "run.sh -C with a non-existent directory exits 2" {
+  run bash "${SANDBOX}/run.sh" -C /definitely/does/not/exist
+  assert_failure 2
+  assert_output --partial "not a directory"
+}
+
+@test "run.sh -C is mentioned in usage help" {
+  run bash "${SANDBOX}/run.sh" --help
+  assert_success
+  assert_output --partial "-C"
+  assert_output --partial "--chdir"
+}

--- a/test/unit/stop_sh_spec.bats
+++ b/test/unit/stop_sh_spec.bats
@@ -180,3 +180,61 @@ teardown() {
   assert_output --partial "使用法"
   rm -rf "${_tmp}"
 }
+
+# ════════════════════════════════════════════════════════════════════
+# -C / --chdir flag (issue docker_harness#53) — see build_sh_spec.
+# ════════════════════════════════════════════════════════════════════
+
+@test "stop.sh -C <dir> redirects FILE_PATH to <dir>" {
+  local ALT="${TEMP_DIR}/alt"
+  mkdir -p "${ALT}/template/script/docker"
+  cp /source/script/docker/_lib.sh "${ALT}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${ALT}/template/script/docker/i18n.sh"
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=altimg"
+    echo "DOCKER_HUB_USER=altuser"
+  } > "${ALT}/.env"
+
+  run bash "${SANDBOX}/stop.sh" -C "${ALT}" --dry-run
+  assert_success
+  # docker compose down's project name comes from .env; alt path proves
+  # FILE_PATH was redirected to ALT.
+  assert_output --partial "altuser-altimg"
+  refute_output --partial "mockuser-mockimg"
+}
+
+@test "stop.sh --chdir <dir> long form is equivalent to -C" {
+  local ALT="${TEMP_DIR}/alt2"
+  mkdir -p "${ALT}/template/script/docker"
+  cp /source/script/docker/_lib.sh "${ALT}/template/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${ALT}/template/script/docker/i18n.sh"
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=altimg2"
+    echo "DOCKER_HUB_USER=altuser2"
+  } > "${ALT}/.env"
+
+  run bash "${SANDBOX}/stop.sh" --chdir "${ALT}" --dry-run
+  assert_success
+  assert_output --partial "altuser2-altimg2"
+}
+
+@test "stop.sh -C without a value exits 2" {
+  run bash "${SANDBOX}/stop.sh" -C
+  assert_failure 2
+  assert_output --partial "requires a value"
+}
+
+@test "stop.sh -C with a non-existent directory exits 2" {
+  run bash "${SANDBOX}/stop.sh" -C /definitely/does/not/exist
+  assert_failure 2
+  assert_output --partial "not a directory"
+}
+
+@test "stop.sh -C is mentioned in usage help" {
+  run bash "${SANDBOX}/stop.sh" --help
+  assert_success
+  assert_output --partial "-C"
+  assert_output --partial "--chdir"
+}


### PR DESCRIPTION
## Summary

Add `-C <dir>` / `--chdir <dir>` flag to all four wrappers (`build.sh` / `run.sh` / `exec.sh` / `stop.sh`), mirroring `git -C` / `make -C`. Operate on the repo at `<dir>` without changing the caller's cwd.

Closes ycpss91255-docker/docker_harness#53.

## Why

Claude Code's sandbox `excludedCommands` matches against the **top-level** token of the bash AST. From a worktree (or any cwd that is not the target repo), the natural alternatives currently break the match:

```bash
# (1) subshell — top-level token is `(`, not `./build.sh`
(cd worktree/foo && ./build.sh test)

# (2) bash -c — top-level token is `bash`; `bash *` is not in excludedCommands
bash -c "cd worktree/foo && ./build.sh test"
```

Both fall through to the sandboxed branch and hit `permission denied while trying to connect to the docker API at unix:///var/run/docker.sock`. The current escape valve is `dangerouslyDisableSandbox: true`, which is broader than needed. With `-C` the top-level token is `./build.sh ...` and the existing bypass works.

```bash
./build.sh -C worktree/foo test
```

## Implementation

- File-scope pre-pass before `_lib.sh` is sourced — overrides `FILE_PATH` to the resolved absolute path of `<dir>`. All path-dependent operations (`_lib.sh` lookup, `setup.sh` `--base-path`, `.env` load, `compose.yaml` resolution) honor the override.
- `-C` must come before the positional `TARGET` / `CMD`. Long form `--chdir` accepted.
- Pre-pass guards: missing value → exit 2, non-existent dir → exit 2.
- `main()`'s parse loop has a matching `-C|--chdir) shift 2 ;;` branch so the catch-all in `stop.sh` does not dump `-C` / value into compose-down passthrough, and so `run.sh` does not accidentally consume the value as a CMD positional.
- 4-locale usage (en / zh-TW / zh-CN / ja) updated.

## Tests

`+20` unit tests across `build_sh_spec` / `run_sh_spec` / `exec_sh_spec` / `stop_sh_spec` (5 each):

- short form `-C <dir>` redirects `FILE_PATH` (verified via `.env` consumed / `setup.sh --base-path` observed in alt sandbox)
- long form `--chdir <dir>` equivalent
- missing value → exit 2 with "requires a value"
- non-existent dir → exit 2 with "not a directory"
- `-h` / usage help mentions `-C` and `--chdir`

`make -f Makefile.ci test` passes locally: 1011 unit + 54 integration, 0 failures, ShellCheck clean.

## Test plan

- [ ] CI green (`test` job)
- [ ] After merge + tag, `/batch-template-upgrade` to fan out to 13 downstream repos so they get `-C` available too
- [ ] Update docker_harness CLAUDE.md "Bash command pattern parser limits" table to point at `-C` (separate PR after fanout)

## Out of scope

- Upstream Claude Code parser fix to walk inside subshells / `bash -c` — slow turnaround; wrapper-side `-C` solves the immediate friction.
- Auto-detecting "you're in a worktree" — too brittle.
