### PR TITLE
ci(self-test): harden classify job fail-open + base ref fetch (#317 P1 follow-up)

### DIFF
--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -56,14 +56,32 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
+        # `-e` is intentionally omitted. The `test` job is the only branch-
+        # protection-required check, and the chain `test needs classify`
+        # means any non-zero exit here blocks every PR merge (Q4 fail-closed
+        # chain — see issue #317). Failing open by treating diff errors as
+        # "differences exist" (handled naturally by the `if git diff` form,
+        # which routes any non-zero exit to the else branch) costs at most
+        # one needless full-suite run on a misclassified doc-only PR — far
+        # cheaper than wedging the merge queue.
         run: |
-          set -euo pipefail
+          set -uo pipefail
           if [[ "${EVENT_NAME}" != "pull_request" ]]; then
             # push to main / tag push / workflow_dispatch — full suite.
             echo "code_changed=true" >> "${GITHUB_OUTPUT}"
             echo "behavioural_relevant=true" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
+          # Fork PRs (and some squash-merged histories) reach this step
+          # without the base ref present in the local repo: actions/checkout
+          # with `fetch-depth: 0` fetches the head branch's full history but
+          # does NOT fetch the base. Pre-fetch defensively; `|| true` lets
+          # us continue even if the fetch fails, because the diff below
+          # will then return non-zero and the `if` falls through to the
+          # fail-open path.
+          git fetch origin \
+            "${BASE_REF}:refs/remotes/origin/${BASE_REF}" \
+            --depth=200 >/dev/null 2>&1 || true
           BASE="origin/${BASE_REF}"
           # code_changed: anything outside the doc-only allow-list.
           if git diff --quiet "${BASE}"...HEAD \

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `.github/workflows/self-test.yaml`: harden `classify` job against latent fail-closed and fork-PR breakage (#317 P1 follow-up). The job's required-check chain (`test` needs `classify`) means any non-zero exit here wedges every PR merge (Q4 fail-closed design). Two robustness changes: (1) `set -uo pipefail` instead of `set -euo pipefail` so transient diff/fetch errors fall through the `if git diff --quiet` form to the existing "differences exist" branch (emits `code_changed=true` / `behavioural_relevant=true` rather than aborting the job); (2) explicit `git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --depth=200 || true` before the diff so fork PRs (where `actions/checkout@v6` `fetch-depth: 0` only fetches the head branch, not the base) don't trip on `origin/<base>` being absent locally. Worst case after this change: a misclassified doc-only PR burns one full-suite run instead of blocking the merge queue.
+
 ## [v0.28.1] - 2026-05-14
 
 Patch release bundling 4 closed-issue PRs since v0.28.0: 2 fixes (#322 multi-user container_name collision, #321 SSH X11 forwarding) + 1 feature (#319 prune.sh + stop.sh --prune for docker garbage cleanup) + 1 internal CI improvement (#317 P1 buildx GHA cache + doc-only classifier short-circuit). No new MINOR features; the prune.sh wrapper is opt-in utility tooling consistent with the existing build/run/exec/stop pattern. No breaking changes from v0.28.0 — but #322 has a one-shot orphan-container cleanup caveat (see entry below); existing running instances need a manual `docker stop <name> && docker rm <name>` or `./prune.sh --all` once.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1233 tests** total (1177 unit + 56 integration).
+Template self-tests: **1235 tests** total (1179 unit + 56 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -215,10 +215,10 @@ on doc-only PRs).
 | #272 GHA buildx cache: `cache_variant` input declared with empty default, `Compute cache scope` step emits `id: cache` + scope key into `GITHUB_OUTPUT`, 4 build steps set `cache-from: type=gha,scope=...`, 4 build steps set `cache-to: ...,mode=max`, default preserves zero-diff for single-call callers | 5 |
 | #273 doc-only PR fast-pass (Phase 1 + Phase 2 shell rewrite): `path-filter` job declared, classifier is pure shell (`git diff --name-only base...head` + `case` glob; no `dorny/paths-filter` dependency), reads EVENT_NAME / BASE_SHA / HEAD_SHA from env: keys so the case body stays portable, non-PR event short-circuits before git diff (BASE_SHA / HEAD_SHA empty on push / tag / workflow_dispatch), 6-path allowlist (`**/*.md`, `doc/**`, `LICENSE`, `.gitignore`, `.github/CODEOWNERS`, `.github/dependabot.yml`) in a single `case` arm, `compute-matrix` + `build` jobs gated on `code_changed == 'true'` (2 occurrences), `docker-build` aggregator handles `code_changed == 'false'` short-circuit + `needs: [path-filter, build]`, non-PR triggers always set `code_changed=true` | 8 |
 
-### test/unit/self_test_yaml_spec.bats (17)
+### test/unit/self_test_yaml_spec.bats (19)
 
 Structural assertions for `.github/workflows/self-test.yaml`. Locks
-two cumulative invariants:
+three cumulative invariants:
 
 1. **#305 actionlint gate** — `actionlint` job declared, runs
    `rhysd/actionlint` via Docker pinned to an explicit version
@@ -238,6 +238,14 @@ two cumulative invariants:
    `docker/build-push-action` with shared `scope=test-tools` GHA
    cache.
 
+3. **#317 P1 follow-up classifier hardening** — `classify` job is
+   fail-open: `set -uo pipefail` (no `-e`) so transient diff/fetch
+   errors don't crash the job and wedge every PR via the Q4
+   fail-closed chain. Explicit `git fetch origin` of the base ref
+   with `--depth=200` before diff so fork PRs (where
+   `actions/checkout@v6 fetch-depth: 0` only fetches the head
+   branch) don't trip on missing `origin/<base>`.
+
 | Category | Tests |
 |----------|-------|
 | `actionlint` job declared | 1 |
@@ -248,6 +256,7 @@ two cumulative invariants:
 | `test` doc-only short-circuit + real-step `code_changed == 'true'` gate | 2 |
 | `integration-e2e` + `behavioural` job-level `if: code_changed == 'true'` | 2 |
 | `test` + `behavioural` use `docker/build-push-action@v6` with `scope=test-tools` GHA cache | 2 |
+| `classify` fail-open (`set -uo pipefail`) + pre-fetch base ref (#317 gotcha-1/2) | 2 |
 
 ### test/unit/build_sh_spec.bats (50)
 

--- a/test/unit/self_test_yaml_spec.bats
+++ b/test/unit/self_test_yaml_spec.bats
@@ -91,6 +91,30 @@ setup() {
   assert_output --partial 'behavioural_relevant=true'
 }
 
+@test "self-test.yaml: classify omits set -e to fail-open on diff errors (#317 gotcha-1)" {
+  # The classifier must not abort the job on diff/fetch failure — the
+  # `test` job needs classify as a gate, and aborting here would block all
+  # PR merges (Q4 fail-closed chain). Verify `set -e` is not in effect by
+  # asserting `set -uo pipefail` (not `set -euo pipefail`) is used.
+  run awk '/^  classify:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'set -uo pipefail'
+  refute_output --partial 'set -euo pipefail'
+}
+
+@test "self-test.yaml: classify pre-fetches base ref before diff (#317 gotcha-2)" {
+  # actions/checkout `fetch-depth: 0` fetches the head branch's full
+  # history but NOT the base ref. Fork PRs (and some squash-merged
+  # histories) start without `origin/<base>` present locally; the
+  # classifier must pre-fetch it explicitly, with failure being non-fatal
+  # so the diff fall-through can still take over.
+  run awk '/^  classify:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'git fetch origin'
+  assert_output --partial '"${BASE_REF}:refs/remotes/origin/${BASE_REF}"'
+  assert_output --partial '|| true'
+}
+
 # ── Downstream jobs gate on actionlint + classify (#305 / #317) ───────
 
 @test "self-test.yaml: test job declares needs on actionlint AND classify (#317)" {


### PR DESCRIPTION
## Summary

Harden the `classify` job in `self-test.yaml` against two failure
modes that would wedge every PR merge via the Q4 fail-closed chain
defined in #317. P1 (PR #318) shipped the classifier but left these
edges unaddressed; this PR closes them before P2 lands more
workflow churn on top.

Refs #317 — gotcha 1 + gotcha 2 from the locked resolutions comment.

## What changes

### `.github/workflows/self-test.yaml` (classify job)

1. **Fail-open** — drop `-e` from `set -euo pipefail` → `set -uo pipefail`.
   The `test` job is the only branch-protection-required check, and it
   declares `needs: [actionlint, classify]`. Any non-zero exit from the
   classifier therefore prevents `test` from running, leaves the required
   status check missing, and blocks merge indefinitely. With `-e` off,
   transient diff/fetch errors fall through the existing `if git diff
   --quiet` form (which already routes any non-zero — both "files differ"
   and "diff errored" — to the else branch), emitting
   `code_changed=true` / `behavioural_relevant=true`. Worst case is one
   needless full-suite run on a misclassified doc-only PR — far cheaper
   than wedging the merge queue.

2. **Pre-fetch the base ref** — `actions/checkout@v6` with
   `fetch-depth: 0` fetches the **head** branch's full history but does
   NOT fetch the base. On fork PRs (and some squash-merged histories)
   `origin/${BASE_REF}` is therefore absent locally, and `git diff
   origin/main...HEAD` fails. Add an explicit
   `git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"
   --depth=200` before the diff. `|| true` makes the fetch non-fatal so
   the (1) fail-open path can still take over if the fetch itself errors.

### Tests

`test/unit/self_test_yaml_spec.bats` — 2 new assertions:

- "classify omits set -e to fail-open on diff errors (#317 gotcha-1)" —
  asserts `set -uo pipefail` is present and `set -euo pipefail` is not.
- "classify pre-fetches base ref before diff (#317 gotcha-2)" — asserts
  the `git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}"`
  line and the `|| true` tolerance are present.

Total `self_test_yaml_spec.bats` count: 17 → 19. Template self-tests
total: 1233 → 1235 (1177 → 1179 unit; integration unchanged at 56).

### Doc alignment

- `doc/test/TEST.md` — total bumped, section count 17 → 19, new
  "fail-open + pre-fetch base ref" row added to the category table, and
  a third invariant added to the section narrative.
- `doc/changelog/CHANGELOG.md` `[Unreleased]` — `### Changed` entry
  describing both robustness changes.

## Verification

- `docker run --rm rhysd/actionlint:1.7.7 .github/workflows/self-test.yaml`
  → exit 0, no findings.
- `make -f Makefile.ci test` → 1235/1235 green (1179 unit + 56
  integration), ShellCheck clean.

## Sequencing

Part of the locked 4-step plan in
[issue #317's resolutions comment](https://github.com/ycpss91255-docker/base/issues/317#issuecomment-4446504983)
and
[issue #325's B-1 decision comment](https://github.com/ycpss91255-docker/base/issues/325#issuecomment-4446504854):

1. **P1 follow-up (this PR)** — classifier fail-open + base ref fetch.
2. #317 P2 — `:main` rolling tag + 3-layer fallback + gotcha-3 paths
   filter.
3. #325 B-1 — `multi-distro-build-worker.yaml` dispatcher.
4. #317 P3 — behavioural job gated on `behavioural_relevant` + gotcha-5
   block-list expansion (`setup.sh`, `lib/**`, `i18n.sh`).
