### PR TITLE
fix(Dockerfile.example): bash -c instead of sh -c for runtime-test (refs #249, #57)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`Dockerfile.example` runtime-test stage `RUN sh -c` blocks bash-source overrides** (template#249 follow-up, surfaced during ycpss91255-docker/docker_harness#57 rollout). `sh` on Debian/Ubuntu is `dash`, which has neither `source` nor bash parameter expansion. Any `RUNTIME_SMOKE_CMD` override that did `source /opt/<framework>/setup.bash && <cmd>` failed with `sh: source: not found`; replacing `source` with POSIX `.` then failed with `Bad substitution` because `setup.bash` itself uses bash-only syntax. The only workable shape was a nested `bash -c '...'` wrapper inside the build-arg value, which is an ugly downstream UX.
+
+  Fix: change `RUN sh -c "${RUNTIME_SMOKE_CMD}"` to `RUN bash -c "${RUNTIME_SMOKE_CMD}"`. Bash is present in every Ubuntu/Debian-based runtime image the template targets (osrf/ros, ros, plain ubuntu/debian), so the dependency is safe. Downstream `RUNTIME_SMOKE_CMD` overrides can now use natural shell semantics including `source <bash-script>`, parameter expansion, and `${var:-default}` without nested wrapping.
+
+  Three unit-test invariants in `test/unit/template_spec.bats` (137 -> 138):
+  - Positive: runtime-test RUN line uses `bash -c` (regression guard for both #243 word-split bug and #57 dash-source bug).
+  - Negative: no bare `RUN ${RUNTIME_SMOKE_CMD}` (regression guard for #243).
+  - Negative (NEW): no stale `sh -c` wrapper (regression guard for this fix).
+
+  Total self-tests 1070 -> 1071 (+1 template_spec). Unit 1014 -> 1015.
+
 ## [v0.23.0] - 2026-05-08
 
 Promoted from `v0.23.0-rc1` (#258). RC tag CI green (Self Test +

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,13 +1,13 @@
 # TEST.md
 
-Template self-tests: **1070 tests** total (1014 unit + 56 integration).
+Template self-tests: **1071 tests** total (1015 unit + 56 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
 > `test/smoke/` are a separate suite that runs at Dockerfile `test`-stage
 > build time (via `./build.sh test`) inside both this repo and every
 > downstream repo, and are documented in [Smoke Tests](#smoke-tests)
-> below. They are **not** included in the 1070 figure because they are
+> below. They are **not** included in the 1071 figure because they are
 > build-time assertions, not self-tests.
 
 ## Test Files
@@ -289,7 +289,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `environment env_N supports multiple cross-references in one value (refs #236)` | multi-ref |
 | `environment env_N transitive cross-reference resolves through chain (refs #236)` | transitive |
 
-### test/unit/template_spec.bats (137)
+### test/unit/template_spec.bats (138)
 
 | Test | Description |
 |------|-------------|

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -246,11 +246,19 @@ RUN bats /smoke_test/
 # package manager queries (`ros2 pkg list | grep ...`, `rospack
 # find ...`) over invoking the GUI binary itself.
 #
-# `sh -c` wrapper required: `RUN ${ARG}` does word-splitting on the
+# `bash -c` wrapper required: `RUN ${ARG}` does word-splitting on the
 # substituted value and treats shell operators (&&, ||, etc.) as
 # literal arguments to the first word. Wrapping with
-# `sh -c "${RUNTIME_SMOKE_CMD}"` passes the value as a single string
-# for sh to parse, preserving operators and nested quotes.
+# `bash -c "${RUNTIME_SMOKE_CMD}"` passes the value as a single string
+# for bash to parse, preserving operators, nested quotes, AND bash-only
+# constructs commonly used in install-checks: `source <bash-script>`
+# (and `. <bash-script>` against bash-syntax files like
+# `/opt/ros/$DISTRO/setup.bash`), `${var:-default}` style parameter
+# expansion, etc. An earlier `sh -c` wrapper (v0.21.1 through v0.23.0)
+# broke any override that sourced bash-syntax files because /bin/sh on
+# Debian/Ubuntu is dash, which has neither `source` nor bash parameter
+# expansion. bash is present in every Ubuntu/Debian-based runtime image
+# the template targets, so the bash dependency is safe.
 #
 # Only enable when the runtime stage above is also enabled. The
 # `if: build_runtime` gate in build-worker.yaml mirrors this -- if
@@ -263,4 +271,4 @@ RUN bats /smoke_test/
 # ARG RUNTIME_SMOKE_CMD='whoami && bash --version'
 # # Inherit USER from runtime (non-root). install-check doesn't need
 # # privilege; if downstream override needs root, prefix with sudo.
-# RUN sh -c "${RUNTIME_SMOKE_CMD}"
+# RUN bash -c "${RUNTIME_SMOKE_CMD}"

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -988,7 +988,8 @@ EOF
 }
 
 # ════════════════════════════════════════════════════════════════════
-# Dockerfile.example: runtime-test stage syntax (#243 / v0.21.1 fix)
+# Dockerfile.example: runtime-test stage syntax (#243 / v0.21.1 fix /
+# v0.23.1 follow-up)
 #
 # v0.21.0 shipped the runtime-test block with `RUN ${RUNTIME_SMOKE_CMD}`
 # and `USER root`. Both were buggy:
@@ -1006,24 +1007,49 @@ EOF
 #
 # v0.21.1 fix: drop USER root (inherit non-root from runtime), and
 # wrap the ARG in `sh -c "..."` so the value is passed as a single
-# string for sh to parse. The grep tests below lock both invariants
-# so the bug can't regress.
+# string for the shell to parse.
+#
+# v0.23.1 follow-up: `sh -c` (dash) doesn't support `source` or
+# bash parameter expansion, blocking any override that sourced
+# bash-syntax files (e.g. `. /opt/ros/$DISTRO/setup.bash`). Switched
+# to `bash -c` -- bash is present in every Ubuntu/Debian runtime
+# image the template targets, the dependency is safe, and downstream
+# overrides can now use natural shell semantics. Discovered during
+# the v0.21.1 runtime-test framework's downstream rollout
+# (ycpss91255-docker/docker_harness#57); see also
+# ycpss91255-docker/template#249.
+#
+# The grep tests below lock all three invariants (positive: bash -c
+# wrapper present; negative: no bare ARG substitution; negative:
+# no stale sh -c wrapper) so the bug can't regress.
 # ════════════════════════════════════════════════════════════════════
 
-@test "Dockerfile.example runtime-test uses sh -c wrapper (regression: v0.21.0 ARG word-split bug)" {
+@test "Dockerfile.example runtime-test uses bash -c wrapper (regression: #243 word-split + #57 dash-source bugs)" {
   local _df="/source/dockerfile/Dockerfile.example"
   [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
   # The runtime-test block is commented out (opt-in for repos with a
-  # runtime stage). The RUN line in the comment must use sh -c.
-  run grep -E '^# RUN sh -c "\$\{RUNTIME_SMOKE_CMD\}"$' "${_df}"
+  # runtime stage). The RUN line in the comment must use bash -c so
+  # downstream RUNTIME_SMOKE_CMD overrides can use bash semantics
+  # (source / . of bash-syntax files, parameter expansion, etc.).
+  run grep -E '^# RUN bash -c "\$\{RUNTIME_SMOKE_CMD\}"$' "${_df}"
   assert_success
 }
 
-@test "Dockerfile.example runtime-test does NOT use bare RUN \${RUNTIME_SMOKE_CMD} (v0.21.0 bug regression guard)" {
+@test "Dockerfile.example runtime-test does NOT use bare RUN \${RUNTIME_SMOKE_CMD} (v0.21.0 word-split regression guard)" {
   local _df="/source/dockerfile/Dockerfile.example"
   [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
   # Regression guard: bare form word-splits operators / nested quotes.
   run grep -E '^# RUN \$\{RUNTIME_SMOKE_CMD\}$' "${_df}"
+  [ "${status}" -ne 0 ] || [ -z "${output}" ]
+}
+
+@test "Dockerfile.example runtime-test does NOT use sh -c wrapper (v0.21.1 -> v0.23.1 dash-source regression guard)" {
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  # Regression guard: sh -c (dash) cannot parse bash-syntax files in
+  # `source` / `.` overrides. Blocks all ROS-style smoke commands.
+  # See ycpss91255-docker/docker_harness#57 + #249 for context.
+  run grep -E '^# RUN sh -c "\$\{RUNTIME_SMOKE_CMD\}"$' "${_df}"
   [ "${status}" -ne 0 ] || [ -z "${output}" ]
 }
 


### PR DESCRIPTION
## Summary

Fix `Dockerfile.example`'s runtime-test stage RUN line from `sh -c "${RUNTIME_SMOKE_CMD}"` to `bash -c "${RUNTIME_SMOKE_CMD}"`. Follow-up to template#249 and docker_harness#57.

## Problem

The v0.21.1 fix (#250) wrapped `${RUNTIME_SMOKE_CMD}` in `sh -c "..."` to stop Docker ARG word-splitting from corrupting shell operators. That fix worked for the default `whoami && bash --version` smoke but blocked every realistic downstream override:

- `sh` on Debian/Ubuntu is `dash`. `dash` has neither `source` nor bash parameter expansion.
- ROS install-check overrides typically need `source /opt/ros/${ROS_DISTRO}/setup.bash && <cmd>` to get the env. With `sh -c`, this fails with `sh: source: not found`.
- Replacing `source` with POSIX `.` then fails with `Bad substitution` because `setup.bash` itself contains bash-only syntax (`${var:offset:length}`, `local`, etc.) that dash can't parse.
- Downstream's only workable shape was to nest a `bash -c '...'` inside the build-arg value -- ugly and surprising UX (see ycpss91255-docker/docker_harness#57's 8 PR fixup waves).

## Fix

```dockerfile
# Dockerfile.example runtime-test (excerpt, commented-out template block)
- # RUN sh -c "${RUNTIME_SMOKE_CMD}"
+ # RUN bash -c "${RUNTIME_SMOKE_CMD}"
```

Bash is present in every Ubuntu/Debian-based runtime image the template targets (`osrf/ros:*`, `ros:*`, plain `ubuntu`, plain `debian`). The dependency is genuinely safe; the dash dependency was an accident of `sh` defaulting to dash on those distros.

Downstream `RUNTIME_SMOKE_CMD` overrides can now use natural shell semantics:

```yaml
# main.yaml -- after this fix, downstream can write naturally
build_args: |
  RUNTIME_SMOKE_CMD=source /opt/ros/${ROS_DISTRO}/setup.bash && rosversion -d
```

instead of the nested wrapper that was the only thing that worked before:

```yaml
# Before this fix -- ugly wrapper
build_args: |
  RUNTIME_SMOKE_CMD=bash -c 'source /opt/ros/${ROS_DISTRO}/setup.bash && rosversion -d'
```

## Tests

Three unit-test invariants in `test/unit/template_spec.bats` (137 -> 138, total 1070 -> 1071):

- **Positive (updated)**: runtime-test RUN line uses `bash -c "${RUNTIME_SMOKE_CMD}"` -- regression guard for both #243 word-split bug and #57 dash-source bug.
- **Negative (kept)**: no bare `RUN ${RUNTIME_SMOKE_CMD}` -- #243 word-split regression guard.
- **Negative (NEW)**: no stale `sh -c` wrapper -- regression guard for this fix.

Comment block above the tests rewritten to capture all three contexts.

## Test plan

- [x] `make -f Makefile.ci test`: 1071 / 1071 green locally (was 1070; +1 template_spec).
- [x] CHANGELOG `[Unreleased]` `### Fixed` entry.
- [x] TEST.md count synced (1070 -> 1071; unit 1014 -> 1015; template_spec.bats 137 -> 138).
- [ ] CI green on this PR.
- [ ] After merge: release as v0.23.1 patch (no RC required for fix-class change per CLAUDE.md `MAJOR.MINOR.PATCH` rule).
- [ ] After release: docker_harness#57's 8 open PRs can drop the `bash -c '...'` wrapper from their `RUNTIME_SMOKE_CMD` values; that cleanup is a separate follow-up wave.

## Related

- ycpss91255-docker/template#249 (the broader behavioural integration coverage gap that allowed this class of bug to ship — see comment at #249 with the dash-source evidence trail).
- ycpss91255-docker/docker_harness#57 (the 8-repo runtime-test rollout that surfaced this bug end-to-end).
- ycpss91255-docker/template#243 / #250 (the v0.21.0-rc2 / v0.21.1 runtime-test framework + word-split fix this PR refines).
