### PR TITLE
fix(dispatcher): per-shard image_name separator hyphen not underscore (v0.29.1 patch)

### DIFF
--- a/.github/workflows/multi-distro-build-worker.yaml
+++ b/.github/workflows/multi-distro-build-worker.yaml
@@ -53,10 +53,12 @@ on:
         type: string
         description: |
           Base image name. The dispatcher derives each shard's image
-          name as `<image_name>_<matrix.distro>` so multi-distro callers
+          name as `<image_name>-<matrix.distro>` so multi-distro callers
           don't have to template that expression themselves. E.g.
           caller sets `image_name: ros1_bridge`, dispatcher passes
-          `ros1_bridge_humble` / `ros1_bridge_jazzy` to build-worker.
+          `ros1_bridge-humble` / `ros1_bridge-jazzy` to build-worker —
+          matching the existing org convention (`app/ros1_bridge`'s
+          pre-dispatcher main.yaml shipped `ros1_bridge-${distro}`).
       extra_build_args:
         required: false
         type: string
@@ -124,8 +126,11 @@ jobs:
     with:
       # Per-shard image_name includes the distro so the GHCR tag
       # disambiguates multi-distro builds from the same caller repo
-      # (e.g. ros1_bridge_humble vs ros1_bridge_jazzy).
-      image_name: ${{ inputs.image_name }}_${{ matrix.distro }}
+      # (e.g. ros1_bridge-humble vs ros1_bridge-jazzy). Hyphen
+      # matches the existing org convention; env/ros{,2}_distro use
+      # a single-image-multi-variant shape that is out of scope for
+      # this 1D dispatcher (tracked at #344 for 2D extension).
+      image_name: ${{ inputs.image_name }}-${{ matrix.distro }}
       build_args: |
         ${{ inputs.distro_input_name }}=${{ matrix.distro }}
         ${{ inputs.extra_build_args }}

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `.github/workflows/multi-distro-build-worker.yaml`: per-shard `image_name` separator changed from `_` (v0.29.0) to `-` to match the existing org convention. `app/ros1_bridge`'s pre-dispatcher `main.yaml` shipped `ros1_bridge-${distro}` (hyphen); v0.29.0's initial dispatcher used `_${distro}` (underscore) which would have forced a registry tag rename on adoption. No consumer had adopted v0.29.0's dispatcher yet — this fix corrects the separator before the first downstream migration (planned for `app/ros1_bridge`). `env/ros{,2}_distro` use a single-image-multi-variant shape (no distro suffix on image_name) that this 1D dispatcher doesn't fit; their migration is tracked at #344 (2D dispatcher extension).
+
 ## [v0.29.0] - 2026-05-14
 
 Promoted from `v0.29.0-rc1` (#343). rc1 tag CI green: `Self Test` + `Release test-tools image to GHCR` both completed/success. The `:main` rolling tag bootstrapped on the rc1 multi-arch publish.

--- a/test/unit/multi_distro_build_worker_yaml_spec.bats
+++ b/test/unit/multi_distro_build_worker_yaml_spec.bats
@@ -97,10 +97,16 @@ setup() {
   assert_output --partial 'distro: ${{ fromJSON(needs.resolve-matrix.outputs.distros) }}'
 }
 
-@test "multi-distro-build-worker.yaml: call-build derives per-shard image_name as <image_name>_<distro> (#325 B-1)" {
+@test "multi-distro-build-worker.yaml: call-build derives per-shard image_name as <image_name>-<distro> (hyphen, v0.29.1 fix matches org convention)" {
+  # Hyphen separator chosen to match the existing org pattern (e.g.
+  # app/ros1_bridge's pre-dispatcher main.yaml shipped
+  # `ros1_bridge-${distro}`). Underscore was used in the v0.29.0
+  # initial implementation but never adopted by any consumer; v0.29.1
+  # corrects it before the first downstream migration lands.
   run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial 'image_name: ${{ inputs.image_name }}_${{ matrix.distro }}'
+  assert_output --partial 'image_name: ${{ inputs.image_name }}-${{ matrix.distro }}'
+  refute_output --partial 'image_name: ${{ inputs.image_name }}_${{ matrix.distro }}'
 }
 
 @test "multi-distro-build-worker.yaml: call-build passes <distro_input_name>=<distro> as build_args (#325 B-1)" {


### PR DESCRIPTION
## Summary

Single-line fix: `multi-distro-build-worker.yaml` (#325 B-1
dispatcher, shipped in v0.29.0 / #339) used `_` as the separator
in `${{ inputs.image_name }}_${{ matrix.distro }}`, producing tag
shapes like `ros1_bridge_humble`. The org convention (set by
`app/ros1_bridge`'s pre-dispatcher `main.yaml`) is hyphen —
`ros1_bridge-humble`. The dispatcher had no consumer yet, so this
PR corrects the separator before the first downstream migration
lands.

Refs #325, #339, #344.

## Verification (just performed)

- Looked at `app/ros1_bridge/.github/workflows/main.yaml` line 31:
  `image_name: ros1_bridge-${{ matrix.ros2_distro }}` — hyphen.
- Comment block at line 22 confirms `ros1_bridge-jazzy:devel` is
  the existing published tag shape.
- `env/ros_distro` + `env/ros2_distro` `main.yaml` both pass
  `image_name: ros_distro` / `ros2_distro` plain (no suffix at all,
  distro differentiated via build_args). Out of scope for this 1D
  dispatcher regardless of separator.

## Diff scope

- `.github/workflows/multi-distro-build-worker.yaml`:
  - Line 130: `image_name: ${{ inputs.image_name }}_${{ matrix.distro }}`
    -> `image_name: ${{ inputs.image_name }}-${{ matrix.distro }}`
  - Adjacent `description:` and comment block updated for clarity
    (mentioning the org convention).
- `test/unit/multi_distro_build_worker_yaml_spec.bats`: the
  matching `assert_output --partial 'image_name: ... _ ...'`
  swaps to hyphen + adds `refute_output --partial` on the old
  underscore form so a future revert can't sneak through.
- `doc/changelog/CHANGELOG.md` `[Unreleased]` `### Fixed`.

## Release plan

After merge: tag `v0.29.1` (patch — separator-correctness fix
before adoption). Same RC discipline as before with this small
fix would be overkill — patch releases per CLAUDE.md's
"MAJOR.MINOR.PATCH = bug fix / doc fix, RC NOT required" rule
(see v0.12.1 / v0.12.2 / v0.12.3 for precedent). Skip RC, tag
v0.29.1 directly on the merge commit.

## After v0.29.1

`app/ros1_bridge` migrates `main.yaml` to call
`multi-distro-build-worker.yaml@v0.29.1` — tracked as the next
session task in this thread.

## Verification (pre-PR)

- `docker run --rm rhysd/actionlint:1.7.7 -color
  .github/workflows/multi-distro-build-worker.yaml` -> exit 0.
- `make -f Makefile.ci test` -> 1268/1268 green (1212 unit + 56
  integration; counts unchanged, only one assertion's content
  flipped + 1 refute added).
