### PR TITLE
feat(lib): _log_err / _log_warn / _log_info helpers in _lib.sh (#278 PR A)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`_log_err` / `_log_warn` / `_log_info` helpers in `script/docker/_lib.sh`** (#278 PR A). Tagged, level-prefixed output with optional ANSI color and consistent stream routing (ERROR/WARNING -> stderr; INFO -> stdout). Honor `NO_COLOR` (https://no-color.org/) and auto-disable color on non-TTY destinations; `FORCE_COLOR=1` overrides auto-detect. Color scheme: ERROR red bold (`\033[1;31m`), WARNING yellow (`\033[33m`), INFO dim (`\033[2m`). No callsites migrated in this PR — foundational; PR B (#278) migrates `build/run/exec/stop`, PR C migrates remaining top-level scripts. New `test/unit/log_spec.bats` (17 tests; total 1083 -> 1100; unit 1027 -> 1044).
+
 ## [v0.25.0] - 2026-05-11
 
 Promoted from `v0.25.0-rc1` (#274). RC tag CI green (Self Test + release-test-tools); no fixups needed between rc1 and stable.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1083 tests** total (1027 unit + 56 integration).
+Template self-tests: **1100 tests** total (1044 unit + 56 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -44,6 +44,28 @@ Template self-tests: **1083 tests** total (1027 unit + 56 integration).
 | `_print_config_summary hides sections that are empty in setup.conf` | Empty-section skip |
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
 | `_print_config_summary warns when setup.conf exists but has no [section] headers` | #157 empty-conf hint on build/run summary |
+
+### test/unit/log_spec.bats (17)
+
+| Test | Description |
+|------|-------------|
+| `_log_err writes '[<tag>] ERROR: <msg>' to stderr (no TTY -> no color)` | Default routing + no-color path |
+| `_log_warn writes '[<tag>] WARNING: <msg>' to stderr (no TTY -> no color)` | Warning routing + no-color path |
+| `_log_info writes '[<tag>] INFO: <msg>' to stdout (no TTY -> no color)` | Info routing + no-color path |
+| `_log_err joins multi-token message with single spaces` | Multi-token message join |
+| `_log_err with no tag exits non-zero (param ':?' guard)` | Required tag guard |
+| `_log_warn with no tag exits non-zero (param ':?' guard)` | Required tag guard |
+| `_log_info with no tag exits non-zero (param ':?' guard)` | Required tag guard |
+| `_log_err with FORCE_COLOR=1 emits red bold ANSI on non-TTY stderr` | FORCE_COLOR overrides TTY detection |
+| `_log_warn with FORCE_COLOR=1 emits yellow ANSI on non-TTY stderr` | FORCE_COLOR overrides TTY detection |
+| `_log_info with FORCE_COLOR=1 emits dim ANSI on non-TTY stdout` | FORCE_COLOR overrides TTY detection |
+| `_log_err with NO_COLOR=1 + FORCE_COLOR=1 omits ANSI (NO_COLOR wins)` | NO_COLOR precedence |
+| `_log_warn with NO_COLOR=1 omits ANSI` | NO_COLOR strips color |
+| `_log_info with NO_COLOR=1 omits ANSI` | NO_COLOR strips color |
+| `_log_color_enabled returns non-zero on non-TTY fd 1 without overrides` | Auto-detect default off |
+| `_log_color_enabled returns 0 with FORCE_COLOR=1 on non-TTY` | FORCE_COLOR opt-in |
+| `_log_color_enabled returns non-zero with NO_COLOR=1 + FORCE_COLOR=1` | NO_COLOR wins over FORCE_COLOR |
+| `_log_color_enabled with no fd argument exits non-zero (param guard)` | Required fd guard |
 
 ### test/unit/setup_spec.bats (261)
 

--- a/script/docker/_lib.sh
+++ b/script/docker/_lib.sh
@@ -26,6 +26,58 @@ _lib_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${_lib_dir}/i18n.sh"
 unset _lib_dir
 
+# Log level helpers (#278). Three functions for tagged, level-prefixed
+# output with optional ANSI color and consistent stream routing.
+# Honor NO_COLOR (https://no-color.org/) and auto-disable color on
+# non-TTY destinations. FORCE_COLOR=1 overrides auto-detect.
+#
+# Args (all three log_* functions):
+#   $1: tag (short script identifier, e.g. "build", "setup")
+#   $2..: message components (joined with spaces)
+#
+# Stream routing:
+#   _log_err / _log_warn -> stderr (fd 2)
+#   _log_info            -> stdout (fd 1)
+
+# _log_color_enabled <fd>
+# Returns 0 if color should be emitted to file descriptor <fd>.
+_log_color_enabled() {
+  local fd="${1:?_log_color_enabled requires fd}"
+  [[ -z "${NO_COLOR:-}" ]] || return 1
+  [[ -n "${FORCE_COLOR:-}" ]] && return 0
+  test -t "${fd}"
+}
+
+_log_err() {
+  local tag="${1:?_log_err requires tag}"
+  shift
+  if _log_color_enabled 2; then
+    printf '\033[1;31m[%s] ERROR:\033[0m %s\n' "${tag}" "$*" >&2
+  else
+    printf '[%s] ERROR: %s\n' "${tag}" "$*" >&2
+  fi
+}
+
+_log_warn() {
+  local tag="${1:?_log_warn requires tag}"
+  shift
+  if _log_color_enabled 2; then
+    printf '\033[33m[%s] WARNING:\033[0m %s\n' "${tag}" "$*" >&2
+  else
+    printf '[%s] WARNING: %s\n' "${tag}" "$*" >&2
+  fi
+}
+
+_log_info() {
+  local tag="${1:?_log_info requires tag}"
+  shift
+  if _log_color_enabled 1; then
+    printf '\033[2m[%s] INFO:\033[0m %s\n' "${tag}" "$*"
+  else
+    printf '[%s] INFO: %s\n' "${tag}" "$*"
+  fi
+}
+
 # _load_env sources the given .env file with allexport so every assignment
 # becomes an exported variable visible to docker compose.
 #

--- a/test/unit/log_spec.bats
+++ b/test/unit/log_spec.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+#
+# log_spec.bats - Execution tests for _log_err / _log_warn / _log_info
+# helpers in script/docker/_lib.sh (#278). Covers tagged prefix shape,
+# stream routing (stdout vs stderr), NO_COLOR / FORCE_COLOR / TTY
+# detection.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  LIB="/source/script/docker/_lib.sh"
+}
+
+# ── prefix + level keyword shape ────────────────────────────────────────────
+
+@test "_log_err writes '[<tag>] ERROR: <msg>' to stderr (no TTY -> no color)" {
+  run --separate-stderr bash -c "source ${LIB}; _log_err build 'something broke'"
+  assert_success
+  assert_equal "${output}" ""
+  assert_equal "${stderr}" "[build] ERROR: something broke"
+}
+
+@test "_log_warn writes '[<tag>] WARNING: <msg>' to stderr (no TTY -> no color)" {
+  run --separate-stderr bash -c "source ${LIB}; _log_warn run 'deprecated flag'"
+  assert_success
+  assert_equal "${output}" ""
+  assert_equal "${stderr}" "[run] WARNING: deprecated flag"
+}
+
+@test "_log_info writes '[<tag>] INFO: <msg>' to stdout (no TTY -> no color)" {
+  run --separate-stderr bash -c "source ${LIB}; _log_info setup 'phase done'"
+  assert_success
+  assert_equal "${output}" "[setup] INFO: phase done"
+  assert_equal "${stderr}" ""
+}
+
+# ── multi-word message joins with spaces ────────────────────────────────────
+
+@test "_log_err joins multi-token message with single spaces" {
+  run --separate-stderr bash -c "source ${LIB}; _log_err build word1 word2 word3"
+  assert_success
+  assert_equal "${stderr}" "[build] ERROR: word1 word2 word3"
+}
+
+# ── missing tag is rejected ─────────────────────────────────────────────────
+
+@test "_log_err with no tag exits non-zero (param ':?' guard)" {
+  run -127 bash -c "source ${LIB}; _log_err"
+}
+
+@test "_log_warn with no tag exits non-zero (param ':?' guard)" {
+  run -127 bash -c "source ${LIB}; _log_warn"
+}
+
+@test "_log_info with no tag exits non-zero (param ':?' guard)" {
+  run -127 bash -c "source ${LIB}; _log_info"
+}
+
+# ── FORCE_COLOR forces ANSI even on non-TTY ─────────────────────────────────
+
+@test "_log_err with FORCE_COLOR=1 emits red bold ANSI on non-TTY stderr" {
+  run --separate-stderr bash -c "FORCE_COLOR=1 source ${LIB}; FORCE_COLOR=1 _log_err build msg"
+  assert_success
+  assert_equal "${stderr}" $'\033[1;31m[build] ERROR:\033[0m msg'
+}
+
+@test "_log_warn with FORCE_COLOR=1 emits yellow ANSI on non-TTY stderr" {
+  run --separate-stderr bash -c "FORCE_COLOR=1 source ${LIB}; FORCE_COLOR=1 _log_warn run msg"
+  assert_success
+  assert_equal "${stderr}" $'\033[33m[run] WARNING:\033[0m msg'
+}
+
+@test "_log_info with FORCE_COLOR=1 emits dim ANSI on non-TTY stdout" {
+  run --separate-stderr bash -c "FORCE_COLOR=1 source ${LIB}; FORCE_COLOR=1 _log_info setup msg"
+  assert_success
+  assert_equal "${output}" $'\033[2m[setup] INFO:\033[0m msg'
+}
+
+# ── NO_COLOR wins over FORCE_COLOR + TTY ────────────────────────────────────
+
+@test "_log_err with NO_COLOR=1 + FORCE_COLOR=1 omits ANSI (NO_COLOR wins)" {
+  run --separate-stderr bash -c "NO_COLOR=1 FORCE_COLOR=1 source ${LIB}; NO_COLOR=1 FORCE_COLOR=1 _log_err build msg"
+  assert_success
+  assert_equal "${stderr}" "[build] ERROR: msg"
+}
+
+@test "_log_warn with NO_COLOR=1 omits ANSI" {
+  run --separate-stderr bash -c "NO_COLOR=1 FORCE_COLOR=1 source ${LIB}; NO_COLOR=1 FORCE_COLOR=1 _log_warn run msg"
+  assert_success
+  assert_equal "${stderr}" "[run] WARNING: msg"
+}
+
+@test "_log_info with NO_COLOR=1 omits ANSI" {
+  run --separate-stderr bash -c "NO_COLOR=1 FORCE_COLOR=1 source ${LIB}; NO_COLOR=1 FORCE_COLOR=1 _log_info setup msg"
+  assert_success
+  assert_equal "${output}" "[setup] INFO: msg"
+}
+
+# ── _log_color_enabled fd argument semantics ───────────────────────────────
+
+@test "_log_color_enabled returns non-zero on non-TTY fd 1 without overrides" {
+  run bash -c "source ${LIB}; _log_color_enabled 1"
+  assert_failure
+}
+
+@test "_log_color_enabled returns 0 with FORCE_COLOR=1 on non-TTY" {
+  run bash -c "FORCE_COLOR=1 source ${LIB}; FORCE_COLOR=1 _log_color_enabled 1"
+  assert_success
+}
+
+@test "_log_color_enabled returns non-zero with NO_COLOR=1 + FORCE_COLOR=1" {
+  run bash -c "NO_COLOR=1 FORCE_COLOR=1 source ${LIB}; NO_COLOR=1 FORCE_COLOR=1 _log_color_enabled 1"
+  assert_failure
+}
+
+@test "_log_color_enabled with no fd argument exits non-zero (param guard)" {
+  run -127 bash -c "source ${LIB}; _log_color_enabled"
+}


### PR DESCRIPTION
## Summary

PR A of #278 — adds `_log_err` / `_log_warn` / `_log_info` log helpers to `script/docker/_lib.sh`. Foundational; no existing callsites migrated. PR B (#278 follow-up) migrates `build/run/exec/stop`; PR C migrates remaining top-level scripts.

Three tagged, level-prefixed output helpers with optional ANSI color and consistent stream routing:

```
_log_err  -> stderr, red bold "[<tag>] ERROR: <msg>"
_log_warn -> stderr, yellow  "[<tag>] WARNING: <msg>"
_log_info -> stdout, dim     "[<tag>] INFO: <msg>"
```

Internal `_log_color_enabled(fd)` gates the color path:

- `NO_COLOR` set to any non-empty value → color off (https://no-color.org/)
- `FORCE_COLOR=1` → color on regardless of TTY
- otherwise → auto-detect via `test -t "$fd"`

Per the [locked decisions in #278](https://github.com/ycpss91255-docker/base/issues/278#issuecomment-4420504085):

- 8-color ANSI only (no 256-color / RGB / background)
- ERROR/WARNING/INFO follow standard severity conventions
- Stream routing: errors+warnings to stderr; info to stdout
- Helpers fold into `_lib.sh` (not a dedicated `logger.sh`), since most scripts already source `_lib.sh` for `_print_config_summary` / `_compose`

## Tests

New `test/unit/log_spec.bats` (17 tests):

- Default routing + no-color path (non-TTY default)
- `FORCE_COLOR=1` ANSI emission on non-TTY
- `NO_COLOR=1` precedence over `FORCE_COLOR=1`
- Multi-token message join
- Missing-tag guards (`run -127` for the `${1:?}` trip-shell exit; suppresses bats BW01 precision warning)
- `_log_color_enabled` fd argument semantics

TEST.md totals: `1083 -> 1100` (unit `1027 -> 1044`). CHANGELOG `[Unreleased]` Added entry.

## Test plan

- [x] `make -f Makefile.ci test` green locally (all 1100 self-tests + 56 integration pass, 0 BW01 warnings)
- [ ] CI green on this PR
- [ ] PR B follow-up migrates `build/run/exec/stop` callsites to the helpers
- [ ] PR C follow-up migrates remaining top-level entry points (`init.sh`, `upgrade.sh`, `ci.sh`, `setup.sh`, `setup_tui.sh`, `_print_config_summary`)

Closes part of #278.
