### PR TITLE
docs(readme): three-namespace naming scheme (image / container / project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,82 @@ configuration. Both files are regenerated on every `make upgrade`
 (init.sh re-runs `setup.sh apply` after the subtree pull) — never
 hand-edit them; put your overrides in `setup.conf` instead.
 
+### Naming scheme: three namespaces, two user identities
+
+`setup.sh` emits three names in `.env` / `compose.yaml`. They look
+similar on a single-user dev machine, but they live in **three
+different namespaces** and pick their user prefix from **two
+different identities**. Sysadmins running shared hosts need to know
+the difference; solo developers can treat the two identities as the
+same and move on.
+
+| Name | Format | Namespace | User prefix |
+|---|---|---|---|
+| `image:` | `${DOCKER_HUB_USER:-local}/<repo>:<tag>` | **Registry** (Docker Hub) | `DOCKER_HUB_USER` |
+| `container_name:` | `${USER_NAME}-<repo>${INSTANCE_SUFFIX}` | **Host daemon** (per docker daemon, flat global) | `USER_NAME` (OS user, refs #322) |
+| compose project name | `${DOCKER_HUB_USER}-<repo>${INSTANCE_SUFFIX}` | **Host daemon** (drives default network / volume labels) | `DOCKER_HUB_USER` |
+
+- `DOCKER_HUB_USER` — your Docker Hub account, used to namespace
+  images on the registry side. Image tags are addressable as
+  `<DOCKER_HUB_USER>/<repo>:<tag>` whether or not you actually push.
+- `USER_NAME` — the OS user (from `id -un`), used to keep two OS
+  users on the same host from colliding on the daemon's flat
+  container-name namespace.
+
+The two identities are deliberately separate. Image names use the
+Docker Hub identity because images are addressable on the registry,
+and forcing per-OS-user image tags would shatter buildx cache reuse
+and Docker Hub layer sharing. Container names use the OS identity
+because the conflict it fixes (two users on the same host running
+the same repo) is a host-daemon problem with no registry component.
+
+Project-name choice of `DOCKER_HUB_USER` predates #322 and was kept
+unchanged: on a single-user dev machine the two identities coincide
+so the names line up visually with `container_name`; on a shared
+host the project name still avoids cross-user collision *because*
+`DOCKER_HUB_USER` happens to differ per user too. The `#322`
+CHANGELOG entry's phrasing "aligns container-level naming with
+project-level naming" is true under that single-user-machine
+assumption — both are user-prefixed, just via different vars — not
+literally the same prefix string in the multi-user case.
+
+**`INSTANCE_SUFFIX`** is the fourth dimension, orthogonal to the
+user split. Same OS user wants to run the same repo as multiple
+parallel containers (e.g. two branches side by side): set
+`INSTANCE_SUFFIX=2` and you get `alice-<repo>-2` /
+`alice-<repo>-2`-named project. Empty by default; bumped by the
+`-n / --instance` flag on the wrappers when applicable.
+
+Worked example. OS user `alice`, Docker Hub user `alice-hub`, repo
+`claude_code`, default `INSTANCE_SUFFIX` empty:
+
+```
+image:          alice-hub/claude_code:devel
+container_name: alice-claude_code
+project name:   alice-hub-claude_code
+```
+
+Same OS user, second instance (`INSTANCE_SUFFIX=2`):
+
+```
+image:          alice-hub/claude_code:devel        (unchanged — same image)
+container_name: alice-claude_code-2
+project name:   alice-hub-claude_code-2
+```
+
+A second OS user `bob` on the same host:
+
+```
+image:          bob-hub/claude_code:devel          (different registry tag, no cache reuse)
+container_name: bob-claude_code
+project name:   bob-hub-claude_code
+```
+
+If `alice` and `bob` share `DOCKER_HUB_USER` (e.g. a shared CI
+service account), `image` collides on Docker Hub but `container_name`
+still differentiates — registry pulls share the cached image and
+hosts stay deconflicted.
+
 ## Quick Start
 
 ### Adding to a new repo

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- `README.md` + `doc/readme/README.{zh-TW,zh-CN,ja}.md`: new "Naming scheme: three namespaces, two user identities" subsection under "Per-repo runtime configuration". Clarifies why `image:` uses `${DOCKER_HUB_USER}` (registry-side namespace, breaks cache reuse if per-OS-user) while `container_name:` uses `${USER_NAME}` (host daemon namespace, the actual collision class #322 fixes), and why compose project name kept `${DOCKER_HUB_USER}` historically — together with a worked example contrasting single-user-machine alignment vs. multi-user-host divergence. Also documents `INSTANCE_SUFFIX` as the fourth orthogonal dimension for same-user same-repo parallel containers. No behaviour change; the #322 CHANGELOG entry's "aligns container-level naming with project-level naming" phrasing is now self-explanatory for sysadmins where OS user and Docker Hub user diverge.
+
 ### Changed
 
 - `.github/workflows/self-test.yaml`: harden `classify` job against latent fail-closed and fork-PR breakage (#317 P1 follow-up). The job's required-check chain (`test` needs `classify`) means any non-zero exit here wedges every PR merge (Q4 fail-closed design). Two robustness changes: (1) `set -uo pipefail` instead of `set -euo pipefail` so transient diff/fetch errors fall through the `if git diff --quiet` form to the existing "differences exist" branch (emits `code_changed=true` / `behavioural_relevant=true` rather than aborting the job); (2) explicit `git fetch origin "${BASE_REF}:refs/remotes/origin/${BASE_REF}" --depth=200 || true` before the diff so fork PRs (where `actions/checkout@v6` `fetch-depth: 0` only fetches the head branch, not the base) don't trip on `origin/<base>` being absent locally. Worst case after this change: a misclassified doc-only PR burns one full-suite run instead of blocking the merge queue.

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -447,6 +447,84 @@ Main
 pull 後に `setup.sh apply` を再実行）— 手動編集はしないでください。
 override は `setup.conf` に書きます。
 
+### 命名スキーム: 3 つの namespace と 2 つの user identity
+
+`setup.sh` は `.env` / `compose.yaml` に 3 つの名前を生成します。
+単一ユーザの開発機では見た目が似通っていますが、これらは**3 つの
+独立した namespace**に属し、**2 つの異なる user identity**から
+プレフィックスを取ります。共用ホスト（複数 OS user）のシナリオで
+は区別が顕在化します。個人開発機では 2 つの identity が一致する
+ことが多く、深追いする必要はありません。
+
+| 名前 | 形式 | Namespace | User プレフィックス |
+|---|---|---|---|
+| `image:` | `${DOCKER_HUB_USER:-local}/<repo>:<tag>` | **Registry**（Docker Hub） | `DOCKER_HUB_USER` |
+| `container_name:` | `${USER_NAME}-<repo>${INSTANCE_SUFFIX}` | **ローカル daemon**（同一 docker daemon 内のフラットなグローバル） | `USER_NAME`（OS user、refs #322） |
+| compose project name | `${DOCKER_HUB_USER}-<repo>${INSTANCE_SUFFIX}` | **ローカル daemon**（デフォルト network / volume label に影響） | `DOCKER_HUB_USER` |
+
+- `DOCKER_HUB_USER` — Docker Hub アカウント。registry 側で image
+  に名前空間を付けるために使います。実際に push しない場合でも、
+  image tag は `<DOCKER_HUB_USER>/<repo>:<tag>` という形で
+  この identity を含みます。
+- `USER_NAME` — ホストの OS user（`id -un`）。同じマシン上の
+  異なる OS user が daemon のフラットな container 名前空間で
+  衝突するのを防ぐために使います。
+
+2 つの identity を意図的に分けています。Image は registry 上で
+アドレス可能なオブジェクトなので Docker Hub identity を使う —
+OS user でプレフィックスを付けてしまうと buildx cache や Docker
+Hub の layer 共有が破綻します。Container name に OS identity を
+使うのは、ここで解決したい衝突（同一ホスト上の 2 user が同一 repo
+を同時実行）が daemon 側の問題であり、registry とは無関係だからです。
+
+Project name に `DOCKER_HUB_USER` を使うのは #322 以前からの
+決定で、そのまま据え置きました。個人開発機では 2 つの identity
+が重なるため `container_name` と視覚的に揃います。共用ホストでは
+`DOCKER_HUB_USER` も user ごとに異なるのが普通なので、project
+name も結果としてユーザ間衝突を回避できます。`#322` の CHANGELOG
+が言う「container レベルの命名を project レベルに揃える」とは
+「単一ユーザ機」前提での記述です — どちらも user プレフィックス
+を持つという意味では揃っていますが、複数ユーザ機ではそれぞれ別の
+変数から来るので前綴文字列は同一ではありません。
+
+**`INSTANCE_SUFFIX`** は 4 つ目の次元で、user 分離とは直交します。
+同じ OS user が同一 repo の container を複数並行起動したい場合
+（例: 2 つの branch を同時にテスト）、`INSTANCE_SUFFIX=2` を設定
+すると `alice-<repo>-2` と対応する project name が得られます。
+デフォルトは空文字列で、wrapper が対応する場面では `-n /
+--instance` で指定できます。
+
+具体例。OS user `alice`、Docker Hub user `alice-hub`、repo
+`claude_code`、デフォルト `INSTANCE_SUFFIX` 空:
+
+```
+image:          alice-hub/claude_code:devel
+container_name: alice-claude_code
+project name:   alice-hub-claude_code
+```
+
+同一 OS user で 2 番目の instance（`INSTANCE_SUFFIX=2`）:
+
+```
+image:          alice-hub/claude_code:devel        (変わらず — 同じ image)
+container_name: alice-claude_code-2
+project name:   alice-hub-claude_code-2
+```
+
+同じホスト上の別の OS user `bob`:
+
+```
+image:          bob-hub/claude_code:devel          (registry tag が異なり cache 共有なし)
+container_name: bob-claude_code
+project name:   bob-hub-claude_code
+```
+
+`alice` と `bob` が同じ `DOCKER_HUB_USER` を共有している場合
+（例: 共用 CI サービスアカウント）、`image` は Docker Hub 上で
+衝突しますが `container_name` で区別できます — registry pull は
+キャッシュされた image を共有し、ホスト内の daemon では互いに
+分離されたままです。
+
 ## クイックスタート
 
 ### 新規 repo への追加

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -423,6 +423,74 @@ Main
 `make upgrade` 都会重新生成这两个文件（init.sh 在 subtree pull 后重跑
 `setup.sh apply`）— 不要手改，需要 override 写到 `setup.conf`。
 
+### 命名规则：三个 namespace、两个 user 身份
+
+`setup.sh` 会在 `.env` / `compose.yaml` 产生三个名称。它们在单人
+开发机上看起来很像，但其实分布在**三个独立的 namespace**，并使用
+两个**不同的 user 身份**作前缀。多 user 共用主机的场景下这层差异
+会浮现；个人开发机上两个身份通常一致可以不必深究。
+
+| 名称 | 格式 | Namespace | User 前缀 |
+|---|---|---|---|
+| `image:` | `${DOCKER_HUB_USER:-local}/<repo>:<tag>` | **Registry**（Docker Hub） | `DOCKER_HUB_USER` |
+| `container_name:` | `${USER_NAME}-<repo>${INSTANCE_SUFFIX}` | **本地 daemon**（同 docker daemon 内 flat 全局） | `USER_NAME`（OS user，refs #322） |
+| compose project name | `${DOCKER_HUB_USER}-<repo>${INSTANCE_SUFFIX}` | **本地 daemon**（影响默认 network / volume label） | `DOCKER_HUB_USER` |
+
+- `DOCKER_HUB_USER` — 你的 Docker Hub 账号，用于在 registry 端把
+  image 加上命名空间。即使从未实际 push，image tag 也以这个
+  identity 拼成 `<DOCKER_HUB_USER>/<repo>:<tag>`。
+- `USER_NAME` — 主机 OS user（`id -un`），用来防止同一台机器上
+  不同 OS user 在 daemon 的 flat container 命名空间内互撞。
+
+刻意把两个身份分开。Image 用 Docker Hub 身份是因为 image 是会在
+registry 上被定址的；如果以 OS user 做前缀，buildx cache 与
+Docker Hub layer 共享会直接失效。Container name 用 OS 身份是
+因为它解决的冲突（同 host 两个 user 跑同一个 repo）是 daemon 端
+问题、与 registry 无关。
+
+Project name 用 `DOCKER_HUB_USER` 是 #322 之前的决定，未变：在单
+人开发机上两个身份重合，与 `container_name` 视觉对齐；多人共用机
+上 `DOCKER_HUB_USER` 通常也不同，所以 project name 同样能避开
+跨 user 冲突。`#322` CHANGELOG 写的「对齐 container-level 与
+project-level naming」在「单人机」假设下成立 — 两者都带 user
+前缀，差别只在「同一个 var 还是两个 var」；多人机场景下两个前缀
+不是同一字符串。
+
+**`INSTANCE_SUFFIX`** 是第四个维度，与 user 分隔正交。同一个
+OS user 想同时跑同一 repo 多个 container（例如并行测两个 branch）：
+设 `INSTANCE_SUFFIX=2` 就会得到 `alice-<repo>-2` 与对应的 project
+name。默认空字符串；wrappers 支持的场合可用 `-n / --instance`。
+
+示例。OS user `alice`、Docker Hub user `alice-hub`、repo
+`claude_code`、默认 `INSTANCE_SUFFIX` 空：
+
+```
+image:          alice-hub/claude_code:devel
+container_name: alice-claude_code
+project name:   alice-hub-claude_code
+```
+
+同一 OS user 起第二份 instance（`INSTANCE_SUFFIX=2`）：
+
+```
+image:          alice-hub/claude_code:devel        (不变 — 同一份 image)
+container_name: alice-claude_code-2
+project name:   alice-hub-claude_code-2
+```
+
+第二位 OS user `bob` 在同台机器上：
+
+```
+image:          bob-hub/claude_code:devel          (不同 registry tag,无 cache 共用)
+container_name: bob-claude_code
+project name:   bob-hub-claude_code
+```
+
+若 `alice` 与 `bob` 共用同一个 `DOCKER_HUB_USER`（例如共用 CI
+service 账号），`image` 会在 Docker Hub 端撞名，但 `container_name`
+仍能区隔 — registry pull 共用 cached image、host 内 daemon 仍
+彼此隔离。
+
 ## 快速开始
 
 ### 添加到新 repo

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -423,6 +423,74 @@ Main
 `make upgrade` 都會重生這兩個檔（init.sh 在 subtree pull 後重跑
 `setup.sh apply`）— 不要手改，需要 override 寫到 `setup.conf`。
 
+### 命名規則：三個 namespace、兩個 user 身份
+
+`setup.sh` 會在 `.env` / `compose.yaml` 產三個名稱。它們在單人開發
+機上長得像，但實際分布在**三個獨立 namespace**，並取兩個**不同的
+user 身份**做前綴。共用機器（多 OS user）的場景下這個差異會浮現；
+個人開發機上兩個身份通常一致可不必細究。
+
+| 名稱 | 格式 | Namespace | User 前綴 |
+|---|---|---|---|
+| `image:` | `${DOCKER_HUB_USER:-local}/<repo>:<tag>` | **Registry**（Docker Hub） | `DOCKER_HUB_USER` |
+| `container_name:` | `${USER_NAME}-<repo>${INSTANCE_SUFFIX}` | **本地 daemon**（同 docker daemon 內 flat 全域） | `USER_NAME`（OS user，refs #322） |
+| compose project name | `${DOCKER_HUB_USER}-<repo>${INSTANCE_SUFFIX}` | **本地 daemon**（影響預設 network / volume label） | `DOCKER_HUB_USER` |
+
+- `DOCKER_HUB_USER` — 你的 Docker Hub 帳號，用來在 registry 端把
+  image 加上命名空間。即使從未實際 push，image tag 仍透過這個
+  identity 寫成 `<DOCKER_HUB_USER>/<repo>:<tag>`。
+- `USER_NAME` — 主機 OS user（`id -un`），用來避免同台機器上不同
+  OS user 在 daemon 的 flat container 命名空間互撞。
+
+刻意把兩個身份分開。Image 用 Docker Hub 身份，因為 image 是會在
+registry 上被定址的物件；若以 OS user 做前綴，buildx cache 與
+Docker Hub layer 共用會直接破功。Container name 用 OS 身份，因為
+這層解決的衝突（同 host 兩 user 同跑同 repo）是 daemon 端問題、
+無 registry 牽涉。
+
+Project name 用 `DOCKER_HUB_USER` 是 #322 之前就決定，未動：在
+單人開發機上兩個身份重合，與 `container_name` 視覺上對齊；多人共
+用機則因為 `DOCKER_HUB_USER` 通常也不同，所以 project name 一樣
+能避開跨 user 衝突。`#322` 的 CHANGELOG 寫的「對齊 container-level
+與 project-level naming」在「單人機」假設下成立 — 兩者都帶 user
+前綴，差別只在「同一個 var 還是兩個 var」；多人機場景下兩個前綴
+是不同字串。
+
+**`INSTANCE_SUFFIX`** 是第四維，跟 user 分隔正交。同一個 OS user
+要同時跑同一 repo 的多個 container（譬如平行測兩個 branch）：設
+`INSTANCE_SUFFIX=2` 就會拿到 `alice-<repo>-2` 跟對應的 project
+name。預設空字串；wrappers 支援的場合可用 `-n / --instance` 帶起來。
+
+範例。OS user `alice`，Docker Hub user `alice-hub`，repo
+`claude_code`，預設 `INSTANCE_SUFFIX` 空：
+
+```
+image:          alice-hub/claude_code:devel
+container_name: alice-claude_code
+project name:   alice-hub-claude_code
+```
+
+同一 OS user 起第二份 instance（`INSTANCE_SUFFIX=2`）：
+
+```
+image:          alice-hub/claude_code:devel        (不變 — 同一份 image)
+container_name: alice-claude_code-2
+project name:   alice-hub-claude_code-2
+```
+
+第二位 OS user `bob` 在同台機器：
+
+```
+image:          bob-hub/claude_code:devel          (不同 registry tag,無 cache 共用)
+container_name: bob-claude_code
+project name:   bob-hub-claude_code
+```
+
+若 `alice` 與 `bob` 共用同一個 `DOCKER_HUB_USER`（例如共用 CI
+service 帳號），`image` 會在 Docker Hub 端撞名，但 `container_name`
+仍能區隔 — registry pull 共用 cached image、host 內 daemon 仍
+彼此隔離。
+
 ## 快速開始
 
 ### 加入新 repo


### PR DESCRIPTION
## Summary

Documentation-only PR clarifying the three-namespace, two-user-identity
scheme behind `image:`, `container_name:`, and the compose project
name as emitted by `setup.sh`. Same wording added to all 4 language
READMEs.

Motivated by ambiguity in v0.28.1's #322 CHANGELOG phrasing: "aligns
container-level naming with project-level naming" reads true on a
single-user dev machine (where `USER_NAME` and `DOCKER_HUB_USER`
typically coincide) but isn't literally true on a shared host where
the two diverge — and the multi-user host is exactly the case #322
was filed for. The new section spells out why `image:` keeps a
Docker-Hub prefix while `container_name:` got an OS-user prefix.

## What changes

A new "Naming scheme: three namespaces, two user identities"
subsection under "Per-repo runtime configuration" in:

- `README.md`
- `doc/readme/README.zh-TW.md`
- `doc/readme/README.zh-CN.md`
- `doc/readme/README.ja.md`

CHANGELOG `[Unreleased]` gets a `### Documentation` entry pointing
to the new section.

The section covers:

1. **Three namespaces** — registry (image), host daemon
   (container_name), and host daemon again (compose project name).
2. **Two user identities** — `DOCKER_HUB_USER` (registry-side) vs.
   `USER_NAME` (OS-side, from `id -un`). Image uses the former
   because per-OS-user image tags would shatter buildx cache reuse.
   Container uses the latter because the collision class #322 fixes
   is daemon-internal with no registry component.
3. **Why project name kept `DOCKER_HUB_USER`** — predates #322; on
   single-user machines the two identities coincide so visual
   alignment with `container_name` works; on multi-user hosts the
   project name still deconflicts because `DOCKER_HUB_USER` also
   tends to differ per user. The #322 CHANGELOG phrasing is true
   under the single-user-machine assumption, not the literal-prefix-
   string assumption.
4. **`INSTANCE_SUFFIX`** — fourth dimension, orthogonal to user
   split. Same OS user, same repo, multiple parallel containers
   (different branches side by side).
5. **Worked example** — `alice` / `alice-hub` / `claude_code` shown
   in three configurations: default, second instance, second OS
   user.

## Why split image / container user prefixes deliberately

Quoted from the new section:

> Image names use the Docker Hub identity because images are
> addressable on the registry, and forcing per-OS-user image tags
> would shatter buildx cache reuse and Docker Hub layer sharing.
> Container names use the OS identity because the conflict it fixes
> (two users on the same host running the same repo) is a
> host-daemon problem with no registry component.

## Verification

- Pure documentation; no shell or test changes. Affects only `.md`
  files under `doc/` and the root `README.md`.
- All 4 language READMEs got the new section at the same anchor
  (after "Derived artifacts (gitignored)" and before "Quick Start").
  This is the first PR to exercise the #317 P1 doc-only
  short-circuit in self-test.yaml + the #317 P1 follow-up (#329)
  classifier hardening — expected behaviour: `test` job logs
  "Doc-only PR — bats / shellcheck / kcov skipped", exits SUCCESS
  in seconds; `integration-e2e` + `behavioural` SKIPPED via
  job-level `if:` gate.

## Out of scope

No CHANGELOG retroactive edit of v0.28.1 #322 entry — the new
section is the canonical clarification, and rewriting history in a
released CHANGELOG entry is more disruptive than a cross-reference
adjacent to it. If reviewers think a one-line "see README naming-
scheme section for details" addition to the #322 entry is worth
it, happy to add as a follow-up.
