### PR TITLE
ci(self-test): gate downstream jobs on actionlint via Docker (closes #305)

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -281,7 +281,7 @@ jobs:
         run: |
           LOCAL_VER=""
           if [ -f .base/.version ]; then
-            LOCAL_VER=$(cat .base/.version | tr -d '[:space:]')
+            LOCAL_VER=$(tr -d '[:space:]' < .base/.version)
           fi
           if [ -n "${LOCAL_VER}" ]; then
             LATEST_VER=$(git ls-remote --tags --sort=-v:refname \

--- a/.github/workflows/publish-worker.yaml
+++ b/.github/workflows/publish-worker.yaml
@@ -198,9 +198,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    outputs:
-      digest_amd64: ${{ steps.export.outputs.digest_amd64 }}
-      digest_arm64: ${{ steps.export.outputs.digest_arm64 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -9,7 +9,27 @@ on:
   workflow_dispatch:
 
 jobs:
+  actionlint:
+    # Catch GHA workflow-validator semantic regressions (the
+    # class behind the v0.26.0-rc1 wedge, #297) before the
+    # bats / docker matrix burns CI minutes. Runs first; the
+    # other jobs gate on it. Refs #305.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run actionlint via Docker
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/repo:ro" \
+            -w /repo \
+            rhysd/actionlint:1.7.7 \
+            -color
+
   test:
+    needs: actionlint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,6 +60,7 @@ jobs:
 
   integration-e2e:
     name: Integration E2E (init.sh → build → run → exec → stop)
+    needs: actionlint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -102,6 +123,7 @@ jobs:
 
   behavioural:
     name: Behavioural Test (runtime-test smoke gate, #249)
+    needs: actionlint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `build-worker.yaml`: surfaced + resolved a pre-existing `SC2002` ("useless cat") in the `Check template version` step's `LOCAL_VER=$(cat .base/.version | tr -d ...)` shell block. Replaced with `tr ... < .base/.version`. Drive-by fix: this was caught the moment the actionlint gate (this PR) ran for the first time — exactly the kind of latent issue actionlint exists to surface.
+- `publish-worker.yaml`: removed two orphan job outputs `digest_amd64` / `digest_arm64` that referenced a non-existent `steps.export.outputs.digest_<arch>` (the workflow has `steps.tags` and `steps.push`, never `steps.export`). No consumer reads these outputs anywhere in the org. Latent since the file was added. Drive-by fix surfaced by the actionlint gate added in this PR.
 
 ## [v0.27.0] - 2026-05-13
 

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `self-test.yaml`: `actionlint` job (Docker invocation, `rhysd/actionlint:1.7.7` pinned) running before the existing `test` / `integration-e2e` / `behavioural` jobs, which now declare `needs: actionlint`. Catches GHA workflow-validator semantic regressions (e.g. `${{ matrix.X }}` referenced outside a step scope — the class behind the v0.26.0-rc1 wedge fixed by #297) at PR time before bats / docker matrix burns CI minutes. No new third-party GHA action dependency (Docker pull, in line with the #273 Phase 2 "no `dorny/paths-filter` dependency" preference). Closes #305.
+
+### Changed
+
+- `test/unit/self_test_yaml_spec.bats` (new, 5 tests): structural assertions locking the actionlint gate — job exists + uses pinned `rhysd/actionlint:x.y.z` Docker image + 3 downstream jobs declare `needs: actionlint`. Aborts CI if a future refactor quietly drops the gate.
+
 ## [v0.27.0] - 2026-05-13
 
 Promoted from `v0.27.0-rc1` (#304). rc1 tag CI green (Self Test + release-test-tools). RC validation pass: all 8 active downstream repos (4 agent + ros1_bridge + urg_node_humble + 2 env multi-distro) merged `chore/template-v0.27.0-rc1` PRs (ai_agent#51, claude_code#50, codex_cli#49, gemini_cli#49, ros1_bridge#90, urg_node_humble#46, ros2_distro#17, ros_distro#17) with CI green on each. The 5 sensor-app repos (realsense_humble / realsense_noetic / sick_humble / sick_noetic / urg_node_noetic) remain on pre-`.base/` v0.24.0 awaiting #263 pip migration; they continue to be deferred from this fanout.

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test/unit/self_test_yaml_spec.bats` (new, 5 tests): structural assertions locking the actionlint gate — job exists + uses pinned `rhysd/actionlint:x.y.z` Docker image + 3 downstream jobs declare `needs: actionlint`. Aborts CI if a future refactor quietly drops the gate.
 
+### Fixed
+
+- `build-worker.yaml`: surfaced + resolved a pre-existing `SC2002` ("useless cat") in the `Check template version` step's `LOCAL_VER=$(cat .base/.version | tr -d ...)` shell block. Replaced with `tr ... < .base/.version`. Drive-by fix: this was caught the moment the actionlint gate (this PR) ran for the first time — exactly the kind of latent issue actionlint exists to surface.
+
 ## [v0.27.0] - 2026-05-13
 
 Promoted from `v0.27.0-rc1` (#304). rc1 tag CI green (Self Test + release-test-tools). RC validation pass: all 8 active downstream repos (4 agent + ros1_bridge + urg_node_humble + 2 env multi-distro) merged `chore/template-v0.27.0-rc1` PRs (ai_agent#51, claude_code#50, codex_cli#49, gemini_cli#49, ros1_bridge#90, urg_node_humble#46, ros2_distro#17, ros_distro#17) with CI green on each. The 5 sensor-app repos (realsense_humble / realsense_noetic / sick_humble / sick_noetic / urg_node_noetic) remain on pre-`.base/` v0.24.0 awaiting #263 pip migration; they continue to be deferred from this fanout.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1140 tests** total (1084 unit + 56 integration).
+Template self-tests: **1145 tests** total (1089 unit + 56 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -203,6 +203,26 @@ on doc-only PRs).
 | #243 stage rename + runtime-test smoke: `target: devel-test` (renamed from `test`), no leftover `target: test`, `target: runtime-test` exists, runtime-test gated on `inputs.build_runtime` (>=2 occurrences shared with runtime gate) | 4 |
 | #272 GHA buildx cache: `cache_variant` input declared with empty default, `Compute cache scope` step emits `id: cache` + scope key into `GITHUB_OUTPUT`, 4 build steps set `cache-from: type=gha,scope=...`, 4 build steps set `cache-to: ...,mode=max`, default preserves zero-diff for single-call callers | 5 |
 | #273 doc-only PR fast-pass (Phase 1 + Phase 2 shell rewrite): `path-filter` job declared, classifier is pure shell (`git diff --name-only base...head` + `case` glob; no `dorny/paths-filter` dependency), reads EVENT_NAME / BASE_SHA / HEAD_SHA from env: keys so the case body stays portable, non-PR event short-circuits before git diff (BASE_SHA / HEAD_SHA empty on push / tag / workflow_dispatch), 6-path allowlist (`**/*.md`, `doc/**`, `LICENSE`, `.gitignore`, `.github/CODEOWNERS`, `.github/dependabot.yml`) in a single `case` arm, `compute-matrix` + `build` jobs gated on `code_changed == 'true'` (2 occurrences), `docker-build` aggregator handles `code_changed == 'false'` short-circuit + `needs: [path-filter, build]`, non-PR triggers always set `code_changed=true` | 8 |
+
+### test/unit/self_test_yaml_spec.bats (5)
+
+Structural assertions for `.github/workflows/self-test.yaml` (#305).
+Locks the actionlint gate so a future refactor cannot quietly drop
+the validator: the `actionlint` job exists and runs
+`rhysd/actionlint` via Docker pinned to an explicit version
+(`x.y.z`); the three downstream jobs (`test`, `integration-e2e`,
+`behavioural`) declare `needs: actionlint` so they cannot start
+until the workflow-validator class of regression that wedged
+v0.26.0-rc1 (`${{ matrix.X }}` outside step scope, refs #297) is
+caught early — before bats / docker matrix burns CI minutes.
+
+| Category | Tests |
+|----------|-------|
+| `actionlint` job declared | 1 |
+| `actionlint` step uses `rhysd/actionlint:<pinned-version>` Docker image | 1 |
+| `test` job declares `needs: actionlint` | 1 |
+| `integration-e2e` job declares `needs: actionlint` | 1 |
+| `behavioural` job declares `needs: actionlint` | 1 |
 
 ### test/unit/build_sh_spec.bats (46)
 

--- a/test/unit/self_test_yaml_spec.bats
+++ b/test/unit/self_test_yaml_spec.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+#
+# self_test_yaml_spec.bats — structural assertions for the
+# `.github/workflows/self-test.yaml` workflow.
+#
+# Locks the #305 actionlint gate: a new `actionlint` job runs
+# rhysd/actionlint via Docker against the workflows tree, and the
+# three downstream jobs (test / integration-e2e / behavioural)
+# declare `needs: actionlint` so they cannot start until actionlint
+# passes. Catches GHA workflow-validator semantic regressions (the
+# class behind the v0.26.0-rc1 wedge, fixed in #297) before bats /
+# docker matrix burns CI minutes.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  WF="/source/.github/workflows/self-test.yaml"
+  [[ -f "${WF}" ]] || skip "self-test.yaml not at expected path"
+}
+
+# ── actionlint job declared (#305) ────────────────────────────────────
+
+@test "self-test.yaml: declares actionlint job" {
+  run grep -E '^  actionlint:' "${WF}"
+  assert_success
+}
+
+@test "self-test.yaml: actionlint job runs rhysd/actionlint via Docker with pinned tag" {
+  run grep -E 'rhysd/actionlint:[0-9]+\.[0-9]+\.[0-9]+' "${WF}"
+  assert_success
+}
+
+# ── Downstream jobs gate on actionlint (#305) ─────────────────────────
+
+@test "self-test.yaml: test job declares needs: actionlint" {
+  run awk '/^  test:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'needs: actionlint'
+}
+
+@test "self-test.yaml: integration-e2e job declares needs: actionlint" {
+  run awk '/^  integration-e2e:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'needs: actionlint'
+}
+
+@test "self-test.yaml: behavioural job declares needs: actionlint" {
+  run awk '/^  behavioural:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'needs: actionlint'
+}


### PR DESCRIPTION
## Summary

Adds an `actionlint` gate job to `self-test.yaml` that runs `rhysd/actionlint:1.7.7` via Docker against the workflows tree. The existing `test` / `integration-e2e` / `behavioural` jobs declare `needs: actionlint` so they cannot start until the workflow-validator class of regression — the one that wedged every v0.26.0-rc1 downstream consumer in 0s with "workflow file issue" (fixed by #297) — is caught early, before bats / docker matrix burns CI minutes.

Closes #305.

## Rationale

`base`'s PR CI exercises `bats` unit + integration tests, ShellCheck, Hadolint, and `kcov`. It does NOT run `actionlint`. The `build_worker_yaml_spec.bats` structural assertions are grep-based and only catch what they explicitly look for; they cannot catch GitHub Actions semantic violations (`context "X" is not allowed here`, invalid event types, malformed step shapes, deprecated action versions, etc.).

The v0.26.0-rc1 release surfaced this gap concretely:

- `build-worker.yaml` was tagged with a literal `${{ matrix.target.name }}` expression token embedded inside the `cache_variant` input description block.
- GitHub's strict workflow validator parses every `${{ ... }}` in workflow files as an expression, even inside description strings. `matrix` context is not available at workflow-input declaration scope, so the validator rejected the file at parse time.
- Every rc1 downstream consumer failed with "workflow file issue" in 0s — no jobs scheduled, no annotations, no logs.
- Local `actionlint` immediately surfaced the violation (`context "matrix" is not allowed here`).

Lifting that local discipline into PR CI closes the gap.

## Design

- **Docker invocation, not a third-party GHA action**. Matches the #273 Phase 2 / #302 spirit of not adding `dorny/paths-filter`-class dependencies. `rhysd/actionlint:1.7.7` is pinned so an upstream image change cannot silently alter behaviour. Bump via a normal dependency-update PR.
- **Gate, not a co-equal job**. The 3 downstream jobs declare `needs: actionlint`. If actionlint fails, no docker image gets built — saves both wall time and GHA minutes.
- **Scope**: all workflows under `.github/workflows/`. `actionlint` recurses the directory by default; the run is ~1 second per file.

## Tests

`test/unit/self_test_yaml_spec.bats` (new, 5 assertions):

- `actionlint` job declared.
- Step uses `rhysd/actionlint:<pinned-version>` Docker image.
- `test` job declares `needs: actionlint`.
- `integration-e2e` job declares `needs: actionlint`.
- `behavioural` job declares `needs: actionlint`.

Self-test totals: **1140 -> 1145**.

`make -f Makefile.ci test` green locally on the branch: 1145 tests, 0 failures.

## Test plan

- [x] `make -f Makefile.ci test` green locally (1089 unit + 56 integration = 1145).
- [ ] CI green on this PR — and as a side effect, this PR's own actionlint step validates all 5 workflows on `base`.
- [ ] After merge, the next RC tag (next non-trivial release) exercises actionlint as a gate before tag CI even reaches the bats / docker matrix.

## Out of scope

- Adding `actionlint` to downstream consumer repos. Their workflows are thin `uses:` calls to base's reusable workflows; the validation happens once at base. Bumping the `rhysd/actionlint:1.7.7` pin is a separate dep-update PR.
- Broader YAML linting (`yamllint`). `actionlint` covers the GitHub-Actions-specific concerns this issue cares about.
