### PR TITLE
feat(scripts): -v / -vv flag on all 4 wrappers (BUILDKIT_PROGRESS=plain) (closes #311)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `self-test.yaml`: `actionlint` job (Docker invocation, `rhysd/actionlint:1.7.7` pinned) running before the existing `test` / `integration-e2e` / `behavioural` jobs, which now declare `needs: actionlint`. Catches GHA workflow-validator semantic regressions (e.g. `${{ matrix.X }}` referenced outside a step scope — the class behind the v0.26.0-rc1 wedge fixed by #297) at PR time before bats / docker matrix burns CI minutes. No new third-party GHA action dependency (Docker pull, in line with the #273 Phase 2 "no `dorny/paths-filter` dependency" preference). Closes #305.
+- `script/docker/{build,run,exec,stop}.sh`: `-v` / `--verbose` and `-vv` / `--very-verbose` flags. `-v` exports `BUILDKIT_PROGRESS=plain` so a hung `docker build` step's real-time stdout/stderr is visible instead of the collapsed single-line progress UI (the common diagnostic scenario when a build appears stuck and the user cannot tell whether it is doing work, waiting on network, or hung). `-vv` adds `set -x` on the wrapper itself for debugging the wrapper's own option parsing / branching. All four wrappers accept both spellings for muscle-memory consistency, even though `BUILDKIT_PROGRESS` is only meaningful when a build actually happens (build.sh always, run.sh via Compose auto-build; exec.sh / stop.sh accept the flag but it is a no-op there). Usage text in all four languages (en / zh-TW / zh-CN / ja) documents both forms. Closes #311.
 
 ### Changed
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1155 tests** total (1099 unit + 56 integration).
+Template self-tests: **1171 tests** total (1115 unit + 56 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -234,7 +234,7 @@ caught early — before bats / docker matrix burns CI minutes.
 | `integration-e2e` job declares `needs: actionlint` | 1 |
 | `behavioural` job declares `needs: actionlint` | 1 |
 
-### test/unit/build_sh_spec.bats (46)
+### test/unit/build_sh_spec.bats (50)
 
 Unit tests for `build.sh` argument handling and control flow. Uses a
 sandbox tree mirroring the expected layout (build.sh + `template/` subtree
@@ -257,9 +257,12 @@ languages via the local `_msg()` table; English remains the default),
 and **`-C` / `--chdir` flag** (docker_harness#53: pre-pass overrides
 FILE_PATH to redirect the wrapper to a different repo, both short and
 long form, value-required and directory-existence guards, usage help
-mention).
+mention), and **`-v` / `--verbose` / `-vv` / `--very-verbose` flag**
+(#311: exports `BUILDKIT_PROGRESS=plain` so a hung `docker build`'s RUN
+step output is visible; `-vv` adds `set -x` on the wrapper itself;
+usage help mentions all four spellings).
 
-### test/unit/run_sh_spec.bats (46)
+### test/unit/run_sh_spec.bats (50)
 
 Unit tests for `run.sh`. Mirrors the build_sh_spec.bats harness;
 `docker ps` reads from a controllable stub file so tests can simulate
@@ -278,9 +281,11 @@ present → silent, image absent + TTY → INFO, image absent + no TTY →
 silent, per-target image inspect, `--build` invokes `./build.sh test`
 before compose up, `--build` after check-drift), and **`-C` / `--chdir`
 flag** (docker_harness#53: redirect FILE_PATH, short + long form,
-value-required and directory guards, usage help mention).
+value-required and directory guards, usage help mention), and **`-v`
+/ `--verbose` / `-vv` / `--very-verbose` flag** (#311: same export +
+trace pattern as build.sh, parity across wrappers).
 
-### test/unit/exec_sh_spec.bats (28)
+### test/unit/exec_sh_spec.bats (32)
 
 Unit tests for `exec.sh` argument parsing, the container-running
 precheck, and i18n. Sandbox tree mirrors build_sh_spec.bats;
@@ -301,9 +306,12 @@ for run.sh parity, no-`--` positional path stays backward-compatible,
 `template/` is absent, and **`-C` / `--chdir` flag**
 (docker_harness#53: redirect FILE_PATH so .env / project name come
 from the alt repo, short + long form, value-required and directory
-guards, usage help mention).
+guards, usage help mention), and **`-v` / `--verbose` / `-vv` /
+`--very-verbose` flag** (#311: symmetry-only for exec since
+`docker exec` itself does not build, but flag is accepted and `-vv`
+enables wrapper trace).
 
-### test/unit/stop_sh_spec.bats (21)
+### test/unit/stop_sh_spec.bats (25)
 
 Unit tests for `stop.sh` argument parsing, the `--all` multi-instance
 teardown, and i18n. `docker ps -a` output is PATH-shimmed via
@@ -315,10 +323,12 @@ validation, default teardown via `docker compose down`, named-instance
 suffix in project name, `--all` no-instances English message,
 Chinese / Simplified Chinese / Japanese translations of the
 no-instances message, `--all` multi-project teardown loop, fallback
-`_detect_lang` branches, and **`-C` / `--chdir` flag**
+`_detect_lang` branches, **`-C` / `--chdir` flag**
 (docker_harness#53: redirect FILE_PATH so .env / project name come
 from the alt repo, short + long form, value-required and directory
-guards, usage help mention).
+guards, usage help mention), and **`-v` / `--verbose` / `-vv` /
+`--very-verbose` flag** (#311: parity across wrappers; flag is a no-op
+for `docker compose down` but `-vv` still enables wrapper trace).
 
 ### test/unit/wrapper_lib_lookup_spec.bats (5)
 

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -102,7 +102,7 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
+用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
 
 選項:
   -h, --help     顯示此說明
@@ -117,6 +117,11 @@ usage() {
   --no-cache     強制不使用 cache 重建
   --clean-tools  build 結束後移除 test-tools:local image（預設保留以加速下次 build）
   --dry-run      只印出將執行的 docker 指令，不實際執行
+  -v, --verbose  詳細 docker 輸出（BUILDKIT_PROGRESS=plain）。build 卡住時用 —
+                 即時顯示每個 RUN 步驟的 stdout/stderr，不再收斂成單行進度條。
+  -vv, --very-verbose
+                 -v 再加 wrapper 本身的 bash trace（set -x），用於除錯 wrapper
+                 邏輯（少用；通常 -v 就夠了）。
   --lang LANG    設定訊息語言（預設: en）
   -t, --target TARGET
                  指定建置目標（等同於位置參數 [TARGET]，與 run.sh -t 對齊）。
@@ -130,7 +135,7 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
+用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
 
 选项:
   -h, --help     显示此说明
@@ -145,6 +150,11 @@ EOF
   --no-cache     强制不使用 cache 重建
   --clean-tools  build 结束后移除 test-tools:local image（默认保留以加速下次 build）
   --dry-run      只打印将执行的 docker 命令，不实际执行
+  -v, --verbose  详细 docker 输出（BUILDKIT_PROGRESS=plain）。build 卡住时用 —
+                 实时显示每个 RUN 步骤的 stdout/stderr，不再收敛成单行进度条。
+  -vv, --very-verbose
+                 -v 再加 wrapper 本身的 bash trace（set -x），用于调试 wrapper
+                 逻辑（少用；通常 -v 就够了）。
   --lang LANG    设置消息语言（默认: en）
   -t, --target TARGET
                  指定构建目标（等同于位置参数 [TARGET]，与 run.sh -t 对齐）。
@@ -158,7 +168,7 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
+使用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
 
 オプション:
   -h, --help     このヘルプを表示
@@ -174,6 +184,12 @@ EOF
   --no-cache     キャッシュを使わず強制リビルド
   --clean-tools  build 終了後に test-tools:local image を削除（デフォルトは保持）
   --dry-run      実行される docker コマンドを表示するのみ（実行はしない）
+  -v, --verbose  docker の詳細出力（BUILDKIT_PROGRESS=plain）。build がハング
+                 した時に使用 — 各 RUN ステップの stdout/stderr をリアルタイム
+                 表示し、単一行プログレスバーに畳まれません。
+  -vv, --very-verbose
+                 -v に加え wrapper 自体の bash trace（set -x）。wrapper ロジック
+                 のデバッグ用（稀；通常は -v で十分）。
   --lang LANG    メッセージ言語を設定（デフォルト: en）
   -t, --target TARGET
                  ビルドターゲットを指定（位置引数 [TARGET] と同義、run.sh -t と整合）。
@@ -187,7 +203,7 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
+Usage: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
 
 Options:
   -h, --help     Show this help
@@ -206,6 +222,14 @@ Options:
   --no-cache     Force rebuild without cache
   --clean-tools  Remove test-tools:local image after build (default: keep for faster next build)
   --dry-run      Print the docker commands that would run, but do not execute
+  -v, --verbose  Verbose docker output (BUILDKIT_PROGRESS=plain). Use when a
+                 build appears hung — surfaces every RUN step's real-time
+                 stdout/stderr instead of the collapsed single-line progress
+                 UI.
+  -vv, --very-verbose
+                 -v plus bash trace (set -x) on the wrapper itself. For
+                 debugging the wrapper's own logic (rare; -v is usually
+                 enough).
   --lang LANG    Set message language (default: en)
   -t, --target TARGET
                  Build target (alias for the positional [TARGET], mirrors
@@ -281,6 +305,23 @@ main() {
         ;;
       --dry-run)
         DRY_RUN=true
+        shift
+        ;;
+      -v|--verbose)
+        # Surface every RUN step's real-time stdout/stderr in docker
+        # build, instead of the collapsed BuildKit progress UI.
+        # https://docs.docker.com/build/building/variables/#progress
+        # Use when a build appears hung to distinguish "still doing
+        # work" from "waiting on network / something else". Closes #311.
+        export BUILDKIT_PROGRESS=plain
+        shift
+        ;;
+      -vv|--very-verbose)
+        # -v plus bash trace on the wrapper itself. For debugging the
+        # wrapper's own option parsing / branching (rare; -v is enough
+        # for diagnosing a hung docker build).
+        export BUILDKIT_PROGRESS=plain
+        set -x
         shift
         ;;
       --lang)

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -85,7 +85,7 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [--] [CMD...]
+用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG] [--] [CMD...]
 
 選項:
   -h, --help        顯示此說明
@@ -95,6 +95,10 @@ usage() {
   --instance NAME   進入命名 instance（預設為 default instance）
   --lang LANG       設定訊息語言（預設: en）
   --dry-run         只印出將執行的 docker 指令，不實際執行
+  -v, --verbose     設定 BUILDKIT_PROGRESS=plain（與其他 wrapper 對齊；docker exec
+                    本身不會 build，但保持 flag 一致便於肌肉記憶）。
+  -vv, --very-verbose
+                    -v 再加 wrapper 本身的 bash trace（set -x）。
   --                明確分隔 exec.sh 選項與 CMD（與 run.sh 對齊），讓 CMD 可以
                     用 dash 開頭（例：./exec.sh -- my-tool --version）
 
@@ -111,7 +115,7 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [--] [CMD...]
+用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG] [--] [CMD...]
 
 选项:
   -h, --help        显示此说明
@@ -121,6 +125,10 @@ EOF
   --instance NAME   进入命名 instance（默认为 default instance）
   --lang LANG       设置消息语言（默认: en）
   --dry-run         只打印将执行的 docker 命令，不实际执行
+  -v, --verbose     设置 BUILDKIT_PROGRESS=plain（与其他 wrapper 对齐；docker exec
+                    本身不会 build，但保持 flag 一致便于肌肉记忆）。
+  -vv, --very-verbose
+                    -v 再加 wrapper 本身的 bash trace（set -x）。
   --                明确分隔 exec.sh 选项与 CMD（与 run.sh 对齐），让 CMD 可以
                     以 dash 开头（例：./exec.sh -- my-tool --version）
 
@@ -137,7 +145,7 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [--] [CMD...]
+使用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG] [--] [CMD...]
 
 オプション:
   -h, --help        このヘルプを表示
@@ -147,6 +155,10 @@ EOF
   --instance NAME   名前付き instance に入る（デフォルトは default instance）
   --lang LANG       メッセージ言語を設定（デフォルト: en）
   --dry-run         実行される docker コマンドを表示するのみ（実行はしない）
+  -v, --verbose     BUILDKIT_PROGRESS=plain を設定（他の wrapper と整合；
+                    docker exec 自体は build しないが、フラグの一貫性のため）。
+  -vv, --very-verbose
+                    -v に加え wrapper 自体の bash trace（set -x）。
   --                exec.sh のオプションと CMD を明示的に区切る（run.sh と整合）。
                     dash で始まる CMD を渡す場合に使う（例: ./exec.sh -- my-tool --version）
 
@@ -163,7 +175,7 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [--lang LANG] [--] [CMD...]
+Usage: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG] [--] [CMD...]
 
 Options:
   -h, --help        Show this help
@@ -173,6 +185,12 @@ Options:
   --instance NAME   Enter a named instance (default: default instance)
   --lang LANG       Set message language (default: en)
   --dry-run         Print the docker commands that would run, but do not execute
+  -v, --verbose     Export BUILDKIT_PROGRESS=plain for parity with build/run/stop.
+                    `docker exec` itself does not build, but keeping the flag
+                    available across all four wrappers gives one muscle-memory
+                    knob to reach for.
+  -vv, --very-verbose
+                    -v plus bash trace (set -x) on the wrapper itself.
   --                Explicit flag/CMD separator, mirroring run.sh. Lets the CMD
                     start with a dash (e.g. ./exec.sh -- my-tool --version).
 
@@ -229,6 +247,20 @@ main() {
         ;;
       --dry-run)
         DRY_RUN=true
+        shift
+        ;;
+      -v|--verbose)
+        # BUILDKIT_PROGRESS=plain — symmetry with build/run/stop (#311).
+        # No-op for `docker exec` itself but harmless; useful for grep-
+        # based discovery ("does this wrapper take -v? yes") and for the
+        # rare case of `exec.sh` triggering a compose build via `--build`
+        # in a future flag.
+        export BUILDKIT_PROGRESS=plain
+        shift
+        ;;
+      -vv|--very-verbose)
+        export BUILDKIT_PROGRESS=plain
+        set -x
         shift
         ;;
       --lang)

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -134,6 +134,7 @@ usage() {
     zh-TW)
       cat >&2 <<'EOF'
 用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
+              [-v|--verbose] [-vv|--very-verbose]
               [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
               [-t|--target TARGET] [CMD...]
 
@@ -149,6 +150,10 @@ usage() {
                     取得本機 / CI 一致驗證；預設行為依賴 compose auto-build
                     時會跳過 lint+smoke gate (#216)
   --dry-run         只印出將執行的 docker 指令，不實際執行
+  -v, --verbose     詳細 docker 輸出（BUILDKIT_PROGRESS=plain）。compose 自動 build
+                    卡住時用 — 顯示每個 RUN 步驟即時輸出，不再收斂成單行進度條。
+  -vv, --very-verbose
+                    -v 再加 wrapper 本身的 bash trace（set -x）。
   --instance NAME   啟動命名 instance（與預設並行,suffix=-NAME）
   --lang LANG       設定訊息語言（預設: en）
 
@@ -160,6 +165,7 @@ EOF
     zh-CN)
       cat >&2 <<'EOF'
 用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
+              [-v|--verbose] [-vv|--very-verbose]
               [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
               [-t|--target TARGET] [CMD...]
 
@@ -175,6 +181,10 @@ EOF
                     取得本机 / CI 一致验证；默认行为依赖 compose auto-build
                     时会跳过 lint+smoke gate (#216)
   --dry-run         只打印将执行的 docker 命令，不实际执行
+  -v, --verbose     详细 docker 输出（BUILDKIT_PROGRESS=plain）。compose 自动 build
+                    卡住时用 — 显示每个 RUN 步骤实时输出，不再收敛成单行进度条。
+  -vv, --very-verbose
+                    -v 再加 wrapper 本身的 bash trace（set -x）。
   --instance NAME   启动命名 instance（与默认并行,suffix=-NAME）
   --lang LANG       设置消息语言（默认: en）
 
@@ -186,6 +196,7 @@ EOF
     ja)
       cat >&2 <<'EOF'
 使用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
+               [-v|--verbose] [-vv|--very-verbose]
                [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
                [-t|--target TARGET] [CMD...]
 
@@ -203,6 +214,11 @@ EOF
                     compose auto-build に依存しており、lint + smoke gate を
                     スキップします (#216)
   --dry-run         実行される docker コマンドを表示するのみ（実行はしない）
+  -v, --verbose     docker の詳細出力（BUILDKIT_PROGRESS=plain）。compose 自動
+                    build がハングした時に使用 — 各 RUN ステップの stdout/stderr
+                    をリアルタイム表示。
+  -vv, --very-verbose
+                    -v に加え wrapper 自体の bash trace（set -x）。
   --instance NAME   名前付き instance を起動（デフォルトと並行、suffix=-NAME）
   --lang LANG       メッセージ言語を設定（デフォルト: en）
 
@@ -214,6 +230,7 @@ EOF
     *)
       cat >&2 <<'EOF'
 Usage: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
+               [-v|--verbose] [-vv|--very-verbose]
                [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
                [-t|--target TARGET] [CMD...]
 
@@ -230,6 +247,12 @@ Options:
                     so local matches CI; default path relies on Compose
                     auto-build which skips the lint + smoke gate (#216)
   --dry-run         Print the docker commands that would run, but do not execute
+  -v, --verbose     Verbose docker output (BUILDKIT_PROGRESS=plain). Use when
+                    compose's auto-build appears hung — surfaces each RUN
+                    step's real-time stdout/stderr instead of the collapsed
+                    single-line progress UI.
+  -vv, --very-verbose
+                    -v plus bash trace (set -x) on the wrapper itself.
   --instance NAME   Start a named parallel instance (suffix=-NAME)
   --lang LANG       Set message language (default: en)
 
@@ -303,6 +326,17 @@ main() {
         ;;
       --dry-run)
         DRY_RUN=true
+        shift
+        ;;
+      -v|--verbose)
+        # BUILDKIT_PROGRESS=plain — verbose docker output. Use when
+        # compose's auto-build appears hung (closes #311).
+        export BUILDKIT_PROGRESS=plain
+        shift
+        ;;
+      -vv|--very-verbose)
+        export BUILDKIT_PROGRESS=plain
+        set -x
         shift
         ;;
       --instance)

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -71,7 +71,7 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
+用法: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG]
 
 停止並移除容器。預設只停止 default instance。
 
@@ -82,11 +82,15 @@ usage() {
   -a, --all         停止所有 instance（預設 + 全部命名 instance)
   --lang LANG       設定訊息語言（預設: en）
   --dry-run         只印出將執行的 docker 指令，不實際執行
+  -v, --verbose     設定 BUILDKIT_PROGRESS=plain（與其他 wrapper 對齊；stop 本身
+                    不會 build，但保持 flag 一致便於肌肉記憶）。
+  -vv, --very-verbose
+                    -v 再加 wrapper 本身的 bash trace（set -x）。
 EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
+用法: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG]
 
 停止并移除容器。默认只停止 default instance。
 
@@ -97,11 +101,15 @@ EOF
   -a, --all         停止所有 instance（默认 + 全部命名 instance)
   --lang LANG       设置消息语言（默认: en）
   --dry-run         只打印将执行的 docker 命令，不实际执行
+  -v, --verbose     设置 BUILDKIT_PROGRESS=plain（与其他 wrapper 对齐；stop 本身
+                    不会 build，但保持 flag 一致便于肌肉记忆）。
+  -vv, --very-verbose
+                    -v 再加 wrapper 本身的 bash trace（set -x）。
 EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
+使用法: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG]
 
 コンテナを停止・削除します。デフォルトは default instance のみ。
 
@@ -112,11 +120,15 @@ EOF
   -a, --all         すべての instance を停止（デフォルト + 全名前付き instance）
   --lang LANG       メッセージ言語を設定（デフォルト: en）
   --dry-run         実行される docker コマンドを表示するのみ（実行はしない）
+  -v, --verbose     BUILDKIT_PROGRESS=plain を設定（他の wrapper と整合；
+                    stop 自体は build しないが、フラグの一貫性のため）。
+  -vv, --very-verbose
+                    -v に加え wrapper 自体の bash trace（set -x）。
 EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [--lang LANG]
+Usage: ./stop.sh [-h] [-C|--chdir DIR] [--instance NAME] [-a|--all] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG]
 
 Stop and remove containers. Default: stop only the default instance.
 
@@ -128,6 +140,12 @@ Options:
   -a, --all         Stop ALL instances (default + every named instance)
   --lang LANG       Set message language (default: en)
   --dry-run         Print the docker commands that would run, but do not execute
+  -v, --verbose     Export BUILDKIT_PROGRESS=plain for parity with build/run/exec.
+                    `docker compose down` itself does not build, but keeping the
+                    flag available across all four wrappers gives one
+                    muscle-memory knob to reach for.
+  -vv, --very-verbose
+                    -v plus bash trace (set -x) on the wrapper itself.
 EOF
       ;;
   esac
@@ -187,6 +205,19 @@ main() {
         ;;
       --dry-run)
         DRY_RUN=true
+        shift
+        ;;
+      -v|--verbose)
+        # BUILDKIT_PROGRESS=plain — symmetry with build/run/exec (#311).
+        # No-op for `docker compose down` itself but harmless; keeps the
+        # flag available across all four wrappers for muscle-memory
+        # consistency.
+        export BUILDKIT_PROGRESS=plain
+        shift
+        ;;
+      -vv|--very-verbose)
+        export BUILDKIT_PROGRESS=plain
+        set -x
         shift
         ;;
       --lang)

--- a/test/unit/build_sh_spec.bats
+++ b/test/unit/build_sh_spec.bats
@@ -660,3 +660,34 @@ EOS
   assert_output --partial "-C"
   assert_output --partial "--chdir"
 }
+
+# ════════════════════════════════════════════════════════════════════
+# -v / --verbose / -vv / --very-verbose (BUILDKIT_PROGRESS=plain, #311)
+# ════════════════════════════════════════════════════════════════════
+
+@test "build.sh -v / --verbose / -vv / --very-verbose are mentioned in usage help (#311)" {
+  run bash "${SANDBOX}/build.sh" --help
+  assert_success
+  assert_output --partial "-v, --verbose"
+  assert_output --partial "-vv, --very-verbose"
+  assert_output --partial "BUILDKIT_PROGRESS=plain"
+}
+
+@test "build.sh -v --dry-run is accepted and exits 0 (#311)" {
+  run bash "${SANDBOX}/build.sh" -v --dry-run
+  assert_success
+}
+
+@test "build.sh --verbose long form is accepted (#311)" {
+  run bash "${SANDBOX}/build.sh" --verbose --dry-run
+  assert_success
+}
+
+@test "build.sh -vv --dry-run enables bash trace (set -x output on stderr) (#311)" {
+  run --separate-stderr bash "${SANDBOX}/build.sh" -vv --dry-run
+  assert_success
+  # set -x emits trace lines starting with `+ ` to stderr. After the case
+  # branch fires the wrapper continues hitting other lines that all get
+  # traced.
+  [[ "${stderr}" == *"+ "* ]]
+}

--- a/test/unit/exec_sh_spec.bats
+++ b/test/unit/exec_sh_spec.bats
@@ -304,3 +304,31 @@ teardown() {
   assert_output --partial "-C"
   assert_output --partial "--chdir"
 }
+
+# ════════════════════════════════════════════════════════════════════
+# -v / --verbose / -vv / --very-verbose (BUILDKIT_PROGRESS=plain, #311)
+# ════════════════════════════════════════════════════════════════════
+
+@test "exec.sh -v / --verbose / -vv / --very-verbose are mentioned in usage help (#311)" {
+  run bash "${SANDBOX}/exec.sh" --help
+  assert_success
+  assert_output --partial "-v, --verbose"
+  assert_output --partial "-vv, --very-verbose"
+  assert_output --partial "BUILDKIT_PROGRESS=plain"
+}
+
+@test "exec.sh -v --dry-run is accepted and exits 0 (#311)" {
+  run bash "${SANDBOX}/exec.sh" -v --dry-run
+  assert_success
+}
+
+@test "exec.sh --verbose long form is accepted (#311)" {
+  run bash "${SANDBOX}/exec.sh" --verbose --dry-run
+  assert_success
+}
+
+@test "exec.sh -vv --dry-run enables bash trace (set -x output on stderr) (#311)" {
+  run --separate-stderr bash "${SANDBOX}/exec.sh" -vv --dry-run
+  assert_success
+  [[ "${stderr}" == *"+ "* ]]
+}

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -702,3 +702,31 @@ EOS
   assert_output --partial "-C"
   assert_output --partial "--chdir"
 }
+
+# ════════════════════════════════════════════════════════════════════
+# -v / --verbose / -vv / --very-verbose (BUILDKIT_PROGRESS=plain, #311)
+# ════════════════════════════════════════════════════════════════════
+
+@test "run.sh -v / --verbose / -vv / --very-verbose are mentioned in usage help (#311)" {
+  run bash "${SANDBOX}/run.sh" --help
+  assert_success
+  assert_output --partial "-v, --verbose"
+  assert_output --partial "-vv, --very-verbose"
+  assert_output --partial "BUILDKIT_PROGRESS=plain"
+}
+
+@test "run.sh -v --dry-run is accepted and exits 0 (#311)" {
+  run bash "${SANDBOX}/run.sh" -v --dry-run
+  assert_success
+}
+
+@test "run.sh --verbose long form is accepted (#311)" {
+  run bash "${SANDBOX}/run.sh" --verbose --dry-run
+  assert_success
+}
+
+@test "run.sh -vv --dry-run enables bash trace (set -x output on stderr) (#311)" {
+  run --separate-stderr bash "${SANDBOX}/run.sh" -vv --dry-run
+  assert_success
+  [[ "${stderr}" == *"+ "* ]]
+}

--- a/test/unit/stop_sh_spec.bats
+++ b/test/unit/stop_sh_spec.bats
@@ -248,3 +248,31 @@ teardown() {
   assert_output --partial "-C"
   assert_output --partial "--chdir"
 }
+
+# ════════════════════════════════════════════════════════════════════
+# -v / --verbose / -vv / --very-verbose (BUILDKIT_PROGRESS=plain, #311)
+# ════════════════════════════════════════════════════════════════════
+
+@test "stop.sh -v / --verbose / -vv / --very-verbose are mentioned in usage help (#311)" {
+  run bash "${SANDBOX}/stop.sh" --help
+  assert_success
+  assert_output --partial "-v, --verbose"
+  assert_output --partial "-vv, --very-verbose"
+  assert_output --partial "BUILDKIT_PROGRESS=plain"
+}
+
+@test "stop.sh -v --dry-run is accepted and exits 0 (#311)" {
+  run bash "${SANDBOX}/stop.sh" -v --dry-run
+  assert_success
+}
+
+@test "stop.sh --verbose long form is accepted (#311)" {
+  run bash "${SANDBOX}/stop.sh" --verbose --dry-run
+  assert_success
+}
+
+@test "stop.sh -vv --dry-run enables bash trace (set -x output on stderr) (#311)" {
+  run --separate-stderr bash "${SANDBOX}/stop.sh" -vv --dry-run
+  assert_success
+  [[ "${stderr}" == *"+ "* ]]
+}


### PR DESCRIPTION
## Summary

- Adds `-v` / `--verbose` and `-vv` / `--very-verbose` to all four wrappers (`build.sh` / `run.sh` / `exec.sh` / `stop.sh`).
- `-v` exports `BUILDKIT_PROGRESS=plain` — surfaces every RUN step's real-time stdout/stderr in `docker build`, replacing the collapsed single-line progress UI. Use when a build appears hung to distinguish "still doing work" from "waiting on network / hung".
- `-vv` additionally enables `set -x` on the wrapper itself for debugging the wrapper's own option parsing / branching.
- All four wrappers accept the flag for muscle-memory consistency, even though `BUILDKIT_PROGRESS` is only meaningful when a build actually happens (build.sh always, run.sh via Compose auto-build; exec.sh / stop.sh accept but no-op).
- Closes #311.

## Why

The default BuildKit progress UI collapses long-running RUN steps into a single line with a ticking timer, so a user cannot tell whether the build is doing actual work, waiting on network (apt mirror / ghcr.io pull / alpine apk fetch), or hung. `BUILDKIT_PROGRESS=plain` is the [documented Docker env var](https://docs.docker.com/build/building/variables/#progress) that surfaces every step's real-time output. Previously users had to know the env var name and re-invoke; now `-v` on the wrapper does it transparently.

Triggered concretely by a `ros1_bridge ./build.sh --no-cache` session today where the test-tools image's `apk add` was waiting on a slow alpine mirror — only diagnosable by killing it and re-invoking with `BUILDKIT_PROGRESS=plain`. With `-v`, that diagnostic step is built in.

## Test plan

- [x] Per wrapper spec (`build_sh_spec` / `run_sh_spec` / `exec_sh_spec` / `stop_sh_spec`), +4 cases:
  - Usage help mentions `-v, --verbose` / `-vv, --very-verbose` / `BUILDKIT_PROGRESS=plain`
  - `<wrapper> -v --dry-run` accepted, exits 0
  - `<wrapper> --verbose --dry-run` long form accepted
  - `<wrapper> -vv --dry-run` emits `set -x` trace (`+ ...`) on stderr
- [x] `make -f Makefile.ci test` in Docker: **1115 unit + 56 integration = 1171 tests** + ShellCheck + Hadolint all green.
- [x] Usage text updated in all four languages (en / zh-TW / zh-CN / ja) across all four wrapper scripts, mirroring the existing `-C` / `--chdir` documentation pattern.
- [x] TEST.md totals + per-file counts synced (build/run 46→50, exec 28→32, stop 21→25, overall 1155→1171).
- [x] CHANGELOG `[Unreleased]` `### Added` entry added.

## Files

| File | Change |
|---|---|
| `script/docker/build.sh` | +49 — parser case + 4-language usage |
| `script/docker/run.sh` | +34 — parser case + 4-language usage |
| `script/docker/exec.sh` | +40 — parser case + 4-language usage |
| `script/docker/stop.sh` | +39 — parser case + 4-language usage |
| `test/unit/build_sh_spec.bats` | +31 — 4 cases |
| `test/unit/run_sh_spec.bats` | +28 — 4 cases |
| `test/unit/exec_sh_spec.bats` | +28 — 4 cases |
| `test/unit/stop_sh_spec.bats` | +28 — 4 cases |
| `doc/changelog/CHANGELOG.md` | `[Unreleased] ### Added` entry |
| `doc/test/TEST.md` | counts + per-spec rows synced |
