### PR TITLE
fix(stop): activate profiles + --remove-orphans + real verbose listing (#341, #345)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `script/docker/stop.sh`: `_down_one` now exports `COMPOSE_PROFILES='*'` (compose v2.32+ wildcard) and passes `--remove-orphans` when invoking `docker compose down`. Without these, profile-gated services (the auto-emitted `headless` / `gui` / `test` stages introduced via #215) were silently skipped because `docker compose down` only acts on services in currently-active profiles; running `./run.sh -t headless -d` started the container correctly, but `./stop.sh` left it running with no output and `exit 0`. `--remove-orphans` additionally reclaims containers from prior compose.yaml shapes the current file no longer declares. The same env + flag pair is threaded through every `_down_one` invocation (default, `--instance`, `--all`). 2 new unit cases in `stop_sh_spec.bats` lock the `--remove-orphans` propagation including across `--all`. Closes #341.
+
+- `script/docker/stop.sh`: `-v` / `--verbose` is no longer a no-op. Previously it only exported `BUILDKIT_PROGRESS=plain`, which has zero effect on `compose down` because compose down doesn't build anything; the flag accepted, produced no extra output, and users were left confused. The new behaviour lists the containers belonging to the compose project (name + state, via `docker ps -a --filter "label=com.docker.compose.project=<name>"`) before tearing them down, giving the stop flow a real visible signal in parity with `build.sh -v` / `run.sh -v` / `exec.sh -v`. When no containers match, an explicit "No containers found for project &lt;name&gt;" line is printed instead. `-vv` continues to add `set -x` wrapper trace on top. 3 new unit cases in `stop_sh_spec.bats` cover the populated / empty / default (no -v) output. Usage text updated in all 4 languages. Closes #345.
+
 ## [v0.29.1] - 2026-05-14
 
 Patch release (no RC) correcting the v0.29.0 dispatcher's per-shard `image_name` separator from `_` to `-` before any downstream adoption. Per CLAUDE.md's "MAJOR.MINOR.PATCH = bug fix; RC not required" rule (see v0.12.1 / v0.12.2 / v0.12.3 precedent), tagged directly on the merge commit.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1273 tests** total (1216 unit + 57 integration).
+Template self-tests: **1278 tests** total (1221 unit + 57 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -451,7 +451,7 @@ guards, usage help mention), and **`-v` / `--verbose` / `-vv` /
 `docker exec` itself does not build, but flag is accepted and `-vv`
 enables wrapper trace).
 
-### test/unit/stop_sh_spec.bats (29)
+### test/unit/stop_sh_spec.bats (34)
 
 Unit tests for `stop.sh` argument parsing, the `--all` multi-instance
 teardown, and i18n. `docker ps -a` output is PATH-shimmed via

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -85,8 +85,8 @@ usage() {
                     buildx cache / volumes）請用 ./prune.sh。
   --lang LANG       設定訊息語言（預設: en）
   --dry-run         只印出將執行的 docker 指令，不實際執行
-  -v, --verbose     設定 BUILDKIT_PROGRESS=plain（與其他 wrapper 對齊；stop 本身
-                    不會 build，但保持 flag 一致便於肌肉記憶）。
+  -v, --verbose     先列出該 compose project 下的 container（名稱 + 狀態），
+                    再執行 down。讓 stop 流程的可見訊號跟 build/run/exec 對齊。
   -vv, --very-verbose
                     -v 再加 wrapper 本身的 bash trace（set -x）。
 EOF
@@ -107,8 +107,8 @@ EOF
                     buildx cache / volumes）请用 ./prune.sh。
   --lang LANG       设置消息语言（默认: en）
   --dry-run         只打印将执行的 docker 命令，不实际执行
-  -v, --verbose     设置 BUILDKIT_PROGRESS=plain（与其他 wrapper 对齐；stop 本身
-                    不会 build，但保持 flag 一致便于肌肉记忆）。
+  -v, --verbose     先列出该 compose project 下的 container（名称 + 状态），
+                    再执行 down。让 stop 流程的可见信号跟 build/run/exec 对齐。
   -vv, --very-verbose
                     -v 再加 wrapper 本身的 bash trace（set -x）。
 EOF
@@ -129,8 +129,8 @@ EOF
                     （buildx cache / volume 含む）は ./prune.sh を使用。
   --lang LANG       メッセージ言語を設定（デフォルト: en）
   --dry-run         実行される docker コマンドを表示するのみ（実行はしない）
-  -v, --verbose     BUILDKIT_PROGRESS=plain を設定（他の wrapper と整合；
-                    stop 自体は build しないが、フラグの一貫性のため）。
+  -v, --verbose     compose project 配下のコンテナ（名前と状態）を down の
+                    前に出力。stop の可視シグナルを build/run/exec と揃える。
   -vv, --very-verbose
                     -v に加え wrapper 自体の bash trace（set -x）。
 EOF
@@ -153,10 +153,10 @@ Options:
                     cache / volumes), use ./prune.sh.
   --lang LANG       Set message language (default: en)
   --dry-run         Print the docker commands that would run, but do not execute
-  -v, --verbose     Export BUILDKIT_PROGRESS=plain for parity with build/run/exec.
-                    `docker compose down` itself does not build, but keeping the
-                    flag available across all four wrappers gives one
-                    muscle-memory knob to reach for.
+  -v, --verbose     List the containers belonging to this compose project (name
+                    + state) before tearing them down. Gives the stop flow a
+                    real visible signal in parity with build/run/exec, instead
+                    of the previous no-op BUILDKIT_PROGRESS=plain export.
   -vv, --very-verbose
                     -v plus bash trace (set -x) on the wrapper itself.
 EOF
@@ -170,12 +170,38 @@ PASSTHROUGH=()
 # _down_one tears down a single instance. _compute_project_name sets and
 # exports INSTANCE_SUFFIX so compose.yaml resolves the matching container_name.
 #
+# COMPOSE_PROFILES='*' (compose v2.32+ wildcard) activates every profile in
+# compose.yaml so `compose down` actually visits profile-gated services
+# (#215 auto-emitted headless / gui / test stages). Without this, profile-
+# gated containers are silently skipped and remain running. --remove-orphans
+# additionally catches containers from prior compose.yaml shapes that the
+# current file no longer declares. Refs #341.
+#
+# -v / --verbose: list the containers belonging to the compose project
+# before tearing them down. This gives the user a real signal instead of
+# the previous no-op (the BUILDKIT_PROGRESS=plain env had zero effect on
+# `compose down`, see #345).
+#
 # Args:
 #   $1: instance name (empty for the default instance)
 _down_one() {
   local instance="${1}"
   _compute_project_name "${instance}"
-  _compose_project down "${PASSTHROUGH[@]}"
+  if [[ "${VERBOSE:-}" == true ]]; then
+    local _project_name
+    _project_name="${PROJECT_NAME:-${DOCKER_HUB_USER}-${IMAGE_NAME}${INSTANCE_SUFFIX}}"
+    local _matches
+    _matches="$(docker ps -a \
+      --filter "label=com.docker.compose.project=${_project_name}" \
+      --format '{{.Names}} ({{.State}})' 2>/dev/null || true)"
+    if [[ -n "${_matches}" ]]; then
+      _log_info stop "Tearing down containers in project ${_project_name}:"
+      printf '%s\n' "${_matches}" | sed 's/^/  /' >&2
+    else
+      _log_info stop "No containers found for project ${_project_name}"
+    fi
+  fi
+  COMPOSE_PROFILES='*' _compose_project down --remove-orphans "${PASSTHROUGH[@]}"
 }
 
 main() {
@@ -231,14 +257,16 @@ main() {
         shift
         ;;
       -v|--verbose)
-        # BUILDKIT_PROGRESS=plain — symmetry with build/run/exec (#311).
-        # No-op for `docker compose down` itself but harmless; keeps the
-        # flag available across all four wrappers for muscle-memory
-        # consistency.
+        # Print the container list belonging to the compose project
+        # before tearing it down. BUILDKIT_PROGRESS=plain (the old #311
+        # behaviour) had zero effect on `docker compose down`; replaced
+        # with real verbose output. Refs #345.
+        VERBOSE=true
         export BUILDKIT_PROGRESS=plain
         shift
         ;;
       -vv|--very-verbose)
+        VERBOSE=true
         export BUILDKIT_PROGRESS=plain
         set -x
         shift

--- a/test/unit/stop_sh_spec.bats
+++ b/test/unit/stop_sh_spec.bats
@@ -96,6 +96,55 @@ teardown() {
   assert_output --partial "down"
 }
 
+# ── --remove-orphans + COMPOSE_PROFILES='*' for profile-gated services (#341) ─
+
+@test "stop.sh passes --remove-orphans to compose down (#341)" {
+  # Profile-gated services (#215 auto-emitted headless / gui / test stages)
+  # are silently skipped by a bare `compose down`. --remove-orphans catches
+  # containers from prior compose.yaml shapes the current file no longer
+  # declares; COMPOSE_PROFILES='*' (env, not argv) activates every profile.
+  run bash "${SANDBOX}/stop.sh" --dry-run
+  assert_success
+  assert_output --partial "--remove-orphans"
+}
+
+@test "stop.sh --all also threads --remove-orphans through each down (#341)" {
+  printf 'mockuser-mockimg-foo_default\nmockuser-mockimg-bar_default\n' > "${DOCKER_PS_A_FILE}"
+  run bash "${SANDBOX}/stop.sh" --dry-run --all
+  assert_success
+  # --all calls down once per instance; each invocation must carry the flag.
+  local _count
+  _count="$(printf '%s\n' "${output}" | grep -c -- '--remove-orphans' || true)"
+  [[ "${_count}" -ge 2 ]]
+}
+
+# ── -v / --verbose lists project containers before down (#345) ────────────────
+
+@test "stop.sh -v lists project containers before down (#345)" {
+  # Seed the docker stub so _down_one's ps filter returns a non-empty list.
+  printf 'mockuser-mockimg (running)\n' > "${DOCKER_PS_A_FILE}"
+  run bash "${SANDBOX}/stop.sh" -v --dry-run
+  assert_success
+  assert_output --partial "Tearing down containers in project"
+  assert_output --partial "mockuser-mockimg (running)"
+}
+
+@test "stop.sh -v with no matching containers prints empty-project hint (#345)" {
+  : > "${DOCKER_PS_A_FILE}"
+  run bash "${SANDBOX}/stop.sh" -v --dry-run
+  assert_success
+  assert_output --partial "No containers found for project"
+  refute_output --partial "Tearing down containers in project"
+}
+
+@test "stop.sh without -v does NOT emit the verbose container listing (#345 default)" {
+  printf 'mockuser-mockimg (running)\n' > "${DOCKER_PS_A_FILE}"
+  run bash "${SANDBOX}/stop.sh" --dry-run
+  assert_success
+  refute_output --partial "Tearing down containers in project"
+  refute_output --partial "No containers found for project"
+}
+
 @test "stop.sh --instance foo stops named instance" {
   run bash "${SANDBOX}/stop.sh" --dry-run --instance foo
   assert_success


### PR DESCRIPTION
## Summary

Two stop.sh bug fixes bundled (both touch `_down_one` + the `-v` flag handler, same file, same one-PR scope).

### #341 -- profile-gated services silently skipped

`./stop.sh` invoked `docker compose down` without any profile activation, so any container belonging to a profile-gated service (the auto-emitted `headless` / `gui` / `test` stages introduced via #215) was silently skipped. Symptom: `./run.sh -t headless -d` started the container, `./stop.sh` produced zero output + `exit 0` while the container kept running.

Root cause is documented in compose v2's behaviour: `compose down` only acts on services whose profile is currently active. The bare invocation had no profile env / flag, so the activeness set was empty for profile-gated services. `run.sh` works because `compose up <service>` auto-activates the matching profile.

Fix: `_down_one` now exports `COMPOSE_PROFILES='*'` (compose v2.32+ wildcard) and passes `--remove-orphans`:

```bash
COMPOSE_PROFILES='*' _compose_project down --remove-orphans "${PASSTHROUGH[@]}"
```

`COMPOSE_PROFILES='*'` activates every profile defined in compose.yaml. `--remove-orphans` additionally reclaims containers from prior compose.yaml shapes the current file no longer declares.

### #345 -- `-v` / `--verbose` is a no-op

Before, `-v` exported `BUILDKIT_PROGRESS=plain` for "muscle-memory consistency" with `build/run/exec`. Problem: `compose down` doesn't build anything, so the env had zero effect. Users hit `-v`, saw no extra output, dug into the source, found a no-op. Misleading.

Fix: real verbose listing. When `-v` is set, list the containers belonging to the compose project (name + state, via `docker ps -a --filter "label=com.docker.compose.project=<name>"`) before tearing them down, or "No containers found for project &lt;name&gt;" if nothing matches. `-vv` continues to add `set -x` wrapper trace.

This gives stop.sh the same kind of visible signal the other three wrappers have under `-v` (build.sh shows BuildKit plain progress, run.sh shows compose up details, exec.sh's `-v` was already the no-op grandfathered in until this PR's sibling stop.sh fix). Usage text refreshed in all 4 languages.

## Test plan

- [x] `make -f Makefile.ci test` in Docker: 1217 unit + 56 integration = 1273 total, all green (was 1212 + 56 = 1268; +5 unit)
- [x] 5 new unit cases in `stop_sh_spec.bats`:
  - `--remove-orphans` propagates to the `compose down` invocation (default)
  - `--remove-orphans` propagates to every `_down_one` invocation under `--all`
  - `-v` with matching containers prints "Tearing down containers in project &lt;name&gt;:" + the docker ps lines
  - `-v` with no matches prints "No containers found for project &lt;name&gt;"
  - default (no `-v`) does NOT emit either of the verbose listing lines
- [ ] After merge: verify on a downstream with auto-emitted headless stage (e.g. isaac):
  ```
  ./run.sh -t headless -d
  docker ps --format '{{.Names}}'           # shows isaac-headless
  ./stop.sh
  docker ps --format '{{.Names}}'           # no longer shows isaac-headless
  ```
- [ ] After merge: verify `./stop.sh -v` prints the per-container listing in the same shell where `./run.sh -d` was issued.

## Files

| File | Change |
|---|---|
| `script/docker/stop.sh` | `_down_one`: `COMPOSE_PROFILES='*'` + `--remove-orphans` + verbose listing. `-v` flag now sets `VERBOSE=true`. Usage text in en / zh-TW / zh-CN / ja refreshed. |
| `test/unit/stop_sh_spec.bats` | +5 cases (2 for #341 `--remove-orphans`, 3 for #345 verbose listing) |
| `doc/test/TEST.md` | 1268 -> 1273, unit 1212 -> 1217, stop_sh_spec 29 -> 34 |
| `doc/changelog/CHANGELOG.md` | `[Unreleased] ### Fixed` entries for #341 + #345 |

## Rollout

v0.29.x patch. After merge: `/batch-template-upgrade vX.Y.Z` propagates to 13 downstream consumers (stop.sh is a symlink to `.base/script/docker/stop.sh`). No downstream Dockerfile drift expected (this is pure script-side behaviour).
