### PR TITLE
feat(scripts): route init / upgrade / ci helpers through _log_* (#278 PR-1)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`_log_err` / `_log_warn` / `_log_info` helpers in `script/docker/_lib.sh`** (#278 PR A). Tagged, level-prefixed output with optional ANSI color and consistent stream routing (ERROR/WARNING -> stderr; INFO -> stdout). Honor `NO_COLOR` (https://no-color.org/) and auto-disable color on non-TTY destinations; `FORCE_COLOR=1` overrides auto-detect. Color scheme: ERROR red bold (`\033[1;31m`), WARNING yellow (`\033[33m`), INFO dim (`\033[2m`). No callsites migrated in this PR — foundational; PR B (#278) migrates `build/run/exec/stop`, PR C migrates remaining top-level scripts. New `test/unit/log_spec.bats` (17 tests; total 1083 -> 1100; unit 1027 -> 1044).
 
+### Changed
+- **`init.sh` / `upgrade.sh` / `script/ci/ci.sh` route inline `_log` / `_error` / `_die` helpers through the `_log_*` family from #278 PR A** (#278 PR-1). Each script now sources `script/docker/_lib.sh` and the in-file helper definitions become thin wrappers (`_log() { _log_info init "$*"; }` etc), so all three top-level entry points gain colored ERROR / INFO output on TTY destinations with `NO_COLOR` honored, without touching any call site. `upgrade.sh`'s `_verify_subtree_intact` integrity error block also migrates 3 raw `printf '[upgrade] ...' >&2` lines onto `_log_err` / `_log_info`. Test fixtures (`test/unit/init_spec.bats`, `test/unit/upgrade_spec.bats` HARNESS, `test/integration/upgrade_spec.bats`, `test/integration/gitignore_sync_spec.bats`) updated to symlink / copy `_lib.sh` + `i18n.sh` alongside the scripts they exercise.
+
 ## [v0.25.0] - 2026-05-11
 
 Promoted from `v0.25.0-rc1` (#274). RC tag CI green (Self Test + release-test-tools); no fixups needed between rc1 and stable.

--- a/init.sh
+++ b/init.sh
@@ -34,8 +34,10 @@ readonly TEMPLATE_REL
 
 # shellcheck disable=SC1091
 source "${TEMPLATE_DIR}/script/docker/lib/gitignore.sh"
+# shellcheck disable=SC1091
+source "${TEMPLATE_DIR}/script/docker/_lib.sh"
 
-_log() { printf "[init] %s\n" "$*"; }
+_log() { _log_info init "$*"; }
 
 # ── Symlink helper ──────────────────────────────────────────────────────────
 
@@ -372,7 +374,7 @@ _call_setup() {
   fi
 }
 
-_error() { printf "[init] ERROR: %s\n" "$*" >&2; exit 1; }
+_error() { _log_err init "$*"; exit 1; }
 
 # ── Main ────────────────────────────────────────────────────────────────────
 

--- a/script/ci/ci.sh
+++ b/script/ci/ci.sh
@@ -22,6 +22,9 @@ readonly SCRIPT_DIR
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/../.." && pwd -P)"
 readonly REPO_ROOT
 
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/../docker/_lib.sh"
+
 # ── Help ─────────────────────────────────────────────────────────────────────
 
 usage() {
@@ -53,7 +56,7 @@ EOF
 
 # ── CI container setup ───────────────────────────────────────────────────────
 
-_die() { printf "[ci] ERROR: %s\n" "$*" >&2; exit 1; }
+_die() { _log_err ci "$*"; exit 1; }
 
 _install_deps() {
   command -v bats >/dev/null 2>&1 && return 0

--- a/test/integration/gitignore_sync_spec.bats
+++ b/test/integration/gitignore_sync_spec.bats
@@ -161,6 +161,10 @@ _seed_upgrade_fixture() {
   cp /source/init.sh "${TMPL_WORK}/init.sh"
   cp /source/upgrade.sh "${TMPL_WORK}/upgrade.sh"
   cp /source/script/docker/lib/gitignore.sh "${TMPL_WORK}/script/docker/lib/gitignore.sh"
+  # init.sh / upgrade.sh source _lib.sh on load (#278: route _log / _error
+  # through _log_info / _log_err). _lib.sh sources i18n.sh, so copy both.
+  cp /source/script/docker/_lib.sh "${TMPL_WORK}/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${TMPL_WORK}/script/docker/i18n.sh"
   printf '#!/usr/bin/env bash\nexit 0\n' > "${TMPL_WORK}/script/docker/setup.sh"
   # _create_symlinks references these paths; empty stubs keep ln -sf happy.
   for _f in build.sh run.sh exec.sh stop.sh setup_tui.sh Makefile; do

--- a/test/integration/upgrade_spec.bats
+++ b/test/integration/upgrade_spec.bats
@@ -41,6 +41,10 @@ _seed_template_remote() {
   printf '#!/usr/bin/env bash\nexit 0\n' > "${TMPL_WORK}/init.sh"
   printf '#!/usr/bin/env bash\nexit 0\n' > "${TMPL_WORK}/script/docker/setup.sh"
   cp "${UPGRADE}" "${TMPL_WORK}/upgrade.sh"
+  # upgrade.sh sources _lib.sh on load (#278: _log / _error wrap _log_*).
+  # _lib.sh itself sources i18n.sh, so copy both into the fake remote.
+  cp /source/script/docker/_lib.sh "${TMPL_WORK}/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh "${TMPL_WORK}/script/docker/i18n.sh"
   chmod +x "${TMPL_WORK}/init.sh" "${TMPL_WORK}/script/docker/setup.sh" "${TMPL_WORK}/upgrade.sh"
   git -C "${TMPL_WORK}" add -A
   git -C "${TMPL_WORK}" commit -q -m "v0.9.5"

--- a/test/unit/init_spec.bats
+++ b/test/unit/init_spec.bats
@@ -23,6 +23,12 @@ setup() {
   # lib so its functions are available to tests that hit _create_new_repo.
   ln -s /source/script/docker/lib/gitignore.sh \
         "${TMP_REPO}/template/script/docker/lib/gitignore.sh"
+  # init.sh sources _lib.sh on load (#278: routes _log / _error through
+  # _log_info / _log_err). _lib.sh itself sources i18n.sh, so symlink both.
+  ln -s /source/script/docker/_lib.sh \
+        "${TMP_REPO}/template/script/docker/_lib.sh"
+  ln -s /source/script/docker/i18n.sh \
+        "${TMP_REPO}/template/script/docker/i18n.sh"
 
   # Minimal Dockerfile.example stub for _create_new_repo's `cp` step.
   cat > "${TMP_REPO}/template/dockerfile/Dockerfile.example" <<'EOF'

--- a/test/unit/upgrade_spec.bats
+++ b/test/unit/upgrade_spec.bats
@@ -24,8 +24,15 @@ setup() {
 # top-level derivation never runs — the tests pin the conventional
 # subtree prefix to make the assertions deterministic.
 TEMPLATE_REL="template"
-_log() { printf '[upgrade] %s\n' "$*"; }
-_error() { printf '[upgrade] ERROR: %s\n' "$*" >&2; exit 1; }
+# Stub the _log_* helpers (#278). Real upgrade.sh sources _lib.sh and
+# routes _log / _error through _log_info / _log_err; this harness
+# extracts function bodies via sed so we re-stub the surface those
+# bodies call.
+_log_info() { printf '[%s] INFO: %s\n' "$1" "${*:2}"; }
+_log_warn() { printf '[%s] WARNING: %s\n' "$1" "${*:2}" >&2; }
+_log_err()  { printf '[%s] ERROR: %s\n' "$1" "${*:2}" >&2; }
+_log()    { _log_info upgrade "$*"; }
+_error()  { _log_err upgrade "$*"; exit 1; }
 EOS
   sed -n '/^_warn_config_drift() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
   sed -n '/^_require_git_identity() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -27,10 +27,13 @@ readonly TEMPLATE_REMOTE
 VERSION_FILE="${REPO_ROOT}/${TEMPLATE_REL}/.version"
 readonly VERSION_FILE
 
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/script/docker/_lib.sh"
+
 cd "${REPO_ROOT}"
 
-_log() { printf "[upgrade] %s\n" "$*"; }
-_error() { printf "[upgrade] ERROR: %s\n" "$*" >&2; exit 1; }
+_log() { _log_info upgrade "$*"; }
+_error() { _log_err upgrade "$*"; exit 1; }
 
 # ── Safety guards ────────────────────────────────────────────────────────────
 #
@@ -89,9 +92,9 @@ _verify_subtree_intact() {
   local _marker
   for _marker in "${_markers[@]}"; do
     if [[ ! -f "${_marker}" ]]; then
-      printf "[upgrade] ERROR: post-pull integrity check failed — '%s' missing.\n" "${_marker}" >&2
-      printf "[upgrade] Likely cause: git-subtree fast-forwarded destructively.\n" >&2
-      printf "[upgrade] Rolling back to %s ...\n" "${_pre_head:0:12}" >&2
+      _log_err upgrade "post-pull integrity check failed — '${_marker}' missing."
+      _log_err upgrade "Likely cause: git-subtree fast-forwarded destructively."
+      _log_info upgrade "Rolling back to ${_pre_head:0:12} ..."
       git reset --hard "${_pre_head}" >/dev/null 2>&1 || true
       _error "upgrade aborted; repo restored to pre-upgrade state"
     fi


### PR DESCRIPTION
## Summary

PR-1 of the #278 series — route `init.sh` / `upgrade.sh` / `script/ci/ci.sh` inline `_log` / `_error` / `_die` helpers through the `_log_err` / `_log_warn` / `_log_info` family added in #278 PR A. Each script now sources `script/docker/_lib.sh` and the in-file helper definitions become thin wrappers, so all three top-level entry points gain colored ERROR / INFO output on TTY destinations (with `NO_COLOR` honored), without touching any call site.

PR-2 of the #278 series (separate PR, follow-up) handles the i18n surface for `build/run/exec/stop`'s `_msg` helper + `setup.sh`'s `_setup_msg`, per the design captured in [#283](https://github.com/ycpss91255-docker/base/issues/283).

## Changes

```text
init.sh
  source script/docker/_lib.sh after lib/gitignore.sh
  _log()   -> _log_info init "$*"
  _error() -> _log_err  init "$*"; exit 1

upgrade.sh
  source script/docker/_lib.sh after VERSION_FILE / before cd REPO_ROOT
  _log()   -> _log_info upgrade "$*"
  _error() -> _log_err  upgrade "$*"; exit 1
  _verify_subtree_intact integrity error path: 3 raw printf migrated
    onto _log_err / _log_info

script/ci/ci.sh
  source script/docker/_lib.sh after REPO_ROOT
  _die() -> _log_err ci "$*"; exit 1
```

Test fixtures updated for the new dependency (each fixture that builds a fake template layout now ships `_lib.sh` + `i18n.sh` next to the scripts it exercises):

- `test/unit/init_spec.bats` — symlinks added for `_lib.sh` + `i18n.sh`
- `test/unit/upgrade_spec.bats` — HARNESS pre-defines `_log_info` / `_log_warn` / `_log_err` stubs (sed-extracted function bodies now reference them)
- `test/integration/upgrade_spec.bats` — copies `_lib.sh` + `i18n.sh` into the fake template remote
- `test/integration/gitignore_sync_spec.bats` — same

## Tests

`make -f Makefile.ci test` green: 1100 self-tests + 56 integration. No new tests added — the helper wiring is covered transitively by existing `init_spec` / `upgrade_spec` / `ci_spec` assertions on `[tag] LEVEL:` output strings, and the underlying color / NO_COLOR / TTY logic is covered by `log_spec.bats` from PR A.

## Test plan

- [x] `make -f Makefile.ci test` green locally
- [ ] CI green on this PR
- [ ] Visual smoke: run `./template/init.sh` / `make upgrade-check` / `make ci` on a TTY and confirm ERROR / INFO lines render in color
- [ ] PR-2 follow-up handles `_msg` / `_setup_msg` i18n refactor (#283)

Closes part of #278. Companion: #283 (i18n refactor), #284 (file split of `_lib.sh` into sub-libs).
