### PR TITLE
docs(setup.conf): rewrite header + trim per-section inline docs (closes #231)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`setup.conf` header rewritten + per-section inline docs trimmed** (#231). New top header explains the derived-file relationship (`.env` / `compose.yaml` are regenerated; never hand-edit them), the recommended edit flow (`./setup_tui.sh` interactive; manual edit supported), and the section-replace override semantics. The deep per-key documentation that previously sat inline (one paragraph per rule type, per GPU mode, per IPC value, etc.) is removed — the TUI shows it interactively, README has the full reference, and the per-repo `<repo>/setup.conf` copy is now leaner (376 -> 121 lines, ~68% reduction). Existing per-section structure / keys / defaults are unchanged; this is doc-only. No user action needed on upgrade.
+
 ## [v0.23.1] - 2026-05-11
 
 Patch release fixing `Dockerfile.example`'s runtime-test stage shell wrapper. No RC: bug-fix-class change per `MAJOR.MINOR.PATCH` policy.

--- a/setup.conf
+++ b/setup.conf
@@ -1,94 +1,52 @@
-# setup.conf - runtime configuration consumed by setup.sh.
+# ═════════════════════════════════════════════════════════════════════
+# setup.conf — source of truth for runtime configuration.
+# ═════════════════════════════════════════════════════════════════════
 #
-# setup.sh reads this file + system detection → generates .env + compose.yaml.
-# Template default lives at <template>/setup.conf; per-repo override at
-# <repo>/setup.conf. Section-level replace strategy: a section present in the
-# per-repo file fully replaces the template's section. Sections the per-repo
-# file omits fall back to the template default.
+# setup.sh reads this file + system detection → generates .env and
+# compose.yaml. Those two files are DERIVED ARTIFACTS — never edit
+# them directly. Any manual change to .env / compose.yaml is silently
+# overwritten on the next ./build.sh / ./run.sh that omits --no-env.
+# Edit this file instead, then re-run a build / run wrapper (or
+# explicitly ./run.sh --setup) to regenerate the artifacts.
 #
-# Lines starting with # and empty lines are ignored. key = value format;
-# whitespace around keys and values is trimmed.
+# How to edit:
+#
+#   1. (Recommended) ./setup_tui.sh — interactive TUI editor. Walks
+#      each section, validates input against the same rules setup.sh
+#      uses, and rewrites in place preserving section structure. The
+#      TUI shows per-key documentation so this file can stay terse.
+#
+#   2. Manual edit — supported. Keep the section structure intact;
+#      ad-hoc keys outside the documented sections are silently
+#      dropped (no warning). After a manual edit, re-run any wrapper
+#      (or ./run.sh --setup) to regenerate .env / compose.yaml.
+#
+# Override layering:
+#
+#   - Template default lives at <template>/setup.conf.
+#   - Per-repo override lives at <repo>/setup.conf (created
+#     automatically on first init).
+#   - Section-level replace: a section present in <repo>/setup.conf
+#     fully replaces the template's section. Sections the per-repo
+#     file omits fall back to the template default — there is no
+#     key-level merge inside a section.
+#
+# Syntax: lines starting with # and empty lines are ignored.
+# Format is key = value (whitespace around keys / values is trimmed).
+# Full per-key reference: README "Configuration" section, or run
+# `./setup_tui.sh <section>` for interactive help.
 
 # ═════════════════════════════════════════════════════════════════════
-# [image] — IMAGE_NAME detection rules
+# [image] — IMAGE_NAME detection rules (tried in numeric order)
 # ═════════════════════════════════════════════════════════════════════
-#
-# Each rule_N below is tried in numeric order; first match wins. Keys
-# are sorted by numeric suffix (rule_2 before rule_10). Clear a rule
-# to skip it; the list is user-editable via ./setup_tui.sh image.
-#
-# Accepted rule types:
-#
-#   string:<value>  Use <value> as the image name verbatim; no path
-#                    inspection. Useful when the dir naming doesn't map
-#                    cleanly (e.g. "string:my_app"). Put it at rule_1
-#                    to short-circuit detection for this repo.
-#
-#   prefix:<value>   Match dirname starting with <value>, strip it.
-#                    e.g. "prefix:docker_" on "docker_ros_noetic" → "ros_noetic"
-#
-#   suffix:<value>   Scan path components for any ending with <value>, strip it.
-#                    e.g. "suffix:_ws" on "/home/ros_noetic_ws/src" → "ros_noetic"
-#
-#   @basename        Use the dirname as-is (last-resort fallback; disabled
-#                    by default to avoid leaking repo paths into image tags).
-#
-#   @default:<value> Use <value> as final fallback when no other rule matches.
-#                    Prints an INFO log so users know to set it explicitly.
 [image]
 rule_1 = prefix:docker_
 rule_2 = suffix:_ws
 rule_3 = @basename
 
 # ═════════════════════════════════════════════════════════════════════
-# [build] — Dockerfile build args
+# [build] — Dockerfile build args + arch + build network
 # ═════════════════════════════════════════════════════════════════════
-#
-# Each `arg_N = KEY=VALUE` entry flows into compose.yaml's build.args
-# as a Docker ARG override. Empty VALUE = "don't override" — the
-# Dockerfile's own `ARG KEY="default"` kicks in (e.g. archive.ubuntu.com
-# for APT, Asia/Taipei for TZ). Add as many args as your Dockerfile
-# declares; ordering is numeric by the arg_ suffix.
-#
-# Three well-known defaults are seeded below (empty, so Dockerfile
-# defaults stay in effect). Fill in to override per repo. Examples
-# with Taiwan mirrors:
-#   arg_1 = APT_MIRROR_UBUNTU=tw.archive.ubuntu.com
-#   arg_2 = APT_MIRROR_DEBIAN=mirror.twds.com.tw
-#   arg_3 = TZ=Asia/Tokyo
-#
-# User-added args:
-#   arg_4 = PYTHON_VERSION=3.12      # matches `ARG PYTHON_VERSION` in Dockerfile
-#   arg_5 = BUILDKIT_INLINE_CACHE=1  # passthrough
-#
-# KEY must match `^[A-Z_][A-Z0-9_]*$` convention (validated via
-# _validate_env_kv). Clear a slot (empty value) to skip it.
-#
-# target_arch: explicit override for Docker's TARGETARCH build arg.
-#   <empty>         → BuildKit auto-fills from host/--platform (default)
-#   amd64 / arm64   → force this value for all build targets (main +
-#                     test-tools). Useful for cross-builds or pinning.
-# When empty, no --build-arg is passed and no TARGETARCH line appears
-# in compose.yaml's build.args, so BuildKit's auto-detection stays
-# intact. Validated via the TUI as `amd64|arm64|<empty>`.
-#
-# network: Docker build-time network mode. Only the user's own
-# Dockerfile RUN stages (apk/apt/curl/git clone) care — runtime is
-# controlled separately via [network] mode.
-#   auto            → auto-detect Jetson (/etc/nv_tegra_release) and
-#                     emit host-net only there; desktop hosts stay on
-#                     Docker's default bridge. Default.
-#   host            → force host-net for all hosts. Necessary when
-#                     Docker's default bridge NAT is unusable:
-#                     stripped embedded kernels (Jetson L4T missing
-#                     iptable_raw), firewall-locked CI runners, hosts
-#                     with `iptables: false` in daemon.json.
-#   bridge|none|default → explicit Docker-known network modes.
-#   off             → never emit (explicitly opt out of auto).
-# When non-empty (after resolve), setup.sh writes BUILD_NETWORK to
-# .env and emits `build.network: <value>` under each service in
-# compose.yaml; build.sh forwards `--network <value>` to the
-# auxiliary `docker build` call for test-tools.
 [build]
 target_arch =
 network = auto
@@ -99,38 +57,6 @@ arg_3 = TZ=Asia/Taipei
 # ═════════════════════════════════════════════════════════════════════
 # [deploy] — GPU reservation (compose.yaml deploy.resources)
 # ═════════════════════════════════════════════════════════════════════
-#
-# Controls whether the generated compose.yaml includes the
-# deploy.resources.reservations.devices block for NVIDIA GPU.
-#
-# gpu_mode          Behaviour for GPU block inclusion:
-#                     auto    Detect nvidia-container-toolkit via dpkg-query.
-#                             Enable GPU block if toolkit installed, else omit.
-#                     force   Always include GPU block (fail-fast on non-GPU hosts).
-#                     off     Never include GPU block.
-#
-# gpu_count         Number of GPUs to reserve. Applied only when block enabled.
-#                     all         Reserve all available GPUs (default).
-#                     <integer>   Reserve exactly N GPUs (e.g. 1, 2).
-#
-# gpu_capabilities  Space-separated GPU capabilities to request:
-#                     gpu         Basic (default, most cases).
-#                     compute     CUDA compute.
-#                     utility     nvidia-smi etc.
-#                     graphics    OpenGL/Vulkan rendering.
-#                   Combine by space: "compute utility graphics"
-#
-# runtime           Docker runtime override (emitted as `runtime:` at
-#                   service level in compose.yaml). Needed on Jetson
-#                   (JetPack) because its nvidia-container-toolkit runs
-#                   in csv mode and refuses the modern `--gpus` flow
-#                   that deploy.resources.reservations.devices uses.
-#                     auto     Emit runtime: nvidia on Jetson
-#                              (detected via /etc/nv_tegra_release),
-#                              omit on desktop (default).
-#                     nvidia   Force emit runtime: nvidia on all hosts
-#                              (e.g. csv-mode toolkit on x86).
-#                     off      Never emit (Docker default runc).
 [deploy]
 gpu_mode = auto
 gpu_count = all
@@ -140,83 +66,20 @@ runtime = auto
 # ═════════════════════════════════════════════════════════════════════
 # [gui] — GUI display support
 # ═════════════════════════════════════════════════════════════════════
-#
-# Controls whether the generated compose.yaml includes GUI-related
-# environment variables (DISPLAY, WAYLAND_DISPLAY, XDG_RUNTIME_DIR,
-# XAUTHORITY) and X11 volume mounts (/tmp/.X11-unix, XAUTHORITY,
-# XDG_RUNTIME_DIR).
-#
-# mode   Behaviour for GUI block inclusion:
-#          auto    Detect host GUI by checking $DISPLAY and $WAYLAND_DISPLAY.
-#                  Include block if either is set, else omit.
-#          force   Always include GUI block (assumes host has X11/Wayland).
-#          off     Never include GUI block (headless containers, CI, servers).
 [gui]
 mode = auto
 
 # ═════════════════════════════════════════════════════════════════════
-# [network] — network, IPC, privileged
+# [network] — network mode, IPC, port mappings
 # ═════════════════════════════════════════════════════════════════════
-#
-# Values baked into compose.yaml via .env (NETWORK_MODE, IPC_MODE, PRIVILEGED).
-# Use env var override at runtime to change without re-running setup.sh
-# (e.g. `NETWORK_MODE=bridge ./run.sh`).
-#
-# mode        Container network mode:
-#               host     Share host network stack (typical for dev envs
-#                        that need direct host-network access).
-#               bridge   Isolated bridge (Docker default).
-#               none     No networking.
-#
-# ipc         Container IPC namespace:
-#               host        Share host IPC (shared memory with host apps).
-#               shareable   Own IPC, accessible to other containers.
-#               private     Own IPC, isolated (Docker default).
-#
-# network_name  Name of a user-defined bridge to attach to.
-#               Only meaningful when mode = bridge.
-#               Empty → use compose-default bridge.
-#               Non-empty → reference an EXTERNAL network by that name;
-#                           create it first with `docker network create <name>`.
-#
-# port_1..port_N  Host→container port mappings. Only emitted when
-#                 mode=bridge (ignored under mode=host since the container
-#                 already shares the host network stack).
-#                 Format: <host_port>:<container_port>[/protocol]
-#                 Examples:
-#                   port_1 = 8080:80
-#                   port_2 = 5000:5000
-#                   port_3 = 9100:9100/udp
 [network]
 mode = host
 ipc = host
 network_name =
 
 # ═════════════════════════════════════════════════════════════════════
-# [security] — container privilege / isolation controls
+# [security] — container privilege / capabilities / security_opt
 # ═════════════════════════════════════════════════════════════════════
-#
-# privileged            Run container with full host privileges:
-#                         true   Required for raw /dev access, kernel
-#                                features. Common for hardware-probing
-#                                workloads.
-#                         false  Unprivileged; use [devices] + explicit
-#                                cap_add / security_opt for finer access.
-#
-# cap_add_1..cap_add_N   Linux capabilities to ADD to the container.
-#                        Empty list = don't emit cap_add block in compose.
-#                        Examples: SYS_ADMIN, NET_ADMIN, MKNOD, SYS_PTRACE
-#
-# cap_drop_1..cap_drop_N Linux capabilities to DROP.
-#                        Rarely needed when privileged=true.
-#                        Example: cap_drop_1 = ALL
-#
-# security_opt_1..N      security_opt entries (seccomp, AppArmor, etc.).
-#                        Empty list = don't emit security_opt block.
-#                        Examples:
-#                          security_opt_1 = seccomp:unconfined
-#                          security_opt_2 = apparmor:unconfined
-#                          security_opt_3 = label=disable      # SELinux
 [security]
 privileged = true
 cap_add_1 = SYS_ADMIN
@@ -225,152 +88,34 @@ cap_add_3 = MKNOD
 security_opt_1 = seccomp:unconfined
 
 # ═════════════════════════════════════════════════════════════════════
-# [resources] — container resource limits
+# [resources] — container resource limits (shm_size, etc.)
 # ═════════════════════════════════════════════════════════════════════
-#
-# shm_size  Size of /dev/shm (shared memory FS) inside the container.
-#           ONLY takes effect when [network] ipc is NOT `host` — with
-#           ipc=host the container uses the host's /dev/shm (typically
-#           half of host RAM) and this setting is ignored by Docker.
-#           Switch ipc to `private` or `shareable` first if you need it.
-#           Default (Docker): 64mb.
-#           Examples:
-#             shm_size = 2gb      # multi-process workloads needing shared memory
-#             shm_size = 512mb
 [resources]
 shm_size =
 
 # ═════════════════════════════════════════════════════════════════════
-# [environment] — runtime environment variables
+# [environment] — runtime env vars (env_N = KEY=VALUE)
 # ═════════════════════════════════════════════════════════════════════
-#
-# env_1..env_N  KEY=VALUE pairs injected into the container at runtime.
-#               Use for per-user / per-machine values that should NOT be
-#               baked into the image (credentials hints, feature flags,
-#               build target selectors, ...). Static values belong in the
-#               Dockerfile.
-#               Examples:
-#                 env_1 = LOG_LEVEL=debug
-#                 env_2 = BUILD_TARGET=production
-#                 env_3 = FEATURE_FLAG_X=1
 [environment]
 
 # ═════════════════════════════════════════════════════════════════════
-# [tmpfs] — RAM-backed (memory) mount points
+# [tmpfs] — RAM-backed mount points (tmpfs_N = /path[:size=N])
 # ═════════════════════════════════════════════════════════════════════
-#
-# tmpfs_1..tmpfs_N  Paths inside the container backed by RAM instead of
-#                   disk. Content is lost when the container stops. Useful
-#                   for heavy-write scratch areas (build caches, package
-#                   caches, IPC sockets). Optional size= suffix caps the
-#                   mount.
-#                   Examples:
-#                     tmpfs_1 = /tmp
-#                     tmpfs_2 = /tmp/cache:size=1g
-#                     tmpfs_3 = /var/run:size=64m
 [tmpfs]
 
-
 # ═════════════════════════════════════════════════════════════════════
-# [devices] — host device bindings
+# [devices] — host device bindings + cgroup rules
 # ═════════════════════════════════════════════════════════════════════
-#
-# Populated into compose.yaml's `devices:` field. Unlike
-# `mount_* = /dev/X:/dev/X` under [volumes] (which needs
-# `privileged=true`), `devices:` automatically grants cgroup read/write
-# permissions and works with `privileged=false`.
-#
-# device_1..device_N   Host device binding (one per entry).
-#                      Format: <host>[:<container>[:<cgroup_perms>]]
-#                        cgroup_perms: combination of r (read), w (write),
-#                                      m (mknod). Default: "rwm".
-#                      Default: /dev:/dev — bind the entire /dev tree so
-#                      hardware-probing workloads see all host devices
-#                      out of the box. Narrow it for production (e.g.
-#                      device_1 = /dev/video0:/dev/video0).
-#                      More examples:
-#                        device_1 = /dev/video0
-#                        device_2 = /dev/dri:/dev/dri
-#                        device_3 = /dev/nvidia0:/dev/nvidia0:rwm
-#
-# cgroup_rule_1..cgroup_rule_N   Device cgroup rules (docker compose
-#                                `device_cgroup_rules:`). Use when a
-#                                device node doesn't exist at container
-#                                start but may appear later (USB hotplug,
-#                                dynamic /dev/video*).
-#                                Format: <type> <major>:<minor|*> <perms>
-#                                  type:  c (char), b (block), a (all)
-#                                  perms: any of r / w / m
-#                                Examples:
-#                                  cgroup_rule_1 = c 189:* rwm    # USB bus
-#                                  cgroup_rule_2 = c 81:* rwm     # V4L2
 [devices]
 device_1 = /dev:/dev
 
 # ═════════════════════════════════════════════════════════════════════
-# [volumes] — host volume mounts (workspace + extras)
+# [volumes] — workspace mount + extras (mount_N = host:container[:mode])
 # ═════════════════════════════════════════════════════════════════════
-#
-# mount_1 is the workspace mount. On first setup.sh run the host-side
-# workspace path is detected automatically and written back here; on
-# subsequent runs setup.sh reads the value from this file as the source
-# of truth. Clear it to opt out of mounting a workspace.
-#
-# mount_2..N are extra user-defined mounts (device pass-through, data
-# directories, SSH keys, etc.).
-#
-# Format: <host_path>:<container_path>[:<mode>]
-#   host_path       Absolute or relative host path. Env var expansion
-#                   supported (e.g. ${HOME}/.cache, ${USER_NAME}).
-#   container_path  Absolute path inside container.
-#   mode            Optional. "ro" = read-only, "rw" = read-write (default).
-#
-# GUI baseline mounts (/tmp/.X11-unix, $XAUTHORITY, $XDG_RUNTIME_DIR)
-# are emitted automatically when [gui] is enabled — do not list them here.
-#
-# Ordering: keys are sorted by numeric suffix.
-#
-# Examples:
-#   mount_2 = /dev:/dev                            # full /dev pass-through
-#   mount_2 = /dev/bus/usb:/dev/bus/usb            # selective: only USB devices
-#   mount_3 = /dev/dri:/dev/dri                    # GPU DRI for OpenGL
-#   mount_4 = /data:/data                          # data volume
-#   mount_5 = /etc/machine-id:/etc/machine-id:ro   # dbus integration
-#   mount_6 = ${HOME}/.ssh:/root/.ssh:ro           # host ssh keys (use cautiously)
 [volumes]
 mount_1 =
 
 # ═════════════════════════════════════════════════════════════════════
-# [additional_contexts] — extra named build contexts
+# [additional_contexts] — extra named build contexts (context_N = name=source)
 # ═════════════════════════════════════════════════════════════════════
-#
-# Forwarded to compose's `build.additional_contexts:` block under each
-# service that has its own `build:` (devel / runtime / test). Lets the
-# Dockerfile pull files from outside the main build context (which is
-# the directory holding compose.yaml — typically `docker/` for repos
-# that nest their docker assets) without flipping the main `context:`
-# root and breaking template-managed COPY paths.
-#
-# context_1..context_N   Each entry: <name>=<source>
-#                        <name>     BuildKit named-context handle.
-#                                   Must match `^[A-Za-z0-9][A-Za-z0-9_.-]*$`.
-#                        <source>   Anything BuildKit accepts as a context
-#                                   source: relative path (``..``,
-#                                   ``../third_party``), ``docker-image://...``,
-#                                   ``https://...``, ``oci-layout://...``.
-#                                   Relative paths resolve against the
-#                                   compose.yaml's directory.
-#
-# Inside the Dockerfile, reference a named context with:
-#   COPY --from=<name> <src> <dst>
-# or
-#   FROM <name> AS <stage>
-#
-# Examples:
-#   context_1 = repo=..                           # pull files from repo root
-#   context_2 = vendor=../third_party             # sibling directory
-#   context_3 = base=docker-image://debian:bookworm-slim
-#
-# Empty list (no entries) = no `additional_contexts:` block emitted —
-# zero diff in compose.yaml versus pre-feature behaviour.
 [additional_contexts]


### PR DESCRIPTION
## Summary

Closes #231. Rewrites `setup.conf`'s header block and strips the deep per-key inline documentation, leaving section markers + a single-line description per section.

## Header (NEW)

The new top header explains three things that were previously absent:

1. **Derived-file warning**: `.env` and `compose.yaml` are generated artifacts. Editing them is silently overwritten on the next `./build.sh` / `./run.sh` (unless `--no-env`). Edit `setup.conf`, then re-run.
2. **Edit flow**: `./setup_tui.sh` is the recommended path (validates input, preserves structure, shows per-key docs interactively). Manual edit is supported; ad-hoc keys outside documented sections are silently dropped.
3. **Override layering**: template default vs `<repo>/setup.conf`. Section-level replace (no key-level merge).

## What was trimmed

Per-key inline documentation that explained rule types, GPU modes, IPC values, port mapping format, security options, etc. — every section had 10-50 lines of paragraph-style docs inside the comments. Per the issue's "since it's generated [to every downstream], many comments below can also be directly removed" feedback:

- TUI surfaces the same info interactively via per-section help screens.
- README "Configuration" section has the full reference.
- Per-repo `<repo>/setup.conf` copy is no longer carrying 300+ lines of redundant docs that downstream maintainers have to scroll past.

Each section now keeps:
- The ═════ box marker with section name
- A single-line description of what the section controls
- The actual key=value lines (defaults unchanged)

## Net effect

- 376 lines -> 121 lines (-68%).
- Zero behavioural change: no key renamed, no default changed, no parser rule touched.
- All 1071 existing tests still pass (`make -f Makefile.ci test` locally green).

## Test plan

- [x] `make -f Makefile.ci test`: 1071 / 1071 green locally.
- [x] No existing test asserts on specific comment text in setup.conf (grep checked — fixtures use minimal `[image]\nrules = @basename\n` shapes, not the trimmed comments).
- [x] CHANGELOG `[Unreleased]` `### Changed` entry.
- [ ] CI green on this PR.

## Out of scope

- Moving `setup.conf` into `config/docker/` (proposed in #262). Separate issue; this PR keeps the root location.
- Adding deeper README "Configuration" section (referenced from the new header but no rewrite in this PR — current README has enough; expand later if needed).

## Related

- #231 (this issue).
- #262 (the location move — separate discussion).
