### PR TITLE
feat(config): layered config/ override + bashrc.d drop-in (closes #254)

### DIFF
--- a/config/shell/bashrc
+++ b/config/shell/bashrc
@@ -35,3 +35,15 @@ color_git_branch() {
 
 alias_func
 color_git_branch
+
+# Source any drop-in snippets in ~/.bashrc.d/. Both template helpers
+# (shipped via template/config/shell/bashrc.d/) and downstream
+# repo-local helpers (shipped via <repo>/config/shell/bashrc.d/) end
+# up here. See ycpss91255-docker/template#254 for the layered
+# config/ override + bashrc.d drop-in design.
+if [[ -d "${HOME}/.bashrc.d" ]]; then
+  for _bashrc_d_f in "${HOME}/.bashrc.d/"*.sh; do
+    [[ -r "${_bashrc_d_f}" ]] && source "${_bashrc_d_f}"
+  done
+  unset _bashrc_d_f
+fi

--- a/config/shell/bashrc.d/.gitkeep
+++ b/config/shell/bashrc.d/.gitkeep
@@ -1,0 +1,8 @@
+# Empty placeholder so this directory exists in the subtree (git
+# does not track empty directories). Drop *.sh files here in the
+# template-side helpers for cross-repo conveniences. Downstream
+# overrides go under <repo>/config/shell/bashrc.d/ and overlay via
+# the layered COPY chain in Dockerfile.example.
+#
+# See ycpss91255-docker/template#254 for the layered config/
+# override design.

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Layered `config/` override at build time** (#254). Mirrors
+  the `setup.conf` repo-override pattern, just at file granularity:
+  `Dockerfile.example`'s `COPY ${CONFIG_SRC} ${CONFIG_DIR}` (the
+  pre-existing `<repo>/config/` copy) is preceded by a new
+  `COPY template/config ${CONFIG_DIR}` layer. The first COPY brings
+  template/config/ defaults; the second overlays
+  `<repo>/config/` on top -- file-level merge, downstream files
+  override matching paths from template, files only in template
+  fall through unchanged. Files only in `<repo>/config/` are
+  added.
+
+  Mental model:
+  - `setup.conf`: repo skips a section -> falls through to
+    template default; repo lists a section -> repo's section
+    replaces template's section (whole section).
+  - `config/` (new): repo skips a file -> falls through to
+    template default; repo provides a file -> repo's file
+    replaces template's file (whole file).
+
+  Docker handles the merge natively via two sequential `COPY` of
+  the same destination. No build-context magic, no setup.sh
+  pre-merge -- just two `COPY` lines.
+
+- **`bashrc.d/` drop-in directory** (#254, supersedes #253).
+  `template/config/shell/` gains a `bashrc.d/` directory (empty
+  placeholder via `.gitkeep`). `template/config/shell/bashrc` gains
+  a bootstrap loop that sources `${HOME}/.bashrc.d/*.sh` at
+  interactive shell start. `Dockerfile.example` gains a
+  `mkdir -p ${HOME}/.bashrc.d` +
+  `cp -n ${CONFIG_DIR}/shell/bashrc.d/*.sh ${HOME}/.bashrc.d/` step
+  in the existing shell-setup RUN block. Empty bashrc.d/ is a
+  clean no-op (the for loop has no iterations + `cp -n` with
+  `2>/dev/null || true` for missing source).
+
+  Use case: downstream `<repo>/config/shell/bashrc.d/<name>.sh`
+  ships per-repo PATH additions, aliases, helpers without forking
+  the template's `bashrc` file. Layered with #254's COPY chain so
+  template-side helpers (in `template/config/shell/bashrc.d/`) and
+  downstream-side helpers (in `<repo>/config/shell/bashrc.d/`)
+  both end up in `${HOME}/.bashrc.d/` after build.
+
+- 3 new tests in `test/unit/bashrc_spec.bats` (7 -> 10) covering
+  the bashrc.d bootstrap loop and `.gitkeep` placeholder.
+- 2 new tests in `test/integration/init_new_repo_spec.bats`
+  (36 -> 38) asserting Dockerfile.example's two-layer COPY chain
+  ordering and the bashrc.d setup step.
+
+### Changed
+- **`init.sh` new-repo seed behaviour** (#254, soft-breaking):
+  pre-#254 `init.sh` seeded `<repo>/config/` as a FULL copy of
+  `template/config/`. Post-#254 it creates an EMPTY placeholder
+  with just a `.gitkeep`, leaving the layered COPY chain in
+  Dockerfile.example to do the merge at build time. Existing
+  repos with a pre-#254 full-copy `<repo>/config/` keep working
+  unchanged -- their copy still overlays every template default
+  at build time, identical to pre-#254 behaviour. They can
+  manually trim files in `<repo>/config/` that match template
+  default to start receiving template-side improvements
+  automatically.
+- `test/integration/init_new_repo_spec.bats` test
+  "config/ is a real directory copied from template/config" ->
+  "config/ is an empty placeholder" (new shape). The
+  preserve-existing-config and stale-symlink tests still pass
+  unchanged.
+- Total self-tests 1065 -> 1070 (+3 bashrc_spec, +2
+  init_new_repo_spec). Unit 1011 -> 1014; integration 54 -> 56.
+
 ## [v0.22.0] - 2026-05-08
 
 Minor release adding `-C` / `--chdir` to the four wrappers for worktree-path

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,13 +1,13 @@
 # TEST.md
 
-Template self-tests: **1065 tests** total (1011 unit + 54 integration).
+Template self-tests: **1070 tests** total (1014 unit + 56 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
 > `test/smoke/` are a separate suite that runs at Dockerfile `test`-stage
 > build time (via `./build.sh test`) inside both this repo and every
 > downstream repo, and are documented in [Smoke Tests](#smoke-tests)
-> below. They are **not** included in the 1045 figure because they are
+> below. They are **not** included in the 1070 figure because they are
 > build-time assertions, not self-tests.
 
 ## Test Files
@@ -420,7 +420,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `setup.sh default _base_path uses /..` | Path resolution |
 | `setup.sh default _base_path uses double parent traversal` | Repo root traversal |
 
-### test/unit/bashrc_spec.bats (7)
+### test/unit/bashrc_spec.bats (10)
 
 | Test | Description |
 |------|-------------|
@@ -654,7 +654,7 @@ Unit tests for `template/script/docker/lib/gitignore.sh` — the canonical
 | `_untrack_canonical_in_repo: idempotent — second run succeeds without error` | Re-run safety |
 | `_untrack_canonical_in_repo: untracks all canonical entries that match` | Multi-entry sweep |
 
-### test/integration/init_new_repo_spec.bats (36)
+### test/integration/init_new_repo_spec.bats (38)
 
 End-to-end verification that `init.sh` produces a complete repo skeleton in
 an empty directory. **Level 1** (file generation only, no Docker). The

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -111,9 +111,18 @@ ARG USER="${USER_NAME}"
 ARG GROUP="${USER_GROUP}"
 ARG ENTRYPOINT_FILE="script/entrypoint.sh"
 ARG CONFIG_DIR="/tmp/config"
-# <repo>/config is a per-repo copy of template/config seeded by
-# init.sh. Edit files there freely; template upgrades do not touch
-# this directory (upgrade.sh prints a diff hint when upstream moves).
+# Layered config/ override (template#254): two sequential COPYs into
+# /tmp/config/. The first brings template/config/ defaults; the
+# second overlays <repo>/config/ on top. File-level merge -- files in
+# <repo>/config/ replace same-path files in /tmp/config/; files only
+# in template/config/ stay; files only in <repo>/config/ are added.
+# Mental model is the same as setup.conf section-replace, just at
+# file granularity. <repo>/config/ becomes opt-in (init.sh seeds an
+# empty .gitkeep for new repos, not the full tree); existing repos
+# with a full <repo>/config/ snapshot from earlier seed continue to
+# work (their copy overrides every template default, identical to
+# pre-v0.22.0 behaviour). Trim <repo>/config/ files that match
+# template default to start receiving template-side improvements.
 ARG CONFIG_SRC="config"
 
 # Add your application-specific packages here
@@ -125,6 +134,11 @@ ARG CONFIG_SRC="config"
 #     rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=0755 "./${ENTRYPOINT_FILE}" "/entrypoint.sh"
+# Layer 1: template/config/ defaults (subtree-managed, updates with
+# template/upgrade.sh).
+COPY --chown="${USER}":"${GROUP}" --chmod=0755 template/config "${CONFIG_DIR}"
+# Layer 2: <repo>/config/ overrides (per-repo, survives subtree
+# pull). Files here overlay matching paths from layer 1.
 COPY --chown="${USER}":"${GROUP}" --chmod=0755 "${CONFIG_SRC}" "${CONFIG_DIR}"
 
 USER "${USER}"
@@ -132,9 +146,14 @@ USER "${USER}"
 # Setup pip packages
 RUN "${CONFIG_DIR}"/pip/setup.sh
 
-# Setup shell, terminator, tmux
+# Setup shell, terminator, tmux. The bashrc append picks up the
+# bashrc.d bootstrap loop (template#254) which sources any *.sh
+# drop-ins under ~/.bashrc.d/ at interactive shell start.
 RUN cat "${CONFIG_DIR}"/shell/bashrc >> "${HOME}/.bashrc" && \
     chown "${USER}":"${GROUP}" "${HOME}/.bashrc" && \
+    mkdir -p "${HOME}/.bashrc.d" && \
+    cp -n "${CONFIG_DIR}"/shell/bashrc.d/*.sh "${HOME}/.bashrc.d/" 2>/dev/null || true && \
+    chown -R "${USER}":"${GROUP}" "${HOME}/.bashrc.d" && \
     "${CONFIG_DIR}"/shell/terminator/setup.sh && \
     "${CONFIG_DIR}"/shell/tmux/setup.sh && \
     sudo rm -rf "${CONFIG_DIR}"

--- a/init.sh
+++ b/init.sh
@@ -73,34 +73,63 @@ _create_symlinks() {
 
 # _populate_config
 #
-# On first init (no <repo>/config/), copy `template/config/` out as a
-# real directory the user owns and can edit freely. Rationale:
+# On first init (no <repo>/config/), create an empty placeholder
+# directory at `<repo>/config/` with a `.gitkeep`. The Dockerfile's
+# layered COPY chain (template#254) reads `template/config/` first
+# as the default layer and `<repo>/config/` second as the override
+# overlay; an empty <repo>/config/ means "no overrides, take all
+# template defaults". Downstream adds files under <repo>/config/
+# only when they want to override a specific template default.
+#
+# Rationale (compared to the pre-#254 full-copy seed):
 #   * a symlink would make edits spill into the subtree and fight
 #     `git subtree pull`;
-#   * a plain Dockerfile COPY from `template/config/` would deny the
-#     user any per-repo override path at all.
-# Copy gives the user a clean, repo-local editing surface; subsequent
-# template upgrades leave this directory untouched and `upgrade.sh`
-# prints a diff hint when the upstream baseline moves so the user can
-# reconcile manually.
+#   * a plain Dockerfile COPY from `template/config/` alone would
+#     deny the user any per-repo override path at all;
+#   * a full-copy seed (pre-#254) gives the user a clean
+#     repo-local editing surface but freezes their config at the
+#     init-time template version -- subsequent template-side
+#     improvements drift, requiring manual diff/reconcile;
+#   * an EMPTY placeholder (post-#254) lets the layered COPY do
+#     the merge at build time. Repos opt into per-file overrides
+#     only when they need them; everything else flows through
+#     from template/config/ on every build, keeping
+#     <repo>/config/ small and the override-vs-default contract
+#     visible in `git status` / `git diff`.
+#
+# Existing repos with a full <repo>/config/ snapshot from a
+# pre-v0.22.0 init keep working unchanged: their copy still
+# overrides every template default at build time, identical to
+# pre-#254 behaviour. They can manually trim files that match
+# template default to start receiving template-side improvements.
 _populate_config() {
-  # User already has a real config/ — preserve (contains their edits).
+  # User already has a real config/ — preserve (contains their edits
+  # or pre-#254 full-copy snapshot, both layered correctly).
   if [[ -d config && ! -L config ]]; then
     _log "  Keeping existing config/ directory"
     return 0
   fi
   # Stale symlink from an earlier init.sh version — drop it before
-  # copying. Without rm, `cp -r` would dereference and write INTO the
-  # symlink's target (i.e. pollute the subtree).
+  # creating the placeholder. Without rm, `mkdir` would fail if the
+  # symlink target is a real dir, or pollute the subtree if it's a
+  # template/config/ symlink.
   if [[ -L config ]]; then
     rm -f config
   fi
-  if [[ ! -d "${TEMPLATE_REL}/config" ]]; then
-    _log "  Skipping config/ seed (${TEMPLATE_REL}/config not found)"
-    return 0
-  fi
-  cp -r "${TEMPLATE_REL}/config" config
-  _log "  Copied config/ from ${TEMPLATE_REL}/config (yours to edit)"
+  # Create empty placeholder + .gitkeep so the dir exists in git
+  # (Docker COPY of <repo>/config/ requires the path to exist).
+  mkdir -p config
+  cat > config/.gitkeep <<'EOF'
+# Placeholder so this directory exists in git. The Dockerfile's
+# layered COPY (template#254) reads template/config/ first then
+# overlays <repo>/config/ on top. Drop files under <repo>/config/
+# only when you want to override a specific template default
+# (e.g. <repo>/config/shell/bashrc to override template's bashrc,
+# or <repo>/config/shell/bashrc.d/your-snippet.sh to add a drop-in).
+# Files NOT placed here keep flowing through from template/config/
+# on every build.
+EOF
+  _log "  Created empty config/ placeholder (template/config/ is the default layer; <repo>/config/ overlays per-file)"
 }
 
 _detect_template_version() {

--- a/test/integration/init_new_repo_spec.bats
+++ b/test/integration/init_new_repo_spec.bats
@@ -140,17 +140,26 @@ teardown() {
   assert_output "template/script/docker/Makefile"
 }
 
-@test "new repo: config/ is a real directory copied from template/config" {
+@test "new repo: config/ is an empty placeholder (template#254 layered override)" {
   bash template/init.sh
   # Must NOT be a symlink — edits should stay in the user's own
   # repo, not leak into the subtree where subtree pulls would fight
-  # them. Must be a real directory seeded with the template content.
+  # them. Must be a real directory.
   assert [ ! -L "${REPO_DIR}/config" ]
   assert [ -d "${REPO_DIR}/config" ]
-  assert [ -d "${REPO_DIR}/config/shell" ]
-  # Sanity-check one of the seeded files actually made it across.
-  assert [ -f "${REPO_DIR}/config/pip/setup.sh" ] \
-    || assert [ -d "${REPO_DIR}/config/shell/bashrc" ]
+  # Pre-#254 init.sh seeded a FULL copy of template/config/ here.
+  # Post-#254 (template v0.22.0+) init.sh creates an empty
+  # placeholder with just a .gitkeep -- the Dockerfile's layered
+  # COPY chain reads template/config/ as defaults and <repo>/config/
+  # as overrides, so an empty <repo>/config/ means "no overrides,
+  # use all template defaults". Downstream adds files only when
+  # they want to override a specific template file.
+  assert [ -f "${REPO_DIR}/config/.gitkeep" ]
+  # Confirm no full-tree seed: shell/, pip/, etc. should NOT be
+  # auto-populated. (Existing repos with a pre-#254 full copy still
+  # work via the next test's preserve-existing path.)
+  run find "${REPO_DIR}/config" -mindepth 1 -maxdepth 1 -not -name '.gitkeep'
+  assert_output ""
 }
 
 @test "new repo: init.sh preserves pre-existing config/ directory (no clobber)" {
@@ -164,16 +173,16 @@ teardown() {
   assert [ -f "${REPO_DIR}/config/custom/marker" ]
 }
 
-@test "new repo: init.sh drops stale config symlink before copying" {
+@test "new repo: init.sh drops stale config symlink before creating placeholder" {
   # An older init.sh created config → template/config as a symlink.
-  # Re-running the new init.sh on such a repo must replace the
-  # symlink with a real copy (cp -r through a symlink would otherwise
-  # silently pollute the subtree target).
+  # Re-running the post-#254 init.sh on such a repo must replace the
+  # symlink with the empty placeholder (mkdir through a symlink
+  # would otherwise pollute the subtree target).
   ln -s template/config "${REPO_DIR}/config"
   bash template/init.sh
   assert [ ! -L "${REPO_DIR}/config" ]
   assert [ -d "${REPO_DIR}/config" ]
-  assert [ -d "${REPO_DIR}/config/shell" ]
+  assert [ -f "${REPO_DIR}/config/.gitkeep" ]
 }
 
 @test "Dockerfile.example references CONFIG_SRC=\"config\" (not template/config)" {
@@ -182,6 +191,44 @@ teardown() {
   assert_success
   run grep -F 'ARG CONFIG_SRC="template/config"' /source/dockerfile/Dockerfile.example
   assert_failure
+}
+
+@test "Dockerfile.example has layered config COPY chain (template#254): template/config first, then config" {
+  # Layered file-level override: layer 1 brings template/config/
+  # defaults, layer 2 overlays <repo>/config/. Files in layer 2
+  # override same-path files from layer 1; files only in layer 1
+  # remain. Order matters -- if layer 2 came first, layer 1 would
+  # overwrite the overrides. Test asserts both lines exist AND the
+  # order is correct.
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  # Both COPY lines exist with --chown / --chmod metadata.
+  run grep -E '^COPY --chown=.* template/config "\$\{CONFIG_DIR\}"$' "${_df}"
+  assert_success
+  run grep -E '^COPY --chown=.* "\$\{CONFIG_SRC\}" "\$\{CONFIG_DIR\}"$' "${_df}"
+  assert_success
+  # Order: template/config COPY line number must be LESS than
+  # config-src COPY line number.
+  local _line1 _line2
+  _line1=$(grep -nE '^COPY --chown=.* template/config "\$\{CONFIG_DIR\}"$' "${_df}" | head -1 | cut -d: -f1)
+  _line2=$(grep -nE '^COPY --chown=.* "\$\{CONFIG_SRC\}" "\$\{CONFIG_DIR\}"$' "${_df}" | head -1 | cut -d: -f1)
+  [[ "${_line1}" -lt "${_line2}" ]] || {
+    echo "expected template/config COPY (line ${_line1}) BEFORE config-src COPY (line ${_line2})"
+    return 1
+  }
+}
+
+@test "Dockerfile.example sets up bashrc.d drop-in directory (template#254)" {
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  # The shell-setup RUN block must mkdir ~/.bashrc.d AND copy
+  # *.sh from CONFIG_DIR/shell/bashrc.d/ into it. The cp -n form
+  # tolerates missing source files (template/config/shell/bashrc.d/
+  # is empty by default; only an explicit .gitkeep ships).
+  run grep -F 'mkdir -p "${HOME}/.bashrc.d"' "${_df}"
+  assert_success
+  run grep -F 'cp -n "${CONFIG_DIR}"/shell/bashrc.d/*.sh "${HOME}/.bashrc.d/"' "${_df}"
+  assert_success
 }
 
 @test "new repo: template/.version exists (no legacy VERSION / .template_version)" {

--- a/test/unit/bashrc_spec.bats
+++ b/test/unit/bashrc_spec.bats
@@ -55,3 +55,34 @@ setup() {
   run grep -q "PS1=" "${RC}"
   assert_success
 }
+
+# ════════════════════════════════════════════════════════════════════
+# bashrc.d drop-in bootstrap loop (template#254 v0.22.0)
+# ════════════════════════════════════════════════════════════════════
+
+@test "bashrc has bashrc.d bootstrap loop sourcing ~/.bashrc.d/*.sh" {
+  # Layered config + drop-in pattern: at interactive shell start,
+  # source any *.sh under ~/.bashrc.d/ so template-side helpers
+  # (from template/config/shell/bashrc.d/) AND downstream-side
+  # helpers (from <repo>/config/shell/bashrc.d/) both get loaded.
+  run grep -qF 'for _bashrc_d_f in "${HOME}/.bashrc.d/"*.sh' "${RC}"
+  assert_success
+  run grep -qF '[[ -r "${_bashrc_d_f}" ]] && source "${_bashrc_d_f}"' "${RC}"
+  assert_success
+}
+
+@test "bashrc.d bootstrap loop guards on directory existing" {
+  # Empty bashrc.d/ (or missing) must not error the bootstrap. The
+  # outer if guards the for loop; the inner [[ -r ]] guards the
+  # source call so a stray broken symlink doesn't tank shell start.
+  run grep -qF 'if [[ -d "${HOME}/.bashrc.d" ]]; then' "${RC}"
+  assert_success
+}
+
+@test "bashrc.d/ directory exists in template/config/shell/" {
+  # Empty placeholder so the dir exists in subtree (git doesn't
+  # track empty dirs). Template-side helpers can drop *.sh here
+  # later without touching Dockerfile.example.
+  assert [ -d "/source/config/shell/bashrc.d" ]
+  assert [ -f "/source/config/shell/bashrc.d/.gitkeep" ]
+}


### PR DESCRIPTION
## Summary

Closes #254. Adds file-level layered override for `config/` at
Dockerfile build time (mirrors `setup.conf`'s section-replace
pattern, just at file granularity), plus the `bashrc.d/` drop-in
directory (folds in #253).

Net effect: downstream repos can override individual files in
`template/config/` by placing a same-path file under
`<repo>/config/`, and template-side improvements to non-overridden
files flow through automatically on every build.

## Mechanism (the core change is two `COPY` lines)

```dockerfile
# Layer 1 (NEW): template/config/ defaults
COPY --chown=...  template/config "${CONFIG_DIR}"
# Layer 2 (existing): <repo>/config/ overrides
COPY --chown=...  "${CONFIG_SRC}"  "${CONFIG_DIR}"
```

Docker COPY of a directory merges with existing dest:

| File location | Result in `${CONFIG_DIR}` |
|---|---|
| Only in `template/config/` | template's version (layer 1 placed it; layer 2 didn't overlay) |
| In both, repo overrides | `<repo>/config/`'s version (layer 2 wins) |
| Only in `<repo>/config/` | repo's version (layer 2 added it) |

No build-context magic, no `setup.sh` pre-merge -- two sequential
`COPY` lines and Docker handles the merge natively.

## Coordinated changes

1. **Layered COPY chain** (Dockerfile.example): the two lines above.
2. **bashrc.d drop-in** (folds in #253):
   - `template/config/shell/bashrc.d/` placeholder + `.gitkeep`
   - `template/config/shell/bashrc` adds bootstrap loop sourcing
     `${HOME}/.bashrc.d/*.sh` at interactive shell start (guarded
     on directory existing + each file readable, so empty
     `bashrc.d/` is a clean no-op).
   - `Dockerfile.example` shell-setup RUN block adds
     `mkdir -p ${HOME}/.bashrc.d` + `cp -n
     ${CONFIG_DIR}/shell/bashrc.d/*.sh ${HOME}/.bashrc.d/` with
     `2>/dev/null || true` for the empty-source case.
3. **init.sh seed change** (soft-breaking): pre-#254 `init.sh`
   seeded `<repo>/config/` as a full copy of `template/config/`;
   post-#254 it creates an empty `<repo>/config/.gitkeep`. The
   layered COPY does the merge at build time.

## Backward compatibility

- Existing repos with a pre-#254 full-copy `<repo>/config/` keep
  working unchanged -- their copy still overlays every template
  default at build time, identical to pre-#254 behaviour. They
  can manually trim files matching template default to start
  receiving template-side improvements automatically.
- **No downstream Dockerfile change required this round.**
  `make -f Makefile.ci upgrade VERSION=v0.22.0` is enough for
  every existing downstream repo; no rollout wave like v0.21.x's
  stage rename.

## Test plan

- [x] `make -f Makefile.ci test`: **1050 / 1050 green** locally
      (was 1045; +3 bashrc_spec, +2 init_new_repo_spec).
- [x] ShellCheck clean.
- [x] Existing tests pass:
  - `init_new_repo_spec.bats` preserve-existing-config + stale-symlink
    paths unchanged (back-compat regression coverage).
  - `init_spec.bats` synthesizes a fake `template/config/` so
    init.sh's _populate_config logic is still exercised at unit
    level.
- [ ] CI green on this PR.
- [ ] After merge: tag `v0.22.0-rc1` and verify Self Test +
      release-test-tools workflows run cleanly.
- [ ] After tag CI green: `/batch-template-upgrade v0.22.0` fanout
      across 13 active downstream repos. **No Dockerfile change
      needed in any downstream**, so this is a regular
      subtree-pull fanout (not the atomic rename wave that v0.21.x
      required).

## Out of scope (deferred to v0.23.0)

`#254`'s body proposed three coordinated changes; one is deferred:

- **Relocating `template/config/pip/setup.sh` out of `config/`**
  to `template/dockerfile/setup/pip.sh` (or similar). `pip/` is
  build-time install scaffolding mis-categorised as user-facing
  config. The relocation requires updating every downstream
  Dockerfile's `RUN ${CONFIG_DIR}/pip/setup.sh` invocation path --
  another atomic-rename rollout wave like v0.21.x's stage rename.
  Deferring to v0.23.0 keeps v0.22.0 purely additive; a follow-up
  issue will track the pip relocation separately.

This decision was a scoping call to keep v0.22.0 small and
backward-compatible. The layered COPY mechanism + bashrc.d
drop-in (this PR) is genuinely additive; the pip relocation is
genuinely breaking. Bundling them risks a v0.21.0-style PoC ->
fix-bug -> patch -> rollout cycle for what's otherwise a clean
v0.22.0 release.

## Related

- Closes #254 (this is the design + implementation).
- Supersedes #253 (`bashrc.d` drop-in) -- folded in here.
- Related to #249 (broader behavioural integration coverage
  gap) -- the static grep tests here are a foundation; the
  comprehensive matrix coverage in #249 is independent work.
- Future: a follow-up issue will track the deferred pip
  relocation (v0.23.0 territory).
