### PR TITLE
feat(exec.sh): support -- separator before CMD (closes #289)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`exec.sh --` flag/CMD separator** (closes #289). Mirrors `run.sh`'s existing `--` arm so the inner CMD can start with a dash (e.g. `./exec.sh -- my-tool --version`) without `exec.sh`'s own option parser capturing it. The separator is consumed by `exec.sh` before the remaining `"$@"` is handed to `docker compose exec`, so the literal `--` never leaks into the docker command line. Positional CMD (`./exec.sh ls /tmp`) keeps working — backward-compatible. 4-language `-h` usage updated with the new `[--]` synopsis token, an Options entry, and an example. New tests in `test/unit/exec_sh_spec.bats` (5 tests; total 1123 -> 1128; unit 1067 -> 1072): standalone `--` consumed before CMD passes through, dash-leading CMD passes through, `--` works after `-t TARGET`, no-`--` positional path stays backward-compatible, `--help` mentions the new separator.
+
 ## [v0.26.0] - 2026-05-13
 
 Promoted from `v0.26.0-rc2` (#297). rc2 tag CI green (Self Test + release-test-tools). RC validation pass on `app/ros1_bridge` (the primary #272 validation target): rc2's `chore/template-v0.26.0-rc2` PR (`ros1_bridge#88`) built end-to-end (rc1 had been wedged at workflow validation; rc2 hotfix unblocked it). Cold baseline measured at ~18m26s total wall-time for the 4-shard matrix (jazzy-amd64 17m43s, humble-amd64 14m16s, jazzy-arm64 13m47s, humble-arm64 12m21s) — sits inside the #272 issue body's stated 15-25 min cold range. Warm-cache wall-time drop (#272 acceptance: >=30%) will be observed organically across the 13-downstream `/batch-template-upgrade v0.26.0` fanout PRs that follow this tag — each repo's first PR is a cold/warm pair on the same SHA when the fanout PR opens.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1123 tests** total (1067 unit + 56 integration).
+Template self-tests: **1128 tests** total (1072 unit + 56 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -247,7 +247,7 @@ before compose up, `--build` after check-drift), and **`-C` / `--chdir`
 flag** (docker_harness#53: redirect FILE_PATH, short + long form,
 value-required and directory guards, usage help mention).
 
-### test/unit/exec_sh_spec.bats (23)
+### test/unit/exec_sh_spec.bats (28)
 
 Unit tests for `exec.sh` argument parsing, the container-running
 precheck, and i18n. Sandbox tree mirrors build_sh_spec.bats;
@@ -260,8 +260,12 @@ Covers: `--help` (en/zh/zh-CN/ja), `--lang` / `--target` / `--instance`
 value validation, English-default not-running error, Chinese /
 Simplified Chinese / Japanese not-running error text, instance-specific
 vs default start hints, `--dry-run` bypassing the guard, compose exec
-routing when container is running, fallback `_detect_lang`
-branches when `template/` is absent, and **`-C` / `--chdir` flag**
+routing when container is running, **`--` flag/CMD separator** (#289:
+standalone `--` consumed before CMD flows through to `docker compose
+exec`, lets a dash-leading CMD pass through, works after `-t TARGET`
+for run.sh parity, no-`--` positional path stays backward-compatible,
+`-h` usage mentions `--`), fallback `_detect_lang` branches when
+`template/` is absent, and **`-C` / `--chdir` flag**
 (docker_harness#53: redirect FILE_PATH so .env / project name come
 from the alt repo, short + long form, value-required and directory
 guards, usage help mention).

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -85,7 +85,7 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
+用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [--] [CMD...]
 
 選項:
   -h, --help        顯示此說明
@@ -95,6 +95,8 @@ usage() {
   --instance NAME   進入命名 instance（預設為 default instance）
   --lang LANG       設定訊息語言（預設: en）
   --dry-run         只印出將執行的 docker 指令，不實際執行
+  --                明確分隔 exec.sh 選項與 CMD（與 run.sh 對齊），讓 CMD 可以
+                    用 dash 開頭（例：./exec.sh -- my-tool --version）
 
 參數:
   CMD              要執行的指令（預設: bash）
@@ -104,11 +106,12 @@ usage() {
   ./exec.sh htop               # 在 devel 容器中執行 htop
   ./exec.sh ls -la /home       # 在 devel 容器中執行 ls
   ./exec.sh -t runtime bash    # 進入 runtime 容器
+  ./exec.sh -- my-tool --version  # 用 -- 把 dash-開頭 CMD 傳進容器
 EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
+用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [--] [CMD...]
 
 选项:
   -h, --help        显示此说明
@@ -118,6 +121,8 @@ EOF
   --instance NAME   进入命名 instance（默认为 default instance）
   --lang LANG       设置消息语言（默认: en）
   --dry-run         只打印将执行的 docker 命令，不实际执行
+  --                明确分隔 exec.sh 选项与 CMD（与 run.sh 对齐），让 CMD 可以
+                    以 dash 开头（例：./exec.sh -- my-tool --version）
 
 参数:
   CMD              要执行的命令（默认: bash）
@@ -127,11 +132,12 @@ EOF
   ./exec.sh htop               # 在 devel 容器中运行 htop
   ./exec.sh ls -la /home       # 在 devel 容器中运行 ls
   ./exec.sh -t runtime bash    # 进入 runtime 容器
+  ./exec.sh -- my-tool --version  # 用 -- 把 dash-开头 CMD 传入容器
 EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
+使用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [--] [CMD...]
 
 オプション:
   -h, --help        このヘルプを表示
@@ -141,6 +147,8 @@ EOF
   --instance NAME   名前付き instance に入る（デフォルトは default instance）
   --lang LANG       メッセージ言語を設定（デフォルト: en）
   --dry-run         実行される docker コマンドを表示するのみ（実行はしない）
+  --                exec.sh のオプションと CMD を明示的に区切る（run.sh と整合）。
+                    dash で始まる CMD を渡す場合に使う（例: ./exec.sh -- my-tool --version）
 
 引数:
   CMD              実行するコマンド（デフォルト: bash）
@@ -150,11 +158,12 @@ EOF
   ./exec.sh htop               # devel コンテナで htop を実行
   ./exec.sh ls -la /home       # devel コンテナで ls を実行
   ./exec.sh -t runtime bash    # runtime コンテナに接続
+  ./exec.sh -- my-tool --version  # -- で dash 始まりの CMD を渡す
 EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [CMD...]
+Usage: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [--] [CMD...]
 
 Options:
   -h, --help        Show this help
@@ -164,6 +173,8 @@ Options:
   --instance NAME   Enter a named instance (default: default instance)
   --lang LANG       Set message language (default: en)
   --dry-run         Print the docker commands that would run, but do not execute
+  --                Explicit flag/CMD separator, mirroring run.sh. Lets the CMD
+                    start with a dash (e.g. ./exec.sh -- my-tool --version).
 
 Arguments:
   CMD              Command to execute (default: bash)
@@ -173,6 +184,7 @@ Examples:
   ./exec.sh htop               # Run htop in devel container
   ./exec.sh ls -la /home       # Run ls in devel container
   ./exec.sh -t runtime bash    # Enter runtime container
+  ./exec.sh -- my-tool --version  # Use -- to pass a dash-leading CMD
 EOF
       ;;
   esac
@@ -223,6 +235,13 @@ main() {
         _LANG="${2:?"--lang requires a value (en|zh-TW|zh-CN|ja)"}"
         _sanitize_lang _LANG "exec"
         shift 2
+        ;;
+      --)
+        # Explicit flag/CMD separator, mirroring run.sh. Lets the user
+        # send a CMD starting with a dash (e.g. `--version`) without it
+        # being captured by exec.sh's own option parsing. Closes #289.
+        shift
+        break
         ;;
       *)
         break

--- a/test/unit/exec_sh_spec.bats
+++ b/test/unit/exec_sh_spec.bats
@@ -146,6 +146,51 @@ teardown() {
   assert_output --partial "exec"
 }
 
+# ── -- flag/CMD separator (issue #289) ──────────────────────────────────────
+
+@test "exec.sh -- separator: standalone -- is consumed, CMD flows through (#289)" {
+  echo "mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run -- ls /tmp
+  assert_success
+  assert_output --partial " ls /tmp"
+  # The literal -- must not survive into the docker exec command line —
+  # confirm there's no ` -- ` standalone token in the captured docker args.
+  refute_output --partial " -- "
+}
+
+@test "exec.sh -- separator: lets a dash-leading CMD pass through (#289)" {
+  # The whole point of -- is to send a CMD starting with a dash to the
+  # container without exec.sh's own option parser capturing it.
+  echo "mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run -- my-tool --version
+  assert_success
+  assert_output --partial "my-tool"
+  assert_output --partial "--version"
+  refute_output --partial " -- "
+}
+
+@test "exec.sh -- separator: works after -t TARGET (run.sh parity, #289)" {
+  echo "mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run -t devel -- echo hi
+  assert_success
+  assert_output --partial "echo hi"
+  refute_output --partial " -- "
+}
+
+@test "exec.sh: no -- still works for positional CMD (backward compat, #289)" {
+  echo "mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run ls -la /tmp
+  assert_success
+  assert_output --partial "ls"
+}
+
+@test "exec.sh --help mentions the -- separator (#289)" {
+  run bash "${SANDBOX}/exec.sh" --help
+  assert_success
+  # Either the synopsis token [--] or the standalone Options entry.
+  assert_output --partial "--"
+}
+
 # ── /lint/-layout _detect_lang (flat dir with _lib.sh + i18n.sh, #104) ─────
 
 @test "exec.sh in /lint/ layout maps zh_TW.UTF-8 to zh-TW" {


### PR DESCRIPTION
## Summary

Adds `--` separator support to `exec.sh`, mirroring `run.sh`'s existing pattern. Closes #289.

Without `--`, `exec.sh`'s own option parser captures any leading-dash arg as a flag and exits with "unknown option" if it doesn't match a known flag. `--` tells the parser to stop and pass everything after it through to `docker compose exec` verbatim, so callers can run commands whose first token starts with a dash:

```bash
# Before this PR: exec.sh refused the leading-dash CMD
./exec.sh my-tool --version    # ERROR: unknown option --version

# After this PR: same CMD works via --
./exec.sh -- my-tool --version  # passes through to compose exec
```

The positional CMD path (`./exec.sh ls /tmp`, `./exec.sh bash`) keeps working — backward-compatible.

## Changes

```text
script/docker/exec.sh         + `--` arm in argument parser; consumed
                                before remaining "$@" passes to compose
                              + 4-language -h usage updated:
                                synopsis adds `[--]` token, new Options
                                entry, new Examples entry
test/unit/exec_sh_spec.bats   +5 regression tests
doc/test/TEST.md              1123 -> 1128 total (1067 -> 1072 unit)
doc/changelog/CHANGELOG.md    [Unreleased] Added entry
```

## Tests

5 new assertions in `test/unit/exec_sh_spec.bats`:

- standalone `--` consumed before CMD passes through (dry-run captures the command without literal `--`)
- dash-leading CMD passes through after `--`
- `--` works after `-t TARGET` flag
- no-`--` positional path stays backward-compatible
- `--help` mentions the new separator

## Test plan

- [x] `make -f Makefile.ci test` green locally (1128 self-tests + 56 integration)
- [ ] CI green on this PR

Closes #289.
