### PR TITLE
feat(lib): _log_plain helper + ANSI color on _print_config_summary (closes #309)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `test/unit/self_test_yaml_spec.bats` (new, 5 tests): structural assertions locking the actionlint gate — job exists + uses pinned `rhysd/actionlint:x.y.z` Docker image + 3 downstream jobs declare `needs: actionlint`. Aborts CI if a future refactor quietly drops the gate.
+- `lib/log.sh`: new `_log_plain <tag> <style> <msg...>` helper for tagged stdout lines that need TTY-aware visual weight (bold / dim) but no level keyword. Reuses the existing `_log_color_enabled` gate so behavior under `NO_COLOR` / `FORCE_COLOR` / piped stdout matches `_log_err` / `_log_warn` / `_log_info`.
+- `lib/config_summary.sh::_print_config_summary`: route the 2 dividers through `_log_plain ... dim` and the 5 section headers (`Files` / `Identity` / `Variables` / `setup.conf` / `Resolved`) through `_log_plain ... bold`. On a TTY the eye lands on structure; piped / `NO_COLOR=1` output is byte-identical to before (the `[<tag>] ` prefix and indented value lines stay unstyled, so grep-based filters on the tag are unaffected). Closes the long tail of #278 (closes #309).
 
 ### Fixed
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1145 tests** total (1089 unit + 56 integration).
+Template self-tests: **1155 tests** total (1099 unit + 56 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -12,7 +12,7 @@ Template self-tests: **1145 tests** total (1089 unit + 56 integration).
 
 ## Test Files
 
-### test/unit/lib_spec.bats (41)
+### test/unit/lib_spec.bats (43)
 
 | Test | Description |
 |------|-------------|
@@ -44,8 +44,10 @@ Template self-tests: **1145 tests** total (1089 unit + 56 integration).
 | `_print_config_summary hides sections that are empty in setup.conf` | Empty-section skip |
 | `_print_config_summary warns when setup.conf is missing` | Missing-conf hint |
 | `_print_config_summary warns when setup.conf exists but has no [section] headers` | #157 empty-conf hint on build/run summary |
+| `_print_config_summary wraps dividers + section headers in ANSI when FORCE_COLOR=1 (#309)` | Color migration via _log_plain |
+| `_print_config_summary omits ANSI when NO_COLOR=1 overrides FORCE_COLOR=1 (#309)` | NO_COLOR precedence on summary |
 
-### test/unit/log_spec.bats (17)
+### test/unit/log_spec.bats (25)
 
 | Test | Description |
 |------|-------------|
@@ -66,6 +68,14 @@ Template self-tests: **1145 tests** total (1089 unit + 56 integration).
 | `_log_color_enabled returns 0 with FORCE_COLOR=1 on non-TTY` | FORCE_COLOR opt-in |
 | `_log_color_enabled returns non-zero with NO_COLOR=1 + FORCE_COLOR=1` | NO_COLOR wins over FORCE_COLOR |
 | `_log_color_enabled with no fd argument exits non-zero (param guard)` | Required fd guard |
+| `_log_plain writes '[<tag>] <msg>' to stdout with no style (no ANSI even with FORCE_COLOR)` | Empty style suppresses color |
+| `_log_plain with bold style + FORCE_COLOR=1 wraps message in ANSI bold` | Bold style ANSI wrap |
+| `_log_plain with dim style + FORCE_COLOR=1 wraps message in ANSI dim` | Dim style ANSI wrap |
+| `_log_plain with bold style + NO_COLOR=1 omits ANSI even with FORCE_COLOR=1` | NO_COLOR precedence on _log_plain |
+| `_log_plain on non-TTY without FORCE_COLOR omits ANSI` | Auto-detect default off |
+| `_log_plain joins multi-token message with single spaces` | Multi-token message join |
+| `_log_plain with no tag exits non-zero (param ':?' guard)` | Required tag guard |
+| `_log_plain with unknown style + FORCE_COLOR=1 falls back to no ANSI (case match miss)` | Unknown style safe fallback |
 
 ### test/unit/setup_spec.bats (272)
 

--- a/script/docker/lib/config_summary.sh
+++ b/script/docker/lib/config_summary.sh
@@ -25,10 +25,12 @@ if [[ -n "${_DOCKER_LIB_CONFIG_SUMMARY_SOURCED:-}" ]]; then
 fi
 _DOCKER_LIB_CONFIG_SUMMARY_SOURCED=1
 
-# Pull in _dump_conf_section. Idempotent — conf.sh has its own guard.
+# Pull in _dump_conf_section + _log_plain. Idempotent — each has its own guard.
 _config_summary_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck disable=SC1091
 source "${_config_summary_dir}/conf.sh"
+# shellcheck disable=SC1091
+source "${_config_summary_dir}/log.sh"
 unset _config_summary_dir
 
 # _lib_msg <key>
@@ -156,12 +158,12 @@ _print_config_summary() {
   local _img="${DOCKER_HUB_USER:-local}/${IMAGE_NAME:-unknown}"
   local _proj="${PROJECT_NAME:-${DOCKER_HUB_USER:-local}-${IMAGE_NAME:-unknown}}"
 
-  printf "[%s] %s\n" "${_tag}" "${_line}"
-  printf "[%s] %s\n" "${_tag}" "$(_lib_msg files)"
+  _log_plain "${_tag}" dim  "${_line}"
+  _log_plain "${_tag}" bold "$(_lib_msg files)"
   printf "[%s]   setup.conf   : %s\n"   "${_tag}" "${_conf}"
   printf "[%s]   .env         : %s\n"   "${_tag}" "${_fp}/.env"
   printf "[%s]   compose.yaml : %s\n"   "${_tag}" "${_fp}/compose.yaml"
-  printf "[%s] %s\n" "${_tag}" "$(_lib_msg identity)"
+  _log_plain "${_tag}" bold "$(_lib_msg identity)"
   printf "[%s]   %-12s : %s (uid=%s)  %s=%s (gid=%s)\n" "${_tag}" \
     "$(_lib_msg user)" "${USER_NAME:--}" "${USER_UID:--}" \
     "$(_lib_msg group)" "${USER_GROUP:--}" "${USER_GID:--}"
@@ -176,7 +178,7 @@ _print_config_summary() {
   # `${USER_NAME}` / `${WS_PATH}` placeholders. This block bridges the
   # two so users can read mount_* lines without re-deriving the mapping
   # from translated labels.
-  printf "[%s] %s\n" "${_tag}" "$(_lib_msg variables)"
+  _log_plain "${_tag}" bold "$(_lib_msg variables)"
   printf "[%s]   \${USER_NAME} = %s\n"  "${_tag}" "${USER_NAME:--}"
   printf "[%s]   \${USER_UID}  = %s\n"  "${_tag}" "${USER_UID:--}"
   printf "[%s]   \${USER_GROUP} = %s\n" "${_tag}" "${USER_GROUP:--}"
@@ -187,7 +189,7 @@ _print_config_summary() {
   # non-empty to stay readable. Order matches the TUI main menu so
   # the printout and setup_tui.sh layout mirror each other.
   if [[ -f "${_conf}" ]]; then
-    printf "[%s] setup.conf\n" "${_tag}"
+    _log_plain "${_tag}" bold "setup.conf"
     # When the file exists but contains no [section] headers (empty file
     # / comments-only / whitespace-only), every section silently falls
     # back to template defaults. Surface a parallel hint to the
@@ -215,7 +217,7 @@ _print_config_summary() {
 
   # Resolved post-merge flags that the user can't infer from setup.conf
   # alone (GPU/GUI depend on host detection in addition to mode=auto).
-  printf "[%s] %s\n" "${_tag}" "$(_lib_msg resolved)"
+  _log_plain "${_tag}" bold "$(_lib_msg resolved)"
   printf "[%s]   %s : %s  count=%s  caps=%s\n" "${_tag}" \
     "$(_lib_msg gpu_enabled)" "${GPU_ENABLED:--}" "${GPU_COUNT:--}" "${GPU_CAPABILITIES:--}"
   printf "[%s]   %s : %s\n" "${_tag}" \
@@ -228,5 +230,5 @@ _print_config_summary() {
 
   printf "[%s] %s: ./setup_tui.sh  |  ./%s.sh --setup  |  edit setup.conf\n" \
     "${_tag}" "$(_lib_msg customize)" "${_tag}"
-  printf "[%s] %s\n" "${_tag}" "${_line}"
+  _log_plain "${_tag}" dim "${_line}"
 }

--- a/script/docker/lib/log.sh
+++ b/script/docker/lib/log.sh
@@ -64,3 +64,28 @@ _log_info() {
     printf '[%s] INFO: %s\n' "${tag}" "$*"
   fi
 }
+
+# _log_plain <tag> <style> <msg...>
+#
+# Tagged stdout line WITHOUT a level keyword. Wraps the message in ANSI
+# iff _log_color_enabled 1 is true AND <style> is non-empty.
+#
+# <style>: "bold" | "dim" | "" (no color)
+#
+# Use for structured stdout (config summaries, dividers, section headers)
+# where adding "INFO:" to every line would be noise but TTY-aware visual
+# weight is still useful. The "[<tag>]" prefix stays unstyled so grep-based
+# filtering against the tag is unaffected; only the message bytes change.
+_log_plain() {
+  local tag="${1:?_log_plain requires tag}"
+  local style="${2-}"
+  shift 2
+  local prefix="" suffix=""
+  if _log_color_enabled 1 && [[ -n "${style}" ]]; then
+    case "${style}" in
+      bold) prefix=$'\033[1m'; suffix=$'\033[0m' ;;
+      dim)  prefix=$'\033[2m'; suffix=$'\033[0m' ;;
+    esac
+  fi
+  printf '[%s] %s%s%s\n' "${tag}" "${prefix}" "$*" "${suffix}"
+}

--- a/test/unit/lib_spec.bats
+++ b/test/unit/lib_spec.bats
@@ -404,6 +404,46 @@ EOF
   assert_output --partial "./setup_tui.sh"
 }
 
+@test "_print_config_summary wraps dividers + section headers in ANSI when FORCE_COLOR=1 (#309)" {
+  local _fp="${BATS_TEST_TMPDIR}"
+  _write_sample_conf "${_fp}/config/docker/setup.conf"
+  run bash -c "
+    FORCE_COLOR=1 source ${LIB}
+    FORCE_COLOR=1
+    FILE_PATH='${_fp}'
+    _print_config_summary build
+  "
+  assert_success
+  # Dividers wrapped in dim ANSI (\033[2m...\033[0m)
+  assert_output --partial $'\033[2m──'
+  # Section headers wrapped in bold ANSI (\033[1m...\033[0m)
+  assert_output --partial $'\033[1mFiles\033[0m'
+  assert_output --partial $'\033[1mIdentity\033[0m'
+  assert_output --partial $'\033[1mVariables\033[0m'
+  assert_output --partial $'\033[1msetup.conf\033[0m'
+  assert_output --partial $'\033[1mResolved\033[0m'
+  # Indented value lines stay un-styled
+  refute_output --partial $'\033[1m  setup.conf'
+  refute_output --partial $'\033[2m  setup.conf'
+}
+
+@test "_print_config_summary omits ANSI when NO_COLOR=1 overrides FORCE_COLOR=1 (#309)" {
+  local _fp="${BATS_TEST_TMPDIR}"
+  _write_sample_conf "${_fp}/config/docker/setup.conf"
+  run bash -c "
+    NO_COLOR=1 FORCE_COLOR=1 source ${LIB}
+    NO_COLOR=1 FORCE_COLOR=1
+    FILE_PATH='${_fp}'
+    _print_config_summary build
+  "
+  assert_success
+  # No ANSI escape sequences anywhere in output
+  refute_output --partial $'\033['
+  # Headers still present as plain text
+  assert_output --partial "Files"
+  assert_output --partial "Resolved"
+}
+
 @test "_print_config_summary warns when setup.conf exists but has no [section] headers" {
   # Empty / comments-only setup.conf is the same situation as missing
   # from a behavior standpoint (every section falls back to template

--- a/test/unit/log_spec.bats
+++ b/test/unit/log_spec.bats
@@ -117,3 +117,53 @@ setup() {
 @test "_log_color_enabled with no fd argument exits non-zero (param guard)" {
   run -127 bash -c "source ${LIB}; _log_color_enabled"
 }
+
+# ── _log_plain helper (#309) ────────────────────────────────────────────────
+
+@test "_log_plain writes '[<tag>] <msg>' to stdout with no style (no ANSI even with FORCE_COLOR)" {
+  run --separate-stderr bash -c "FORCE_COLOR=1 source ${LIB}; FORCE_COLOR=1 _log_plain build '' 'plain text'"
+  assert_success
+  assert_equal "${output}" "[build] plain text"
+  assert_equal "${stderr}" ""
+}
+
+@test "_log_plain with bold style + FORCE_COLOR=1 wraps message in ANSI bold" {
+  run --separate-stderr bash -c "FORCE_COLOR=1 source ${LIB}; FORCE_COLOR=1 _log_plain build bold 'header'"
+  assert_success
+  assert_equal "${output}" $'[build] \033[1mheader\033[0m'
+  assert_equal "${stderr}" ""
+}
+
+@test "_log_plain with dim style + FORCE_COLOR=1 wraps message in ANSI dim" {
+  run --separate-stderr bash -c "FORCE_COLOR=1 source ${LIB}; FORCE_COLOR=1 _log_plain build dim '────────'"
+  assert_success
+  assert_equal "${output}" $'[build] \033[2m────────\033[0m'
+}
+
+@test "_log_plain with bold style + NO_COLOR=1 omits ANSI even with FORCE_COLOR=1" {
+  run --separate-stderr bash -c "NO_COLOR=1 FORCE_COLOR=1 source ${LIB}; NO_COLOR=1 FORCE_COLOR=1 _log_plain build bold 'header'"
+  assert_success
+  assert_equal "${output}" "[build] header"
+}
+
+@test "_log_plain on non-TTY without FORCE_COLOR omits ANSI" {
+  run --separate-stderr bash -c "source ${LIB}; _log_plain build bold 'header'"
+  assert_success
+  assert_equal "${output}" "[build] header"
+}
+
+@test "_log_plain joins multi-token message with single spaces" {
+  run --separate-stderr bash -c "source ${LIB}; _log_plain build '' word1 word2 word3"
+  assert_success
+  assert_equal "${output}" "[build] word1 word2 word3"
+}
+
+@test "_log_plain with no tag exits non-zero (param ':?' guard)" {
+  run -127 bash -c "source ${LIB}; _log_plain"
+}
+
+@test "_log_plain with unknown style + FORCE_COLOR=1 falls back to no ANSI (case match miss)" {
+  run --separate-stderr bash -c "FORCE_COLOR=1 source ${LIB}; FORCE_COLOR=1 _log_plain build invalid 'msg'"
+  assert_success
+  assert_equal "${output}" "[build] msg"
+}


### PR DESCRIPTION
## Summary

- Adds `_log_plain <tag> <style> <msg...>` helper to `lib/log.sh` — tagged stdout WITHOUT a level keyword. ANSI-wraps the message body iff `_log_color_enabled 1` is true AND `<style>` is non-empty (`bold` / `dim`). Reuses the existing NO_COLOR / FORCE_COLOR / TTY auto-detect gate shared with `_log_err` / `_log_warn` / `_log_info`.
- Routes `_print_config_summary`'s two `────` dividers through `_log_plain ... dim` and the five section headers (`Files` / `Identity` / `Variables` / `setup.conf` / `Resolved`) through `_log_plain ... bold`.
- Closes the long tail of #278 — config_summary was the fourth / last migration batch from the original issue body that did not happen. Closes #309.

## Visual result

On a TTY the eye lands on structure (dividers de-emphasized via dim, section headers bolded). Piped / `NO_COLOR=1` output is byte-identical to before — the `[<tag>] ` prefix and indented value lines stay unstyled, so grep-based filters on the tag are unaffected; only the message bytes between divider / header positions change.

## Test plan

- [x] `test/unit/log_spec.bats` +8 cases: `_log_plain` prefix shape, bold / dim ANSI wrap with FORCE_COLOR, NO_COLOR precedence over FORCE_COLOR, non-TTY default off, multi-token join, required-tag `:?` guard, unknown-style safe fallback.
- [x] `test/unit/lib_spec.bats` +2 cases: end-to-end FORCE_COLOR assertion on `_print_config_summary` (dividers wrapped in `\033[2m`, all five section headers wrapped in `\033[1m`, indented value lines stay unstyled), and NO_COLOR-strips-all-ANSI assertion.
- [x] `make -f Makefile.ci test` in Docker: **1099 unit + 56 integration = 1155 tests** + ShellCheck + Hadolint all green.
- [x] TEST.md totals + per-file rows synced (`lib_spec.bats` 41→43, `log_spec.bats` 17→25, overall 1145→1155).
- [x] CHANGELOG `[Unreleased]` `### Changed` entry added.

## Files

| File | Change |
|---|---|
| `script/docker/lib/log.sh` | +25 lines — `_log_plain` helper |
| `script/docker/lib/config_summary.sh` | explicit `source log.sh` for safety + 7 `printf` → `_log_plain` (2 dividers + 5 section headers) |
| `test/unit/log_spec.bats` | +50 — 8 `_log_plain` cases |
| `test/unit/lib_spec.bats` | +40 — 2 ANSI integration cases |
| `doc/changelog/CHANGELOG.md` | `[Unreleased] ### Changed` entry |
| `doc/test/TEST.md` | counts + new rows |
