### PR TITLE
feat(ci): multi-distro-build-worker.yaml dispatcher reusable workflow (#325 B-1)

### DIFF
--- a/.github/workflows/multi-distro-build-worker.yaml
+++ b/.github/workflows/multi-distro-build-worker.yaml
@@ -1,0 +1,164 @@
+name: Multi-distro build dispatcher
+
+# Two-job dispatcher reusable workflow (#325 B-1). Resolves a per-event
+# distro subset and fans it out across `build-worker.yaml` matrix shards,
+# so multi-distro callers (`env/ros_distro`, `env/ros2_distro`,
+# `app/ros1_bridge`) don't have to copy-paste a
+# `${{ github.event_name == 'pull_request' && fromJSON('[...]') || ... }}`
+# expression into every main.yaml.
+#
+# Pull-request events use `pr_distros`; tag pushes, main pushes, and
+# workflow_dispatch use `tag_distros` (the full validation matrix).
+# Callers express the policy once per repo via two JSON-array inputs.
+#
+# A `ci-passed` rollup job aggregates the matrix result for branch
+# protection — matches the existing rollup naming used by env/ros_distro
+# / env/ros2_distro per CLAUDE.md's status-check table, so downstream
+# branch protection contexts don't need to change when adopting this
+# dispatcher.
+
+on:
+  workflow_call:
+    # === Multi-distro specific ===
+    inputs:
+      pr_distros:
+        required: true
+        type: string
+        description: |
+          JSON-array string of distro values to build on `pull_request`
+          events. Typically a subset of `tag_distros` to keep PR CI
+          fast — e.g. `'["humble"]'` while `tag_distros: '["humble",
+          "jazzy"]'` for `app/ros1_bridge`. Tag-time still validates the
+          full matrix.
+      tag_distros:
+        required: true
+        type: string
+        description: |
+          JSON-array string of distro values to build on tag push, main
+          push, and `workflow_dispatch`. This is the "release-validation"
+          matrix — everything that ships needs to pass here.
+      distro_input_name:
+        required: true
+        type: string
+        description: |
+          Name of the Dockerfile `ARG` (and corresponding `build_args`
+          key) that consumes the per-shard distro value. The dispatcher
+          emits `<distro_input_name>=<matrix.distro>` as the first
+          build_args line for each shard. Example values: `ROS_DISTRO`
+          (ROS 1), `ROS2_DISTRO` (ROS 2 / bridge), `ROS_DISTRO` etc.
+    # === Forwarded to build-worker.yaml (mirror keep build-worker
+    # defaults so existing semantics are preserved when caller omits) ===
+      image_name:
+        required: true
+        type: string
+        description: |
+          Base image name. The dispatcher derives each shard's image
+          name as `<image_name>_<matrix.distro>` so multi-distro callers
+          don't have to template that expression themselves. E.g.
+          caller sets `image_name: ros1_bridge`, dispatcher passes
+          `ros1_bridge_humble` / `ros1_bridge_jazzy` to build-worker.
+      extra_build_args:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Multi-line KEY=VALUE build_args appended after the
+          dispatcher-emitted `<distro_input_name>=<distro>` line.
+          Forwarded as-is to build-worker.yaml's `build_args` input.
+      build_runtime:
+        required: false
+        type: boolean
+        default: true
+      test_tools_version:
+        required: false
+        type: string
+        default: "latest"
+      platforms:
+        required: false
+        type: string
+        default: "linux/amd64"
+      context_path:
+        required: false
+        type: string
+        default: "."
+      dockerfile_path:
+        required: false
+        type: string
+        default: ""
+      build_contexts:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  resolve-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      distros: ${{ steps.r.outputs.distros }}
+    steps:
+      - id: r
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_DISTROS: ${{ inputs.pr_distros }}
+          TAG_DISTROS: ${{ inputs.tag_distros }}
+        # PR event -> pr_distros subset. Every other event
+        # (push to main, push of a v* tag, workflow_dispatch) ->
+        # tag_distros full matrix. Tag pushes specifically benefit
+        # from full validation since they cut releases; main pushes
+        # benefit because the same code path is what tag-cut will see.
+        run: |
+          set -euo pipefail
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            echo "distros=${PR_DISTROS}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "distros=${TAG_DISTROS}" >> "${GITHUB_OUTPUT}"
+          fi
+
+  call-build:
+    needs: resolve-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        distro: ${{ fromJSON(needs.resolve-matrix.outputs.distros) }}
+    uses: ./.github/workflows/build-worker.yaml
+    with:
+      # Per-shard image_name includes the distro so the GHCR tag
+      # disambiguates multi-distro builds from the same caller repo
+      # (e.g. ros1_bridge_humble vs ros1_bridge_jazzy).
+      image_name: ${{ inputs.image_name }}_${{ matrix.distro }}
+      build_args: |
+        ${{ inputs.distro_input_name }}=${{ matrix.distro }}
+        ${{ inputs.extra_build_args }}
+      build_runtime: ${{ inputs.build_runtime }}
+      test_tools_version: ${{ inputs.test_tools_version }}
+      platforms: ${{ inputs.platforms }}
+      context_path: ${{ inputs.context_path }}
+      dockerfile_path: ${{ inputs.dockerfile_path }}
+      build_contexts: ${{ inputs.build_contexts }}
+      # Per-distro buildx cache scope so e.g. humble and jazzy shards
+      # don't evict each other's cache. Matches the `cache_variant`
+      # contract added in #272 for env/ros{,2}_distro's variant matrix.
+      cache_variant: ${{ matrix.distro }}
+
+  ci-passed:
+    name: ci-passed
+    needs: call-build
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate matrix results
+        env:
+          NEEDS_RESULT: ${{ needs.call-build.result }}
+        # Rollup gate for downstream branch protection. The matrix
+        # `result` is `success` only when every shard finished with
+        # `conclusion: success`; any failure or cancellation surfaces
+        # here. `if: always()` ensures the rollup runs even when one
+        # matrix shard failed, otherwise branch protection would see a
+        # missing required check rather than a failed one.
+        run: |
+          set -euo pipefail
+          if [[ "${NEEDS_RESULT}" != "success" ]]; then
+            echo "call-build matrix did not all succeed: ${NEEDS_RESULT}"
+            exit 1
+          fi
+          echo "All distro shards passed."

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `.github/workflows/multi-distro-build-worker.yaml`: new dispatcher reusable workflow (#325 B-1). Multi-distro callers (`env/ros_distro`, `env/ros2_distro`, `app/ros1_bridge`) pass `pr_distros` / `tag_distros` JSON-array inputs plus a `distro_input_name`; the dispatcher resolves the per-event distro subset (`pull_request` -> `pr_distros`; everything else -> `tag_distros`) and fans the subset across `build-worker.yaml` matrix shards. Each shard derives `image_name` as `<image_name>_<distro>`, passes `<distro_input_name>=<distro>` as the first build_args line, and shards buildx GHA cache via `cache_variant: ${{ matrix.distro }}` (#272 contract reuse). A `ci-passed` rollup job satisfies branch protection — same name used by env/ros_distro / env/ros2_distro per CLAUDE.md's status-check table, so downstream protection contexts don't change on adoption. Solves the maintenance drift caused by the previous "copy-paste the `github.event_name == 'pull_request' && fromJSON('[...]') || fromJSON('[...]')` expression into every multi-distro `main.yaml`" pattern (#325 Path A, explicitly rejected in favour of B-1 dispatcher per the locked decision).
+
 ## [v0.28.2] - 2026-05-14
 
 Patch release for SSH X11 forwarding follow-up (#321 hotfix #333) bundled with CI infrastructure improvements (#317 P2 rolling `:main` tag + 3-layer Obtain fallback, #336 integration-e2e driver fix, #317 P1 follow-up classify-job hardening) and documentation clarifying the v0.28.1 naming-scheme change (#322 follow-up). No breaking changes from v0.28.1; users on v0.28.1 should upgrade to pick up the SSH X11 fix (the v0.28.1 cookie-rewrite path silently produced empty cookies under common `~/.Xauthority` lock contention).

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1253 tests** total (1197 unit + 56 integration).
+Template self-tests: **1267 tests** total (1211 unit + 56 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -312,6 +312,52 @@ which would leave a freshly-pushed `:main` unverified).
 | Resolve tags step: 3 publish modes (`v*` + `main` + dispatch) emit correct tag sets and `smoke` output | 3 |
 | Smoke step pulls trigger's tag via `steps.tags.outputs.smoke` (#317 P2) | 1 |
 | Build step pushes multi-arch (amd64 + arm64) + declares `packages: write` permission | 2 |
+
+### test/unit/multi_distro_build_worker_yaml_spec.bats (14)
+
+Structural assertions for `.github/workflows/multi-distro-build-worker.yaml`
+(#325 B-1 dispatcher). The dispatcher fans a per-event distro
+subset across `build-worker.yaml` matrix shards so multi-distro
+caller `main.yaml`s (`env/ros_distro`, `env/ros2_distro`,
+`app/ros1_bridge`) stop copy-pasting a
+`${{ github.event_name == 'pull_request' && ... || ... }}`
+expression. Three jobs:
+
+1. **`resolve-matrix`** — pure-shell selector emitting a `distros`
+   JSON-array output. `pull_request` -> `pr_distros` (subset);
+   anything else (tag push, main push, `workflow_dispatch`) ->
+   `tag_distros` (release validation matrix).
+
+2. **`call-build`** — strategy.matrix job invoking the local
+   `build-worker.yaml` per distro shard. Derives per-shard
+   `image_name` as `<image_name>_<distro>`, passes
+   `<distro_input_name>=<distro>` as the first `build_args` line,
+   and shards buildx GHA cache by distro via
+   `cache_variant: ${{ matrix.distro }}` (reuses #272's per-variant
+   scope contract). `fail-fast: false` so one shard's failure
+   doesn't cancel siblings.
+
+3. **`ci-passed`** — rollup gate for branch protection. Matches the
+   existing `ci-passed` rollup naming used by env/ros_distro /
+   env/ros2_distro per CLAUDE.md's status-check table, so
+   downstream branch-protection contexts don't change on adoption.
+
+| Category | Tests |
+|----------|-------|
+| Declares `workflow_call` | 1 |
+| Required inputs: `pr_distros`, `tag_distros`, `distro_input_name`, `image_name` | 1 |
+| Passthrough inputs mirror build-worker (build_runtime / test_tools_version / platforms / context_path / dockerfile_path / build_contexts) | 1 |
+| Defines `extra_build_args` passthrough | 1 |
+| `resolve-matrix` emits `distros` output | 1 |
+| `resolve-matrix` branches on `github.event_name == 'pull_request'` | 1 |
+| `call-build` `uses: ./.github/workflows/build-worker.yaml` | 1 |
+| `call-build` matrix `fromJSON(needs.resolve-matrix.outputs.distros)` | 1 |
+| `call-build` per-shard `image_name: <image_name>_<distro>` | 1 |
+| `call-build` `build_args` line `<distro_input_name>=<distro>` | 1 |
+| `call-build` `cache_variant: ${{ matrix.distro }}` (per-distro cache scope) | 1 |
+| `call-build` `fail-fast: false` | 1 |
+| `ci-passed` rollup depends on `call-build`, runs with `if: always()` | 1 |
+| `ci-passed` declares `name: ci-passed` to satisfy branch protection contract | 1 |
 
 ### test/unit/build_sh_spec.bats (51)
 

--- a/test/unit/multi_distro_build_worker_yaml_spec.bats
+++ b/test/unit/multi_distro_build_worker_yaml_spec.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+#
+# multi_distro_build_worker_yaml_spec.bats — structural assertions for
+# `.github/workflows/multi-distro-build-worker.yaml` (#325 B-1 dispatcher).
+#
+# The dispatcher is a two-job reusable workflow on top of
+# build-worker.yaml:
+#
+# 1. `resolve-matrix` — pure-shell selector that emits a `distros` JSON
+#    array output based on `github.event_name`. `pull_request` ->
+#    `pr_distros` (subset); everything else (tag push, main push,
+#    workflow_dispatch) -> `tag_distros` (full release matrix).
+#
+# 2. `call-build` — strategy.matrix job invoking
+#    `./.github/workflows/build-worker.yaml` per distro shard. Derives
+#    per-shard `image_name` as `<image_name>_<distro>` so GHCR tags
+#    disambiguate across distros, and passes
+#    `<distro_input_name>=<distro>` as the first `build_args` line.
+#    Per-distro `cache_variant: ${{ matrix.distro }}` so buildx GHA
+#    cache shards by distro (matches #272's per-variant scope pattern).
+#
+# 3. `ci-passed` — rollup aggregating the matrix result for branch
+#    protection. Matches the existing rollup naming used by
+#    env/ros_distro / env/ros2_distro per CLAUDE.md's status-check
+#    table, so downstream branch-protection contexts don't change when
+#    adopting this dispatcher.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  WF="/source/.github/workflows/multi-distro-build-worker.yaml"
+  [[ -f "${WF}" ]] || skip "multi-distro-build-worker.yaml not at expected path"
+}
+
+# ── workflow_call interface ─────────────────────────────────────────
+
+@test "multi-distro-build-worker.yaml: declares workflow_call (#325 B-1)" {
+  run grep -E '^\s+workflow_call:' "${WF}"
+  assert_success
+}
+
+@test "multi-distro-build-worker.yaml: required inputs include pr_distros + tag_distros + distro_input_name + image_name (#325 B-1)" {
+  run awk '/^on:/{flag=1} /^jobs:/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'pr_distros:'
+  assert_output --partial 'tag_distros:'
+  assert_output --partial 'distro_input_name:'
+  assert_output --partial 'image_name:'
+}
+
+@test "multi-distro-build-worker.yaml: passthrough inputs mirror build-worker (build_runtime / test_tools_version / platforms / context_path / dockerfile_path / build_contexts) (#325 B-1)" {
+  run awk '/^on:/{flag=1} /^jobs:/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'build_runtime:'
+  assert_output --partial 'test_tools_version:'
+  assert_output --partial 'platforms:'
+  assert_output --partial 'context_path:'
+  assert_output --partial 'dockerfile_path:'
+  assert_output --partial 'build_contexts:'
+}
+
+@test "multi-distro-build-worker.yaml: defines extra_build_args passthrough (caller can append KEY=VALUE after the dispatcher's distro arg) (#325 B-1)" {
+  run awk '/^on:/{flag=1} /^jobs:/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'extra_build_args:'
+}
+
+# ── resolve-matrix job ───────────────────────────────────────────────
+
+@test "multi-distro-build-worker.yaml: resolve-matrix job emits distros output (#325 B-1)" {
+  run awk '/^  resolve-matrix:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'distros: ${{ steps.r.outputs.distros }}'
+}
+
+@test "multi-distro-build-worker.yaml: resolve-matrix branches on github.event_name == pull_request (#325 B-1)" {
+  run awk '/^  resolve-matrix:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'EVENT_NAME: ${{ github.event_name }}'
+  assert_output --partial '"${EVENT_NAME}" == "pull_request"'
+  assert_output --partial 'distros=${PR_DISTROS}'
+  assert_output --partial 'distros=${TAG_DISTROS}'
+}
+
+# ── call-build matrix job ────────────────────────────────────────────
+
+@test "multi-distro-build-worker.yaml: call-build uses local build-worker via ./.github/workflows/build-worker.yaml (#325 B-1)" {
+  run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'uses: ./.github/workflows/build-worker.yaml'
+}
+
+@test "multi-distro-build-worker.yaml: call-build matrix is fromJSON(needs.resolve-matrix.outputs.distros) (#325 B-1)" {
+  run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'distro: ${{ fromJSON(needs.resolve-matrix.outputs.distros) }}'
+}
+
+@test "multi-distro-build-worker.yaml: call-build derives per-shard image_name as <image_name>_<distro> (#325 B-1)" {
+  run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'image_name: ${{ inputs.image_name }}_${{ matrix.distro }}'
+}
+
+@test "multi-distro-build-worker.yaml: call-build passes <distro_input_name>=<distro> as build_args (#325 B-1)" {
+  run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial '${{ inputs.distro_input_name }}=${{ matrix.distro }}'
+}
+
+@test "multi-distro-build-worker.yaml: call-build splits buildx cache by distro via cache_variant: matrix.distro (#272 reuse, #325 B-1)" {
+  run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'cache_variant: ${{ matrix.distro }}'
+}
+
+@test "multi-distro-build-worker.yaml: call-build has fail-fast: false so one shard's failure doesn't cancel siblings (#325 B-1)" {
+  run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'fail-fast: false'
+}
+
+# ── ci-passed rollup ─────────────────────────────────────────────────
+
+@test "multi-distro-build-worker.yaml: ci-passed rollup job exists, depends on call-build, runs even if matrix failed (#325 B-1)" {
+  run awk '/^  ci-passed:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'needs: call-build'
+  assert_output --partial 'if: ${{ always() }}'
+  assert_output --partial 'NEEDS_RESULT'
+  assert_output --partial 'needs.call-build.result'
+}
+
+@test "multi-distro-build-worker.yaml: ci-passed job has explicit name: ci-passed (matches existing multi-distro rollup contract) (#325 B-1)" {
+  run awk '/^  ci-passed:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'name: ci-passed'
+}


### PR DESCRIPTION
## Summary

Implements #325 B-1 (locked decision): a new dispatcher reusable
workflow `multi-distro-build-worker.yaml` that fans a per-event
distro subset across `build-worker.yaml` matrix shards. Replaces
the "copy-paste a `${{ github.event_name == 'pull_request' &&
fromJSON('[...]') || fromJSON('[...]') }}` expression into every
multi-distro `main.yaml`" pattern that Path A would have left as
maintenance debt.

Refs #325 (decision locked in
[the B-1 comment](https://github.com/ycpss91255-docker/base/issues/325#issuecomment-4446504854)).

## What this PR ships

`.github/workflows/multi-distro-build-worker.yaml` — new reusable
workflow. Caller surface:

```yaml
jobs:
  call-docker-build:
    uses: ycpss91255-docker/base/.github/workflows/multi-distro-build-worker.yaml@<ref>
    with:
      image_name: ros1_bridge
      pr_distros: '["humble"]'
      tag_distros: '["humble", "jazzy"]'
      distro_input_name: ROS2_DISTRO
      build_runtime: true
```

Three jobs internally:

1. **`resolve-matrix`** — pure-shell selector emitting a `distros`
   JSON-array output. `pull_request` -> `pr_distros` (subset);
   anything else (tag push, main push, `workflow_dispatch`) ->
   `tag_distros` (release validation matrix).

2. **`call-build`** — `strategy.matrix` over the resolved JSON,
   invoking the local `./.github/workflows/build-worker.yaml` per
   shard. Derives per-shard `image_name` as `<image_name>_<distro>`,
   passes `<distro_input_name>=<distro>` as the first `build_args`
   line, and shards buildx GHA cache via `cache_variant: ${{
   matrix.distro }}` (reuses #272's per-variant scope contract).
   `fail-fast: false` so one shard's failure doesn't cancel
   siblings.

3. **`ci-passed`** — rollup gate for branch protection. Same name
   as the existing `ci-passed` rollup used by `env/ros_distro` /
   `env/ros2_distro` per CLAUDE.md's status-check table, so
   downstream branch-protection contexts don't change on adoption.

## Reusable-workflow nesting depth

Decision-comment math:

```
downstream/main.yaml
  -> base/multi-distro-build-worker.yaml        (level 2)
       -> base/build-worker.yaml                (level 3)
```

3 levels, within GitHub Actions' 4-level limit. One level of
margin for future composition.

## Tests

New `test/unit/multi_distro_build_worker_yaml_spec.bats` (14
tests). Locks:

- `workflow_call` declared.
- Required inputs (`pr_distros`, `tag_distros`, `distro_input_name`,
  `image_name`) all present.
- Passthrough inputs mirror build-worker (`build_runtime`,
  `test_tools_version`, `platforms`, `context_path`,
  `dockerfile_path`, `build_contexts`).
- Optional `extra_build_args` passthrough.
- `resolve-matrix` job emits `distros` output, branches on
  `github.event_name == 'pull_request'`.
- `call-build` job uses local `./.github/workflows/build-worker.yaml`,
  `matrix` is `fromJSON(needs.resolve-matrix.outputs.distros)`,
  derives per-shard `image_name`, passes
  `<distro_input_name>=<distro>` build arg, shards cache by distro,
  `fail-fast: false`.
- `ci-passed` rollup depends on `call-build`, runs with `if:
  always()`, named `ci-passed`.

Total template self-tests 1252 -> 1266 (1196 -> 1210 unit;
integration unchanged 56).

## Verification

- `docker run --rm rhysd/actionlint:1.7.7 -color
  .github/workflows/multi-distro-build-worker.yaml` -> exit 0,
  no findings.
- `make -f Makefile.ci test` -> 1266/1266 green.

## Sequencing

Part of the locked 4-step plan in
[issue #317's resolutions comment](https://github.com/ycpss91255-docker/base/issues/317#issuecomment-4446504983):

1. ~~P1 follow-up~~ — classifier fail-open + base ref fetch
   (#329, merged).
2. ~~P2~~ — `:main` rolling tag + 3-layer fallback (#332 +
   #336 hotfix, both merged).
3. **B-1 (this PR)** — `multi-distro-build-worker.yaml`
   dispatcher.
4. #317 P3 — behavioural job gated on `behavioural_relevant`
   + gotcha-5 block-list expansion (`setup.sh`, `lib/**`,
   `i18n.sh`).

Plus separately, 3 downstream `main.yaml` migration PRs to adopt
the dispatcher (`env/ros_distro`, `env/ros2_distro`,
`app/ros1_bridge`). Out of scope for this PR — each downstream
repo deserves its own PR for per-repo CI signal review.

## Note on auto-merge

`test` is the only branch-protection-required check on `base`
([#337](https://github.com/ycpss91255-docker/base/issues/337)
filed to expand). For this PR I'll keep auto-merge OFF and wait
for `wait-pr-ci`'s ALL_DONE on all 4 checks before merging
manually — avoids a #332-style premature merge if any non-required
check fails.
