### PR TITLE
feat(upgrade): auto-patch downstream Dockerfile lib drift on subtree pull (closes #348)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `upgrade.sh`: auto-patch downstream Dockerfile lint stage to add `COPY .base/script/docker/lib /lint/lib` + extend `RUN shellcheck` to cover `/lint/lib/*.sh` on first upgrade after #284 (closes #348). Every fanout cycle since v0.27.0 has tripped on 12 of 13 downstream Dockerfiles failing CI with `/lint/lib/log.sh: No such file or directory` because the umbrella loader (`_lib.sh`) source-chains into `lib/{log,env,conf,compose,config_summary,gitignore}.sh` but the stock `COPY .base/script/docker/*.sh /lint/` doesn't recurse into the `lib/` subdirectory. The auto-patch detects the missing COPY line and the stock `RUN shellcheck -S warning /lint/*.sh` anchor, then sed-inserts the COPY line and extends the shellcheck invocation. Idempotent (no-op when the COPY line is already present); skips with a warning when the Dockerfile uses a custom shape (no stock anchor); skips cleanly when no Dockerfile is at the repo root (subtree-only consumer repos). Patched changes ride on the existing `chore: update template references to vX.Y.Z` commit. Eliminates the recurring `fix-dockerfile-lint-lib.sh` post-fanout cleanup workflow used through v0.28.2.
+
 ## [v0.29.2] - 2026-05-14
 
 Patch release bundling 4 small-bug closures since v0.29.1: #334 (Dockerfile.example WORKDIR collapse), #335 (exec.sh -t non-devel precheck), #341 (stop.sh skips profile-gated services), #345 (stop.sh -v no-op). No breaking changes from v0.29.1. Per CLAUDE.md's "MAJOR.MINOR.PATCH = bug fix; RC not required" rule, tagged directly on the merge commit.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1278 tests** total (1221 unit + 57 integration).
+Template self-tests: **1282 tests** total (1221 unit + 61 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -988,19 +988,25 @@ invocation — `build.sh --dry-run`).
 | `fresh clone with stale absolute mount_1: build.sh auto-migrates + generates local .env` | Stale-path auto-migrate |
 | `fresh clone with portable ${WS_PATH} mount_1: no warning, .env gets local path` | Happy path round-trip |
 
-### test/integration/upgrade_spec.bats (8)
+### test/integration/upgrade_spec.bats (12)
 
 End-to-end verification for `upgrade.sh` driving a real subtree update
 against a fake template remote (bare repo with `v0.9.5` / `v0.9.7` tags
 on a minimal subtree layout) attached to a sandbox downstream repo.
 **Level 1** (no Docker). Exercises the happy path, the pre-flight
-guards, and — most importantly — the destructive-FF rollback path added
-after the Jetson v0.9.7 incident (stubs `git-subtree pull` via
-`GIT_EXEC_PATH` to simulate the bug and asserts the repo is restored).
+guards, the destructive-FF rollback path added after the Jetson v0.9.7
+incident (stubs `git-subtree pull` via `GIT_EXEC_PATH` to simulate the
+bug and asserts the repo is restored), and the post-#284 Dockerfile
+lint-stage auto-patch that heals downstream Dockerfiles missing the
+`COPY .base/script/docker/lib /lint/lib` line (#348).
 
 | Test | Description |
 |------|-------------|
 | `upgrade.sh v0.9.7: bumps template/.version, pulls new content, updates main.yaml` | Happy path |
+| `upgrade.sh patches Dockerfile lint stage when missing COPY .base/script/docker/lib /lint/lib (#348)` | Auto-heal post-#284 lib drift on first upgrade |
+| `upgrade.sh is idempotent on Dockerfile already containing the lib COPY line (#348)` | Already-patched Dockerfile is unchanged on re-run |
+| `upgrade.sh warns + skips Dockerfile patch when stock shellcheck anchor is missing (#348)` | Custom Dockerfile shape opts out of auto-heal |
+| `upgrade.sh continues cleanly when no Dockerfile at repo root (#348)` | Subtree-only repos (no consumer Dockerfile) skip silently |
 | `upgrade.sh v0.9.7 is idempotent on a second run` | Re-run is no-op |
 | `upgrade.sh --check reports update available from v0.9.5 → v0.9.7` | --check flag |
 | `make upgrade-check (downstream Makefile): exit 0 when update available (#175)` | Regression #175: make wraps exit 1 |

--- a/test/integration/upgrade_spec.bats
+++ b/test/integration/upgrade_spec.bats
@@ -112,6 +112,73 @@ YAML
   [ "$(cat README.md)" = "DOWNSTREAM" ]
 }
 
+@test "upgrade.sh patches Dockerfile lint stage when missing COPY .base/script/docker/lib /lint/lib (#348)" {
+  cd "${DOWN_DIR}"
+  cat > Dockerfile <<'EOF'
+FROM busybox AS lint
+COPY .base/script/docker/*.sh /lint/
+RUN shellcheck -S warning /lint/*.sh
+EOF
+  git add Dockerfile
+  git commit -q -m "add Dockerfile"
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" ./.base/upgrade.sh v0.9.7
+  assert_success
+  assert_output --partial "Dockerfile patched"
+
+  grep -Fq "COPY .base/script/docker/lib /lint/lib" Dockerfile
+  grep -Fq "RUN shellcheck -S warning /lint/*.sh /lint/lib/*.sh" Dockerfile
+}
+
+@test "upgrade.sh is idempotent on Dockerfile already containing the lib COPY line (#348)" {
+  cd "${DOWN_DIR}"
+  cat > Dockerfile <<'EOF'
+FROM busybox AS lint
+COPY .base/script/docker/*.sh /lint/
+COPY .base/script/docker/lib /lint/lib
+RUN shellcheck -S warning /lint/*.sh /lint/lib/*.sh
+EOF
+  git add Dockerfile
+  git commit -q -m "add Dockerfile (already patched)"
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" ./.base/upgrade.sh v0.9.7
+  assert_success
+  assert_output --partial "already copies .base/script/docker/lib"
+  refute_output --partial "Dockerfile patched"
+
+  # Single COPY line, no duplicate insertion.
+  [ "$(grep -c 'COPY .base/script/docker/lib /lint/lib' Dockerfile)" = "1" ]
+}
+
+@test "upgrade.sh warns + skips Dockerfile patch when stock shellcheck anchor is missing (#348)" {
+  cd "${DOWN_DIR}"
+  cat > Dockerfile <<'EOF'
+FROM busybox AS lint
+COPY .base/script/docker/*.sh /lint/
+RUN echo "custom Dockerfile lint setup"
+EOF
+  git add Dockerfile
+  git commit -q -m "add custom Dockerfile"
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" ./.base/upgrade.sh v0.9.7
+  assert_success
+  assert_output --partial "lacks stock 'RUN shellcheck -S warning /lint/*.sh' anchor"
+  refute_output --partial "Dockerfile patched"
+
+  ! grep -q "COPY .base/script/docker/lib /lint/lib" Dockerfile
+}
+
+@test "upgrade.sh continues cleanly when no Dockerfile at repo root (#348)" {
+  cd "${DOWN_DIR}"
+  # Default _seed_downstream_repo fixture leaves no Dockerfile at root —
+  # exercise the early-return branch.
+  [ ! -f Dockerfile ]
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" ./.base/upgrade.sh v0.9.7
+  assert_success
+  assert_output --partial "no Dockerfile at repo root"
+}
+
 @test "upgrade.sh v0.9.7 is idempotent on a second run" {
   cd "${DOWN_DIR}"
 

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -828,7 +828,11 @@ EOF
   # production sed commands here, mirroring what upgrade.sh does.
   # We do this by extracting and running the sed commands from upgrade.sh.
   local _seds
-  _seds="$(grep -E "^[[:space:]]*sed -i" /source/upgrade.sh)"
+  # Narrow the sed extract to main_yaml-targeted lines. upgrade.sh also
+  # carries Dockerfile-targeted seds (#348 auto-patch); the substitution
+  # below only knows how to fill in main_yaml + target_ver, so feeding it
+  # a Dockerfile sed would `eval sed -i ... ""` with an empty filename.
+  _seds="$(grep -E '^[[:space:]]*sed -i.*main_yaml' /source/upgrade.sh)"
   while IFS= read -r _line; do
     # shellcheck disable=SC2001
     _line="$(echo "${_line}" | sed "s|\${main_yaml}|${_yaml}|g; s|\${target_ver}|v0.6.4|g")"
@@ -862,7 +866,11 @@ jobs:
     uses: ycpss91255-docker/base/.github/workflows/release-worker.yaml@v0.10.0-rc1
 EOF
   local _seds
-  _seds="$(grep -E "^[[:space:]]*sed -i" /source/upgrade.sh)"
+  # Narrow the sed extract to main_yaml-targeted lines. upgrade.sh also
+  # carries Dockerfile-targeted seds (#348 auto-patch); the substitution
+  # below only knows how to fill in main_yaml + target_ver, so feeding it
+  # a Dockerfile sed would `eval sed -i ... ""` with an empty filename.
+  _seds="$(grep -E '^[[:space:]]*sed -i.*main_yaml' /source/upgrade.sh)"
   while IFS= read -r _line; do
     # shellcheck disable=SC2001
     _line="$(echo "${_line}" | sed "s|\${main_yaml}|${_yaml}|g; s|\${target_ver}|v0.10.0-rc2|g")"
@@ -895,7 +903,11 @@ jobs:
     uses: ycpss91255-docker/base/.github/workflows/release-worker.yaml@v0.9.9
 EOF
   local _seds
-  _seds="$(grep -E "^[[:space:]]*sed -i" /source/upgrade.sh)"
+  # Narrow the sed extract to main_yaml-targeted lines. upgrade.sh also
+  # carries Dockerfile-targeted seds (#348 auto-patch); the substitution
+  # below only knows how to fill in main_yaml + target_ver, so feeding it
+  # a Dockerfile sed would `eval sed -i ... ""` with an empty filename.
+  _seds="$(grep -E '^[[:space:]]*sed -i.*main_yaml' /source/upgrade.sh)"
   while IFS= read -r _line; do
     # shellcheck disable=SC2001
     _line="$(echo "${_line}" | sed "s|\${main_yaml}|${_yaml}|g; s|\${target_ver}|v0.10.0|g")"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -258,21 +258,21 @@ _upgrade() {
   _pre_setup_conf_hash="$(git rev-parse --verify "HEAD:${TEMPLATE_REL}/config/docker/setup.conf" 2>/dev/null || true)"
 
   # Step 1: subtree pull
-  _log "Step 1/4: git subtree pull"
+  _log "Step 1/5: git subtree pull"
   git subtree pull --prefix="${TEMPLATE_REL}" \
     "${TEMPLATE_REMOTE}" "${target_ver}" --squash \
     -m "chore: upgrade ${TEMPLATE_REL} subtree to ${target_ver}"
 
   # Step 2: post-pull integrity check (rolls back on corruption)
-  _log "Step 2/4: verify ${TEMPLATE_REL}/ subtree integrity"
+  _log "Step 2/5: verify ${TEMPLATE_REL}/ subtree integrity"
   _verify_subtree_intact "${_pre_head}"
 
   # Step 3: re-run init.sh to sync symlinks (in case template structure changed)
-  _log "Step 3/4: re-run init.sh to sync symlinks"
+  _log "Step 3/5: re-run init.sh to sync symlinks"
   "./${TEMPLATE_REL}/init.sh"
 
   # Step 4: update main.yaml @tag references
-  _log "Step 4/4: update workflow @tag references"
+  _log "Step 4/5: update workflow @tag references"
   local main_yaml="${REPO_ROOT}/.github/workflows/main.yaml"
   if [[ -f "${main_yaml}" ]]; then
     # Replace @vX.Y.Z(-prerelease)? with new version in reusable workflow
@@ -284,6 +284,37 @@ _upgrade() {
     sed -i -E "s|build-worker\.yaml@v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?|build-worker.yaml@${target_ver}|g" "${main_yaml}"
     sed -i -E "s|release-worker\.yaml@v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?|release-worker.yaml@${target_ver}|g" "${main_yaml}"
     git add "${main_yaml}"
+  fi
+
+  # Step 5: patch downstream Dockerfile lint stage for the #284 lib/ split
+  # (closes #348). The split lives inside the subtree
+  # (`.base/script/docker/lib/{log,env,conf,compose,config_summary,gitignore}.sh`)
+  # and propagates via subtree pull, but the downstream Dockerfile's
+  # `COPY .base/script/docker/*.sh /lint/` only copies the umbrella loaders —
+  # not the lib/ subdirectory the umbrella source-chains into. Every
+  # post-#284 fanout has tripped the same `/lint/lib/log.sh: No such file
+  # or directory` failure on 12 of 13 downstream repos until manually
+  # patched. This step auto-heals each downstream Dockerfile on first
+  # upgrade so the next fanout is clean.
+  _log "Step 5/5: patch Dockerfile lint stage for lib/ split (#284 / #348)"
+  local _dockerfile="${REPO_ROOT}/Dockerfile"
+  if [[ ! -f "${_dockerfile}" ]]; then
+    _log "  no Dockerfile at repo root — skip"
+  elif grep -qE '^[[:space:]]*COPY[[:space:]]+\.base/script/docker/lib[[:space:]/]' "${_dockerfile}"; then
+    _log "  Dockerfile already copies .base/script/docker/lib — skip (idempotent)"
+  elif ! grep -qE '^RUN shellcheck -S warning /lint/\*\.sh$' "${_dockerfile}"; then
+    # Custom Dockerfile shape (no stock /lint/*.sh shellcheck anchor) —
+    # do not force-patch. The user can adopt the COPY + extended shellcheck
+    # invocation manually, or upgrade.sh will re-detect on the next run
+    # once they normalize.
+    _log "  Dockerfile lacks stock 'RUN shellcheck -S warning /lint/*.sh' anchor — skip (custom shape)"
+  else
+    # Insert COPY before the shellcheck anchor and extend the shellcheck
+    # invocation to also cover /lint/lib/*.sh.
+    sed -i '/^RUN shellcheck -S warning \/lint\/\*\.sh$/i COPY .base/script/docker/lib /lint/lib' "${_dockerfile}"
+    sed -i 's|^RUN shellcheck -S warning /lint/\*\.sh$|RUN shellcheck -S warning /lint/*.sh /lint/lib/*.sh|' "${_dockerfile}"
+    git add "${_dockerfile}"
+    _log "  Dockerfile patched: COPY .base/script/docker/lib /lint/lib + shellcheck extended"
   fi
 
   # Step 3 ran init.sh which (re-)synced .gitignore via lib/gitignore.sh


### PR DESCRIPTION
## Summary

Closes #348. Moves the recurring post-fanout
`fix-dockerfile-lint-lib.sh` cleanup into `upgrade.sh` as a new
Step 5/5, so each `make -f Makefile.ci upgrade` heals its own
Dockerfile in-place on the same chore commit that bumps the
`main.yaml @tag` references and syncs `.gitignore`. Future
`/batch-template-upgrade vX.Y.Z` fanouts are clean without
post-fanout cleanup scripts.

## What changes

### `upgrade.sh`

New Step 5/5 (between the main.yaml @tag bump and the
.gitignore stage):

```bash
if [[ ! -f "${_dockerfile}" ]]; then
  _log "  no Dockerfile at repo root — skip"
elif grep -qE '^[[:space:]]*COPY[[:space:]]+\.base/script/docker/lib[[:space:]/]' "${_dockerfile}"; then
  _log "  Dockerfile already copies .base/script/docker/lib — skip (idempotent)"
elif ! grep -qE '^RUN shellcheck -S warning /lint/\*\.sh$' "${_dockerfile}"; then
  _log "  Dockerfile lacks stock 'RUN shellcheck -S warning /lint/*.sh' anchor — skip (custom shape)"
else
  sed -i '/^RUN shellcheck -S warning \/lint\/\*\.sh$/i COPY .base/script/docker/lib /lint/lib' "${_dockerfile}"
  sed -i 's|^RUN shellcheck -S warning /lint/\*\.sh$|RUN shellcheck -S warning /lint/*.sh /lint/lib/*.sh|' "${_dockerfile}"
  git add "${_dockerfile}"
  _log "  Dockerfile patched: COPY .base/script/docker/lib /lint/lib + shellcheck extended"
fi
```

Behaviour matrix:

| Dockerfile state | Action |
|---|---|
| Has stock anchor + missing COPY line | Patch in-place + stage |
| Has COPY line already | Skip silently (idempotent) |
| Lacks stock anchor (custom shape) | Skip with warning |
| Not present at repo root | Skip silently |

The patched Dockerfile rides on the existing `chore: update template
references to vX.Y.Z` commit alongside `main.yaml` + `.gitignore`
staging — no extra commits.

Step numbering bumped `4` -> `5` everywhere (`_log "Step X/4"` ->
`_log "Step X/5"`).

### `test/integration/upgrade_spec.bats`

4 new test cases (8 -> 12), one per behaviour branch:

- `upgrade.sh patches Dockerfile lint stage when missing COPY
  .base/script/docker/lib /lint/lib (#348)`
- `upgrade.sh is idempotent on Dockerfile already containing the
  lib COPY line (#348)`
- `upgrade.sh warns + skips Dockerfile patch when stock shellcheck
  anchor is missing (#348)`
- `upgrade.sh continues cleanly when no Dockerfile at repo root
  (#348)`

Each seeds a downstream Dockerfile of the appropriate shape into
the existing fake-template-remote fixture, runs upgrade.sh against
v0.9.7, and asserts the resulting Dockerfile + log output.

### `test/unit/template_spec.bats`

3 pre-existing `main.yaml sed` regression tests use:

```bash
_seds="$(grep -E '^[[:space:]]*sed -i' /source/upgrade.sh)"
# ... substitute ${main_yaml} + ${target_ver}, eval each
```

This extracts ALL `sed -i` lines from upgrade.sh and feeds them
through a substitution loop that only knows how to fill
`${main_yaml}` + `${target_ver}`. After this PR, upgrade.sh has
two new Dockerfile-targeted seds (using `${_dockerfile}`) that
would `eval sed -i ... ""` with an empty filename — the failure
spotted as `sed: : No such file or directory` while bringing this
PR up.

Fix: narrow the grep to `main_yaml`-targeted lines only:

```bash
_seds="$(grep -E '^[[:space:]]*sed -i.*main_yaml' /source/upgrade.sh)"
```

### `doc/test/TEST.md` + `doc/changelog/CHANGELOG.md`

- TEST.md: integration `upgrade_spec.bats` row goes `8 -> 12`;
  total `1278 -> 1282` (1221 unit unchanged; 57 -> 61 integration).
  Narrative explains the new auto-heal coverage.
- CHANGELOG.md `[Unreleased]` `### Added` entry.

## Verification

- `make -f Makefile.ci test` -> 1282/1282 green (1221 unit + 61
  integration).
- `shellcheck -S warning upgrade.sh` -> clean (run via the
  pinned koalaman/shellcheck:stable Docker image to match the CI
  invocation).

## Why this is `Added` not `Fixed`

The `_lib.sh` split (#284) shipped in template v0.27.0 with the
documented assumption that downstream Dockerfiles would carry the
new `COPY .base/script/docker/lib /lint/lib` line — the
documentation just never reached every downstream Dockerfile, so
the assumption broke silently. This PR adds a NEW capability to
`upgrade.sh` (post-pull Dockerfile auto-heal) rather than fixing a
bug in existing behaviour. The recurring fanout failures were
side-effects of the missing capability, not the existence of a bug.

## Auto-merge note

Keeping auto-merge OFF — `test` is the only branch-protection-
required check on base
([#337](https://github.com/ycpss91255-docker/base/issues/337) for
the systemic fix). Will manually merge after wait-pr-ci's
`ALL_DONE` confirms all 4 checks green.
