### PR TITLE
feat: consolidate wrappers under script/ + Makefile UX overhaul (#330)

### DIFF
--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -273,14 +273,17 @@ jobs:
           cd "${REPO_DIR}"
           bash .base/init.sh
 
-          # Sanity: verify symlinks resolve and core files exist
-          test -L build.sh && test -L run.sh && test -L exec.sh && test -L stop.sh
-          test -L setup_tui.sh
+          # Sanity: verify symlinks resolve and core files exist.
+          # Post-#330: wrappers live under script/; Makefile stays at root.
+          test -L script/build.sh && test -L script/run.sh \
+            && test -L script/exec.sh && test -L script/stop.sh
+          test -L script/setup_tui.sh
+          test -L Makefile
           test -f Dockerfile && test -f compose.yaml && test -f config/docker/setup.conf
 
           echo "REPO_DIR=${REPO_DIR}" >> "${GITHUB_ENV}"
 
-      - name: Build test stage (build.sh test)
+      - name: Build test stage (script/build.sh test)
         working-directory: ${{ env.REPO_DIR }}
         env:
           # build.sh skips its internal test-tools:local build when this
@@ -291,25 +294,25 @@ jobs:
           # the dockerfile/Dockerfile.test-tools build.
           TEST_TOOLS_IMAGE: test-tools:local
         run: |
-          ./build.sh test
+          ./script/build.sh test
 
       - name: Build devel stage
         working-directory: ${{ env.REPO_DIR }}
         run: |
-          ./build.sh
+          ./script/build.sh
 
       - name: Run container in detach mode and exec into it
         working-directory: ${{ env.REPO_DIR }}
         run: |
-          ./run.sh -d
+          ./script/run.sh -d
           # Verify the container is up and reachable via exec.sh
-          ./exec.sh echo "exec.sh OK from CI"
-          ./exec.sh whoami
+          ./script/exec.sh echo "exec.sh OK from CI"
+          ./script/exec.sh whoami
 
       - name: Stop and verify cleanup
         working-directory: ${{ env.REPO_DIR }}
         run: |
-          ./stop.sh
+          ./script/stop.sh
           # No project containers should remain
           if docker ps --format '{{.Names}}' | grep -q '^e2e_test$'; then
             echo "ERROR: container still running after stop.sh"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ graph TB
     end
 
     subgraph consumer["Docker Repo (e.g. ros_noetic)"]
-        symlinks["build.sh → .base/script/docker/build.sh<br/>run.sh → .base/script/docker/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
+        symlinks["Makefile → .base/script/docker/Makefile<br/>script/build.sh → ../.base/script/docker/build.sh<br/>script/run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
         dockerfile["Dockerfile<br/>compose.yaml<br/>.env.example<br/>script/entrypoint.sh"]
         repo_test["test/smoke/<br/>app_env.bats (repo-specific)"]
         main_yaml["main.yaml<br/>→ calls reusable workflows"]
@@ -81,8 +81,8 @@ graph TB
 ```mermaid
 flowchart LR
     subgraph local["Local"]
-        build_test["./build.sh test"]
-        make_test["make test"]
+        build_test["./script/build.sh test"]
+        make_test["make build test"]
     end
 
     subgraph ci_container["CI Container (kcov/kcov)"]
@@ -126,8 +126,8 @@ flowchart LR
 | `test/unit/` | Template self-tests (bats + kcov) |
 | `test/integration/` | Level-1 `init.sh` end-to-end tests |
 | `.hadolint.yaml` | Shared Hadolint rules |
-| `Makefile` | Repo entry (`make build`, `make run`, `make stop`, etc.) |
-| `Makefile.ci` | Template CI entry (`make test`, `make -f Makefile.ci lint`, etc.) |
+| `Makefile` | Repo entry (`make build`, `make run`, `make stop`, etc.). Sub-cmds forward positionally (`make build test`); flags need `--` separator (`make build -- --no-cache test`). `make` no-arg prints help (`.DEFAULT_GOAL := help`). |
+| `Makefile.ci` | Template CI entry (`make -f Makefile.ci test`, `make -f Makefile.ci lint`, etc.). The user-facing vs CI-facing split is intentional. |
 | `init.sh` | First-time symlink setup + new-repo scaffolding |
 | `upgrade.sh` | Subtree version upgrade |
 | `script/ci/ci.sh` | CI pipeline (local + remote) |
@@ -219,10 +219,15 @@ ENTRYPOINT ["/isaac-sim/runapp.sh"]
 ```
 
 ```bash
-./build.sh                    # regenerates compose.yaml, builds all stages
-./run.sh -t headless          # runs the headless variant
-./run.sh -t gui               # runs the gui variant
-./exec.sh -t headless bash    # exec into running headless container
+make build                            # regenerates compose.yaml, builds all stages
+make run -- -t headless               # runs the headless variant
+make run -- -t gui                    # runs the gui variant
+make exec -- -t headless bash         # exec into running headless container
+
+# Equivalent direct .sh invocation:
+./script/build.sh
+./script/run.sh -t headless
+./script/exec.sh -t headless bash
 ```
 
 Constraints:
@@ -412,13 +417,13 @@ every build or launch:
 > `target: devel-test` stage that runs ShellCheck / Hadolint / Bats
 > smoke (pre-#243 this stage was named `test`). `run.sh`
 > prints an informational `[run] INFO:` block when this is about to
-> happen (TTY only). Pass `--build` to pre-flight `./build.sh test`
+> happen (TTY only). Pass `--build` to pre-flight `./script/build.sh test`
 > first if you want full local-CI parity in one command:
 >
 > ```bash
-> ./build.sh test           # explicit lint + smoke pass
-> ./run.sh --build          # same, then compose up
-> ./run.sh                  # default — fast path, lint/smoke skipped
+> make build test                   # explicit lint + smoke pass
+> make run -- --build               # same, then compose up
+> make run                          # default — fast path, lint/smoke skipped
 > ```
 
 `setup.sh apply` rewrites `compose.yaml` from scratch every time but

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** (#330) — wrapper consolidation: the seven user-facing wrappers (`build.sh` / `run.sh` / `exec.sh` / `stop.sh` / `prune.sh` / `setup.sh` / `setup_tui.sh`) move from the downstream repo root into a `script/` subfolder. `Makefile` stays at the root as the elevated user-facing entry. `init.sh` produces the new layout on fresh repos and migrates existing repos automatically (the stale-root-removal loop in `_create_symlinks` drops the seven legacy root symlinks plus the pre-rename `tui.sh`). `upgrade.sh` calls `init.sh` after the subtree pull, so `make -f Makefile.ci upgrade VERSION=v0.31.0` (or `./.base/upgrade.sh v0.31.0`) is the one-shot migration trigger for downstream consumers. The Dockerfile-level `script/entrypoint.sh` already lived under `script/` and coexists with the new wrappers. External callers hardcoding `./build.sh` / `./run.sh` / etc. break — migration table below.
+
+- **BREAKING** (#330) — Makefile rewrite: the user-facing `.base/script/docker/Makefile` is rewritten to a 1:1 wrapper Makefile with positional-argument forwarding via `$(filter-out $@,$(MAKECMDGOALS))` and a `%:` catch-all rule. Net effect: `make build test` now forwards `test` to `./script/build.sh test` (positional sub-cmds align with `.sh` calling convention); flags require the `--` separator (`make build -- --no-cache test` -> `./script/build.sh --no-cache test`) because Make's argument parser consumes `-` / `--` tokens before `MAKECMDGOALS` is computed. The previously-existing sub-cmd targets `test` / `runtime` / `run-detach` are removed in favour of the positional forwarding pattern. Three new targets ship: `prune` / `setup` / `setup-tui`. `.DEFAULT_GOAL := help` flips the bare-`make` default from "build" to "print help" for better discoverability. `Makefile.ci` is unchanged — the user-facing vs CI-facing split is intentional and preserved (CI keeps using `make -f Makefile.ci test` / `lint` / `upgrade VERSION=vX.Y.Z`).
+
+  Migration table for external consumers:
+
+  | Old | New |
+  |---|---|
+  | `./build.sh` | `make build` (no args) or `./script/build.sh` |
+  | `./build.sh test` | `make build test` or `./script/build.sh test` |
+  | `./build.sh --no-cache test` | `make build -- --no-cache test` or `./script/build.sh --no-cache test` |
+  | `./run.sh -d` | `make run -- -d` or `./script/run.sh -d` |
+  | `./exec.sh -t bats-src bash` | `make exec -- -t bats-src bash` or `./script/exec.sh -t bats-src bash` |
+  | `make test` (removed) | `make build test` (positional forward to `./script/build.sh test`) |
+  | `make runtime` (removed) | `make build runtime` |
+  | `make run-detach` (removed) | `make run -- -d` |
+  | `make` (was: build) | `make` now prints help (`.DEFAULT_GOAL := help`); use `make build` to build |
+
+  New tests cover the 1:1 invocation, positional forwarding, `--` separator, `.DEFAULT_GOAL`, and catch-all behaviour (NEW `test/unit/makefile_user_spec.bats`, ~25 cases) plus the `script/` symlink layout + migration loop (`test/integration/init_new_repo_spec.bats` +3 cases, `test/unit/init_spec.bats` updates + 1 new migration case).
+
 ## [v0.30.0] - 2026-05-14
 
 Promoted from `v0.30.0-rc1` (#360). rc1 tag CI green: `Self Test` +

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -64,7 +64,7 @@ graph TB
     end
 
     subgraph consumer["Docker Repo（例: my_app）"]
-        symlinks["build.sh → .base/script/docker/build.sh<br/>run.sh → .base/script/docker/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
+        symlinks["Makefile → .base/script/docker/Makefile<br/>script/build.sh → ../.base/script/docker/build.sh<br/>script/run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
         dockerfile["Dockerfile<br/>compose.yaml<br/>.env.example<br/>script/entrypoint.sh"]
         repo_test["test/smoke/<br/>app_env.bats（repo 固有）"]
         main_yaml["main.yaml<br/>→ 再利用可能な workflows を呼び出し"]
@@ -81,8 +81,8 @@ graph TB
 ```mermaid
 flowchart LR
     subgraph local["ローカル"]
-        build_test["./build.sh test"]
-        make_test["make test"]
+        build_test["./script/build.sh test"]
+        make_test["make build test"]
     end
 
     subgraph ci_container["CI コンテナ（kcov/kcov）"]
@@ -126,8 +126,8 @@ flowchart LR
 | `test/unit/` | Template 自身のテスト（bats + kcov） |
 | `test/integration/` | Level-1 `init.sh` 統合テスト |
 | `.hadolint.yaml` | 共有 Hadolint ルール |
-| `Makefile` | Repo コマンドエントリ（`make build`、`make run`、`make stop` 等） |
-| `Makefile.ci` | Template CI コマンドエントリ（`make test`、`make lint` 等） |
+| `Makefile` | Repo コマンドエントリ（`make build`、`make run`、`make stop` 等）。Sub-cmd は位置引数として直接渡し（`make build test`）；flag には `--` セパレータが必要（`make build -- --no-cache test`）。`make` 単独で help を表示（`.DEFAULT_GOAL := help`）。 |
+| `Makefile.ci` | Template CI コマンドエントリ（`make -f Makefile.ci test`、`make -f Makefile.ci lint` 等）。user-facing と CI-facing の分離は意図的。 |
 | `init.sh` | 初回 symlink セットアップ + 新 repo スケルトン生成 |
 | `upgrade.sh` | Subtree バージョンアップグレード |
 | `script/ci/ci.sh` | CI パイプライン（ローカル + リモート） |
@@ -183,10 +183,15 @@ ENTRYPOINT ["/isaac-sim/runapp.sh"]
 ```
 
 ```bash
-./build.sh                    # compose.yaml を再生成、全 stage を build
-./run.sh -t headless          # headless バリアントを起動
-./run.sh -t gui               # gui バリアントを起動
-./exec.sh -t headless bash    # running の headless container に exec
+make build                            # compose.yaml を再生成、全 stage を build
+make run -- -t headless               # headless バリアントを起動
+make run -- -t gui                    # gui バリアントを起動
+make exec -- -t headless bash         # running の headless container に exec
+
+# 等価な直接 .sh 呼び出し:
+./script/build.sh
+./script/run.sh -t headless
+./script/exec.sh -t headless bash
 ```
 
 制約：
@@ -386,9 +391,9 @@ Main
 > で実行したい場合は `--build` フラグを付けてください：
 >
 > ```bash
-> ./build.sh test           # 明示的に lint + smoke を実行
-> ./run.sh --build          # lint + smoke を実行してから compose up
-> ./run.sh                  # デフォルト — 高速パス、lint/smoke はスキップ
+> make build test                   # 明示的に lint + smoke を実行
+> make run -- --build               # lint + smoke を実行してから compose up
+> make run                          # デフォルト — 高速パス、lint/smoke はスキップ
 > ```
 
 `setup.sh apply` は毎回 `compose.yaml` をゼロから書き直しますが、

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -64,7 +64,7 @@ graph TB
     end
 
     subgraph consumer["Docker Repo（例如 my_app）"]
-        symlinks["build.sh → .base/script/docker/build.sh<br/>run.sh → .base/script/docker/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
+        symlinks["Makefile → .base/script/docker/Makefile<br/>script/build.sh → ../.base/script/docker/build.sh<br/>script/run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
         dockerfile["Dockerfile<br/>compose.yaml<br/>.env.example<br/>script/entrypoint.sh"]
         repo_test["test/smoke/<br/>app_env.bats（repo 专属）"]
         main_yaml["main.yaml<br/>→ 调用可重用 workflows"]
@@ -81,8 +81,8 @@ graph TB
 ```mermaid
 flowchart LR
     subgraph local["本地"]
-        build_test["./build.sh test"]
-        make_test["make test"]
+        build_test["./script/build.sh test"]
+        make_test["make build test"]
     end
 
     subgraph ci_container["CI 容器（kcov/kcov）"]
@@ -126,8 +126,8 @@ flowchart LR
 | `test/unit/` | Template 自身测试（bats + kcov） |
 | `test/integration/` | Level-1 `init.sh` 集成测试 |
 | `.hadolint.yaml` | 共用 Hadolint 规则 |
-| `Makefile` | Repo 命令入口（`make build`、`make run`、`make stop` 等） |
-| `Makefile.ci` | Template CI 命令入口（`make test`、`make lint` 等） |
+| `Makefile` | Repo 命令入口（`make build`、`make run`、`make stop` 等）。Sub-cmd 直接位置传递（`make build test`）；flag 需要 `--` 分隔符（`make build -- --no-cache test`）。`make` 无参打印 help（`.DEFAULT_GOAL := help`）。 |
+| `Makefile.ci` | Template CI 命令入口（`make -f Makefile.ci test`、`make -f Makefile.ci lint` 等）。user-facing 跟 CI-facing 是有意切割。 |
 | `init.sh` | 首次初始化 symlinks + 新 repo 骨架生成 |
 | `upgrade.sh` | Subtree 版本升级 |
 | `script/ci/ci.sh` | CI pipeline（本地 + 远端） |
@@ -181,10 +181,15 @@ ENTRYPOINT ["/isaac-sim/runapp.sh"]
 ```
 
 ```bash
-./build.sh                    # 重新生成 compose.yaml，build 所有 stages
-./run.sh -t headless          # 跑 headless 变体
-./run.sh -t gui               # 跑 gui 变体
-./exec.sh -t headless bash    # 进入 running 的 headless container
+make build                            # 重新生成 compose.yaml，build 所有 stages
+make run -- -t headless               # 跑 headless 变体
+make run -- -t gui                    # 跑 gui 变体
+make exec -- -t headless bash         # 进入 running 的 headless container
+
+# 等效直接 .sh 写法：
+./script/build.sh
+./script/run.sh -t headless
+./script/exec.sh -t headless bash
 ```
 
 约束：
@@ -365,9 +370,9 @@ Main
 > 想要一次取得跟 CI 同样的完整验证，加 `--build` flag：
 >
 > ```bash
-> ./build.sh test           # 显式跑 lint + smoke
-> ./run.sh --build          # 跑完 lint + smoke 再 compose up
-> ./run.sh                  # 默认 — 快速路径，跳过 lint/smoke
+> make build test                   # 显式跑 lint + smoke
+> make run -- --build               # 跑完 lint + smoke 再 compose up
+> make run                          # 默认 — 快速路径，跳过 lint/smoke
 > ```
 
 `setup.sh apply` 每次都会从头重新生成 `compose.yaml`，但会保留既有 `.env`

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -64,7 +64,7 @@ graph TB
     end
 
     subgraph consumer["Docker Repo（例如 my_app）"]
-        symlinks["build.sh → .base/script/docker/build.sh<br/>run.sh → .base/script/docker/run.sh<br/>exec.sh / stop.sh / .hadolint.yaml"]
+        symlinks["Makefile → .base/script/docker/Makefile<br/>script/build.sh → ../.base/script/docker/build.sh<br/>script/run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
         dockerfile["Dockerfile<br/>compose.yaml<br/>.env.example<br/>script/entrypoint.sh"]
         repo_test["test/smoke/<br/>app_env.bats（repo 專屬）"]
         main_yaml["main.yaml<br/>→ 呼叫可重用 workflows"]
@@ -81,8 +81,8 @@ graph TB
 ```mermaid
 flowchart LR
     subgraph local["本地"]
-        build_test["./build.sh test"]
-        make_test["make test"]
+        build_test["./script/build.sh test"]
+        make_test["make build test"]
     end
 
     subgraph ci_container["CI 容器（kcov/kcov）"]
@@ -126,8 +126,8 @@ flowchart LR
 | `test/unit/` | Template 自身測試（bats + kcov） |
 | `test/integration/` | Level-1 `init.sh` 整合測試 |
 | `.hadolint.yaml` | 共用 Hadolint 規則 |
-| `Makefile` | Repo 指令入口（`make build`、`make run`、`make stop` 等） |
-| `Makefile.ci` | Template CI 指令入口（`make test`、`make lint` 等） |
+| `Makefile` | Repo 指令入口（`make build`、`make run`、`make stop` 等）。Sub-cmd 直接位置傳遞（`make build test`）；flag 需要 `--` 分隔符（`make build -- --no-cache test`）。`make` 無參印 help（`.DEFAULT_GOAL := help`）。 |
+| `Makefile.ci` | Template CI 指令入口（`make -f Makefile.ci test`、`make -f Makefile.ci lint` 等）。user-facing 跟 CI-facing 是刻意切割。 |
 | `init.sh` | 首次初始化 symlinks + 新 repo 骨架產生 |
 | `upgrade.sh` | Subtree 版本升級 |
 | `script/ci/ci.sh` | CI pipeline（本地 + 遠端） |
@@ -181,10 +181,15 @@ ENTRYPOINT ["/isaac-sim/runapp.sh"]
 ```
 
 ```bash
-./build.sh                    # 重新產 compose.yaml，build 所有 stages
-./run.sh -t headless          # 跑 headless 變體
-./run.sh -t gui               # 跑 gui 變體
-./exec.sh -t headless bash    # 進入 running 的 headless container
+make build                            # 重新產 compose.yaml，build 所有 stages
+make run -- -t headless               # 跑 headless 變體
+make run -- -t gui                    # 跑 gui 變體
+make exec -- -t headless bash         # 進入 running 的 headless container
+
+# 等效直接 .sh 寫法：
+./script/build.sh
+./script/run.sh -t headless
+./script/exec.sh -t headless bash
 ```
 
 限制：
@@ -365,9 +370,9 @@ Main
 > 想要一次取得跟 CI 同樣的完整驗證，加 `--build` flag：
 >
 > ```bash
-> ./build.sh test           # 顯式跑 lint + smoke
-> ./run.sh --build          # 跑完 lint + smoke 再 compose up
-> ./run.sh                  # 預設 — 快速路徑，跳過 lint/smoke
+> make build test                   # 顯式跑 lint + smoke
+> make run -- --build               # 跑完 lint + smoke 再 compose up
+> make run                          # 預設 — 快速路徑，跳過 lint/smoke
 > ```
 
 `setup.sh apply` 每次都會從頭重生 `compose.yaml`，但會保留既有 `.env`

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1336 tests** total (1275 unit + 61 integration).
+Template self-tests: **1361 tests** total (1299 unit + 62 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -512,6 +512,29 @@ exists alongside the wrapper symlink; the documented "cannot find _lib.sh"
 error path still fires (with the new `.base/...` path in the diagnostic)
 when neither `.base/` nor the sibling fallback is present.
 
+### test/unit/makefile_user_spec.bats (23)
+
+Unit tests for the user-facing `script/docker/Makefile` rewritten in #330.
+Each named wrapper target is a thin 1:1 forward to `./script/<name>.sh`
+with positional sub-cmd args carried via `$(filter-out $@,$(MAKECMDGOALS))`
+and flags requiring the `--` separator. A `%:` catch-all rule no-ops the
+forwarded positional tokens so Make does not error on `make build test`.
+`.DEFAULT_GOAL := help` flips the bare-`make` invocation from build to
+help. Sandbox copies the Makefile into a fake repo, planting stub
+`script/*.sh` recorders that log their argv into stdout so each test
+can assert exactly which underlying script ran and with what args.
+
+Covers: `.DEFAULT_GOAL` (bare `make` -> help, does not invoke wrappers);
+`make help` lists 10 user-facing targets; removed sub-cmd targets
+(`test` / `runtime` / `run-detach`) are absent from help; 1:1 invocation
+across all 10 targets (build / run / exec / stop / prune / setup /
+setup-tui / upgrade / upgrade-check / help); positional forwarding
+(`make build test`, `make build runtime`, `make upgrade v0.30.0`, `make
+setup foo`); `--` separator + flag forwarding (`make build -- --no-cache
+test`, `make run -- -d`, `make exec -- -t bats-src bash`); catch-all
+no-op (`make foo` succeeds silently, `make build foo bar` forwards
+multiple positional args).
+
 ### test/unit/compose_gen_spec.bats (50)
 
 Covers `generate_compose_yaml` conditional output: AUTO-GENERATED
@@ -778,7 +801,7 @@ the host file content and the inherited stdout (preserving
 | `main: dispatches no-flag default to the ci service` | End-to-end default dispatch |
 | `main: dispatches --coverage to the coverage service` | End-to-end --coverage dispatch |
 
-### test/unit/init_spec.bats (21)
+### test/unit/init_spec.bats (22)
 
 Unit coverage for `init.sh` helpers that previous rounds exercised only
 through the Level-1 integration test. Complements
@@ -799,8 +822,9 @@ are hard to trigger from a real `bash template/init.sh` invocation
 | `_create_new_repo: main.yaml falls back to @main when ref arg omitted` | Default ref |
 | `_create_new_repo: main.yaml falls back to @main when ref arg is empty` | Empty-string → `@main` |
 | `_create_new_repo: does NOT generate .env.example (image name via setup.conf)` | setup.conf rules drive IMAGE_NAME |
-| `_create_symlinks: produces all seven docker-script symlinks` | Symlink set |
-| `_create_symlinks: replaces a stale file at the symlink path` | Re-init over existing files |
+| `_create_symlinks: places 7 wrapper symlinks under script/, Makefile stays at root (#330)` | 7 wrappers under script/ with ../ targets; Makefile at root |
+| `_create_symlinks: replaces a stale file at the new symlink path under script/ (#330)` | Re-init over stale file at script/build.sh |
+| `_create_symlinks: removes stale root *.sh symlinks left by pre-#330 init (#330 migration loop)` | Migration: plant 7 root symlinks, re-run, all gone + script/ created |
 | `_create_symlinks: keeps custom .hadolint.yaml when it differs` | Custom-hadolint preservation |
 
 ### test/unit/smoke_helper_spec.bats (19)
@@ -970,7 +994,7 @@ Unit tests for `template/script/docker/lib/gitignore.sh` — the canonical
 | `_untrack_canonical_in_repo: idempotent — second run succeeds without error` | Re-run safety |
 | `_untrack_canonical_in_repo: untracks all canonical entries that match` | Multi-entry sweep |
 
-### test/integration/init_new_repo_spec.bats (39)
+### test/integration/init_new_repo_spec.bats (40)
 
 End-to-end verification that `init.sh` produces a complete repo skeleton in
 an empty directory. **Level 1** (file generation only, no Docker). The
@@ -987,25 +1011,38 @@ which has access to a Docker daemon on the host runner.
 | `new repo: script/entrypoint.sh exists and is executable` | entrypoint gen |
 | `new repo: smoke test skeleton exists for the repo` | smoke skeleton |
 | `new repo: .github/workflows/main.yaml exists with reusable workflow ref` | CI gen |
+| `new repo: main.yaml grants permissions: contents: write` | #62 release perms |
 | `new repo: .gitignore exists` | gitignore |
 | `new repo: doc/ tree exists with README translations` | i18n docs |
 | `new repo: doc/test/TEST.md exists` | TEST.md gen |
 | `new repo: doc/changelog/CHANGELOG.md exists` | CHANGELOG gen |
-| `new repo: build.sh symlink → template/script/docker/build.sh` | symlink target |
-| `new repo: run.sh / exec.sh / stop.sh / Makefile symlinks correct` | symlink set |
-| `new repo: template/.version exists (no legacy VERSION / .template_version)` | version file |
+| `new repo: build.sh symlink lives under script/, not root (#330)` | symlink target moved to script/build.sh |
+| `new repo: 7 wrapper symlinks under script/, Makefile stays at root (#330)` | symlink set: 7 wrappers + Makefile root |
+| `new repo: config/ is an empty placeholder (template#254 layered override)` | config placeholder |
+| `new repo: init.sh preserves pre-existing config/ directory (no clobber)` | config preservation |
+| `new repo: init.sh drops stale config symlink before creating placeholder` | config-symlink drop |
+| `Dockerfile.example references CONFIG_SRC="config" (not .base/config)` | CONFIG_SRC default |
+| `Dockerfile.example has layered config COPY chain (template#254)` | layered COPY order |
+| `Dockerfile.example declares ENV HOME before WORKDIR ${HOME}/work (#334)` | HOME env directive |
+| `Dockerfile.example sets up bashrc.d drop-in directory (template#254)` | bashrc.d setup |
+| `new repo: .base/.version exists (no legacy VERSION / .template_version)` | version file |
 | `new repo: re-running init.sh on the result is idempotent` | idempotent |
-| `new repo: init.sh creates setup_tui.sh symlink (not legacy tui.sh)` | post-rename symlink |
-| `new repo: init.sh removes stale tui.sh symlink from earlier versions` | upgrade cleanup |
-| `new repo: build.sh -h works against the generated symlink` | smoke build.sh |
-| `new repo: run.sh -h works against the generated symlink` | smoke run.sh |
-| `new repo: exec.sh -h works against the generated symlink` | smoke exec.sh |
-| `new repo: stop.sh -h works against the generated symlink` | smoke stop.sh |
+| `new repo: init.sh creates setup_tui.sh symlink under script/ (not legacy tui.sh)` | setup_tui under script/ |
+| `new repo: init.sh removes stale tui.sh symlink from earlier versions (#330 stale-removal loop)` | upgrade cleanup |
+| `new repo: init.sh removes stale root *.sh symlinks (#330 migration)` | migrate 7 root symlinks to script/ |
+| `new repo: build.sh -h works against the generated symlink` | smoke script/build.sh |
+| `new repo: run.sh -h works against the generated symlink` | smoke script/run.sh |
+| `new repo: exec.sh -h works against the generated symlink` | smoke script/exec.sh |
+| `new repo: stop.sh -h works against the generated symlink` | smoke script/stop.sh |
+| `new repo: setup.sh symlink under script/ → ../.base/script/docker/setup.sh` | setup.sh under script/ |
+| `new repo: setup.sh -h works against the generated symlink` | smoke script/setup.sh |
 | `init.sh --gen-conf copies setup.conf to repo root` | setup.conf gen |
 | `init.sh --gen-conf refuses to overwrite existing setup.conf` | overwrite safety |
 | `new repo: .gitignore contains compose.yaml (derived artifact)` | gitignore compose.yaml |
 | `new repo: .gitignore contains .env (derived artifact)` | gitignore .env |
 | `new repo: compose.yaml has AUTO-GENERATED header (produced by setup.sh)` | setup.sh generated compose.yaml |
+| `new repo: compose.yaml ships devices: /dev:/dev by default` | default device mount |
+| `new repo: setup.conf mount_1 is NOT empty after first init` | workspace writeback non-empty |
 | `new repo: per-repo setup.conf auto-created on first init (workspace writeback)` | #201 — bootstrap writes WS_PATH back |
 
 ### test/integration/fresh_clone_portability_spec.bats (2)

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -220,8 +220,11 @@ COPY --from=test-tools-stage /usr/local/bin/hadolint /usr/local/bin/hadolint
 # Lint: ShellCheck (.sh) + Hadolint (Dockerfile)
 COPY .hadolint.yaml /lint/.hadolint.yaml
 COPY Dockerfile /lint/Dockerfile
-COPY *.sh /lint/
-# Helpers sourced by the root-level scripts. Must sit next to them so
+# Post-#330 the seven user-facing wrappers live under <repo>/script/;
+# pull them in via that directory (BuildKit follows the ../.base/...
+# symlinks since the target sits inside the build context).
+COPY script/*.sh /lint/
+# Helpers sourced by the wrappers. Must sit next to them so
 # build.sh / run.sh / exec.sh / stop.sh / setup.sh can source _lib.sh
 # (which in turn sources i18n.sh); setup.sh also sources _tui_conf.sh.
 # Issue #104: removing these used to be compensated by inline

--- a/init.sh
+++ b/init.sh
@@ -52,19 +52,30 @@ _symlink() {
 
 _create_symlinks() {
   _log "Creating symlinks:"
-  _symlink "${TEMPLATE_REL}/script/docker/build.sh" "build.sh"
-  _symlink "${TEMPLATE_REL}/script/docker/run.sh" "run.sh"
-  _symlink "${TEMPLATE_REL}/script/docker/exec.sh" "exec.sh"
-  _symlink "${TEMPLATE_REL}/script/docker/stop.sh" "stop.sh"
-  _symlink "${TEMPLATE_REL}/script/docker/prune.sh" "prune.sh"
-  _symlink "${TEMPLATE_REL}/script/docker/setup.sh" "setup.sh"
-  _symlink "${TEMPLATE_REL}/script/docker/setup_tui.sh" "setup_tui.sh"
-  # Upgrade hygiene: drop the pre-rename `tui.sh` symlink if present
-  # so we don't leave a dangling pointer after the file was renamed.
-  if [[ -L tui.sh ]]; then
-    rm -f tui.sh
-    _log "  Removed stale tui.sh symlink (renamed to setup_tui.sh)"
-  fi
+  # #330: the seven user-facing wrappers live under script/ now, with
+  # link targets relative to the link's directory ("../" prefix).
+  # Root keeps `Makefile` as the elevated user entry; flag / sub-cmd
+  # forwarding is documented in script/docker/Makefile itself.
+  mkdir -p script
+  _symlink "../${TEMPLATE_REL}/script/docker/build.sh" "script/build.sh"
+  _symlink "../${TEMPLATE_REL}/script/docker/run.sh" "script/run.sh"
+  _symlink "../${TEMPLATE_REL}/script/docker/exec.sh" "script/exec.sh"
+  _symlink "../${TEMPLATE_REL}/script/docker/stop.sh" "script/stop.sh"
+  _symlink "../${TEMPLATE_REL}/script/docker/prune.sh" "script/prune.sh"
+  _symlink "../${TEMPLATE_REL}/script/docker/setup.sh" "script/setup.sh"
+  _symlink "../${TEMPLATE_REL}/script/docker/setup_tui.sh" "script/setup_tui.sh"
+  # Migration hygiene: drop pre-#330 root *.sh symlinks (now under
+  # script/) plus the pre-setup_tui-rename `tui.sh` legacy name. The
+  # [[ -L X ]] guard makes the loop idempotent on already-migrated
+  # repos and silent on very old forks that never carried setup.sh /
+  # setup_tui.sh at root.
+  local _stale
+  for _stale in build.sh run.sh exec.sh stop.sh prune.sh setup.sh setup_tui.sh tui.sh; do
+    if [[ -L "${_stale}" ]]; then
+      rm -f "${_stale}"
+      _log "  Removed stale root symlink ${_stale} (moved to script/)"
+    fi
+  done
   _symlink "${TEMPLATE_REL}/script/docker/Makefile" "Makefile"
 
   if [[ ! -f .hadolint.yaml ]] \

--- a/script/docker/Makefile
+++ b/script/docker/Makefile
@@ -1,28 +1,43 @@
-.PHONY: build run run-detach test runtime exec stop help
+.PHONY: build run exec stop prune setup setup-tui upgrade upgrade-check help
 
-build: ## Build devel image
-	./build.sh
+# Default goal: bare `make` prints help instead of building. Discoverability
+# beats implicit build for a user-facing entry. RFC #330.
+.DEFAULT_GOAL := help
 
-run: ## Run container (interactive)
-	./run.sh
+# Each wrapper recipe forwards the remaining positional args from
+# MAKECMDGOALS to the underlying script. The `%:` catch-all at the bottom
+# turns those positional tokens into no-ops so Make does not error on
+# `make build test` ("test" has no rule of its own). Flags such as
+# --no-cache must come after a `--` separator because Make's argument
+# parser consumes `-` / `--` tokens as its own options before MAKECMDGOALS
+# is built:
+#
+#   make build test                # -> ./script/build.sh test
+#   make build -- --no-cache test  # -> ./script/build.sh --no-cache test
 
-run-detach: ## Run container in background
-	./run.sh -d
+build: ## Build devel image (e.g. make build test  |  make build -- --no-cache)
+	./script/build.sh $(filter-out $@,$(MAKECMDGOALS))
 
-test: ## Build and run smoke tests
-	./build.sh test
+run: ## Run container interactively (e.g. make run  |  make run -- -d)
+	./script/run.sh $(filter-out $@,$(MAKECMDGOALS))
 
-runtime: ## Build runtime image
-	./build.sh runtime
-
-exec: ## Exec into running container (default: bash)
-	./exec.sh
+exec: ## Exec into running container (e.g. make exec -- -t bats-src bash)
+	./script/exec.sh $(filter-out $@,$(MAKECMDGOALS))
 
 stop: ## Stop and remove containers
-	./stop.sh
+	./script/stop.sh $(filter-out $@,$(MAKECMDGOALS))
 
-upgrade: ## Upgrade base subtree
-	./.base/upgrade.sh
+prune: ## Prune build cache / dangling images
+	./script/prune.sh $(filter-out $@,$(MAKECMDGOALS))
+
+setup: ## Regenerate .env + compose.yaml from setup.conf
+	./script/setup.sh $(filter-out $@,$(MAKECMDGOALS))
+
+setup-tui: ## Interactive TUI to edit setup.conf
+	./script/setup_tui.sh $(filter-out $@,$(MAKECMDGOALS))
+
+upgrade: ## Upgrade base subtree (e.g. make upgrade v0.30.0)
+	./.base/upgrade.sh $(filter-out $@,$(MAKECMDGOALS))
 
 upgrade-check: ## Check for base updates
 	@./.base/upgrade.sh --check || [ $$? -eq 1 ]
@@ -30,3 +45,9 @@ upgrade-check: ## Check for base updates
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*##"}; {printf "  \033[36m%-16s\033[0m %s\n", $$1, $$2}'
+
+# Catch-all: positional args forwarded by the named recipes above land here
+# as goal names with no recipe of their own. Silent no-op keeps Make from
+# erroring on `make build test`, `make upgrade v0.30.0`, etc.
+%:
+	@:

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -3,17 +3,36 @@
 
 set -euo pipefail
 
-# Default FILE_PATH = the directory the wrapper symlink lives in (i.e.
-# the repo root in normal usage). `-C <dir>` / `--chdir <dir>` overrides
-# it so the wrapper operates on a different repo without changing the
-# caller's cwd. Critical for Claude Code's sandbox `excludedCommands`
-# matching: top-level command stays `./build.sh ...` rather than
-# `(cd <dir> && ...)` or `bash -c "cd <dir> && ..."`, neither of which
-# the bash AST parser unwraps into the `./build.sh *` prefix
-# (refs docker_harness#53). The pre-pass runs before _lib.sh is sourced
-# so all path-dependent operations (including the _lib.sh lookup) honor
-# the override.
-FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# Default FILE_PATH = the user's repo root. Invocation paths we need to
+# cover, all of which must resolve FILE_PATH to the repo root so that
+# ${FILE_PATH}/.base/, ${FILE_PATH}/config/, ${FILE_PATH}/.env, etc.
+# work:
+#   - <repo>/build.sh                       # pre-#330 root-symlink layout
+#   - <repo>/script/build.sh                # post-#330 script/-subfolder layout
+#   - <repo>/.base/script/docker/build.sh   # direct invocation
+#   - /lint/build.sh                        # Dockerfile test stage
+# Heuristic: if our invocation directory has a .base/ sibling, we are at
+# the repo root already; if the parent has .base/ we are one level deeper
+# (the post-#330 script/ subfolder) and step up; otherwise (direct or
+# test-stage call) fall back to the invocation directory and rely on the
+# sibling _lib.sh lookup below.
+# `-C <dir>` / `--chdir <dir>` overrides this so the wrapper operates on
+# a different repo without changing the caller's cwd. Critical for
+# Claude Code's sandbox `excludedCommands` matching: top-level command
+# stays `./build.sh ...` rather than `(cd <dir> && ...)` or
+# `bash -c "cd <dir> && ..."`, neither of which the bash AST parser
+# unwraps into the `./build.sh *` prefix (refs docker_harness#53). The
+# pre-pass runs before _lib.sh is sourced so all path-dependent
+# operations (including the _lib.sh lookup) honor the override.
+_FILE_PATH_INVOKE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+if [[ -d "${_FILE_PATH_INVOKE_DIR}/.base" ]]; then
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+elif [[ -d "${_FILE_PATH_INVOKE_DIR}/../.base" ]]; then
+  FILE_PATH="$(cd -- "${_FILE_PATH_INVOKE_DIR}/.." && pwd -P)"
+else
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+fi
+unset _FILE_PATH_INVOKE_DIR
 _chdir_i=1
 while (( _chdir_i <= $# )); do
   case "${!_chdir_i}" in

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -6,7 +6,17 @@ set -euo pipefail
 # `-C <dir>` / `--chdir <dir>` pre-pass — see build.sh for the full
 # rationale (refs docker_harness#53). Override FILE_PATH before _lib.sh
 # is sourced so all path-dependent operations honor the target repo.
-FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# FILE_PATH detection covers root-symlink (pre-#330), script/-subfolder
+# (post-#330), and direct invocation — see build.sh for the heuristic.
+_FILE_PATH_INVOKE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+if [[ -d "${_FILE_PATH_INVOKE_DIR}/.base" ]]; then
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+elif [[ -d "${_FILE_PATH_INVOKE_DIR}/../.base" ]]; then
+  FILE_PATH="$(cd -- "${_FILE_PATH_INVOKE_DIR}/.." && pwd -P)"
+else
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+fi
+unset _FILE_PATH_INVOKE_DIR
 _chdir_i=1
 while (( _chdir_i <= $# )); do
   case "${!_chdir_i}" in

--- a/script/docker/prune.sh
+++ b/script/docker/prune.sh
@@ -22,8 +22,18 @@ set -euo pipefail
 # `-C <dir>` / `--chdir <dir>` pre-pass — mirrors build.sh / run.sh /
 # exec.sh / stop.sh. prune.sh itself is daemon-wide so cwd does not
 # affect what gets pruned, but the flag is accepted for muscle-memory
-# consistency across all 5 wrappers.
-FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# consistency across all wrappers.
+# FILE_PATH detection covers root-symlink (pre-#330), script/-subfolder
+# (post-#330), and direct invocation — see build.sh for the heuristic.
+_FILE_PATH_INVOKE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+if [[ -d "${_FILE_PATH_INVOKE_DIR}/.base" ]]; then
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+elif [[ -d "${_FILE_PATH_INVOKE_DIR}/../.base" ]]; then
+  FILE_PATH="$(cd -- "${_FILE_PATH_INVOKE_DIR}/.." && pwd -P)"
+else
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+fi
+unset _FILE_PATH_INVOKE_DIR
 _chdir_i=1
 while (( _chdir_i <= $# )); do
   case "${!_chdir_i}" in

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -6,7 +6,17 @@ set -euo pipefail
 # `-C <dir>` / `--chdir <dir>` pre-pass — see build.sh for the full
 # rationale (refs docker_harness#53). Override FILE_PATH before _lib.sh
 # is sourced so all path-dependent operations honor the target repo.
-FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# FILE_PATH detection covers root-symlink (pre-#330), script/-subfolder
+# (post-#330), and direct invocation — see build.sh for the heuristic.
+_FILE_PATH_INVOKE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+if [[ -d "${_FILE_PATH_INVOKE_DIR}/.base" ]]; then
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+elif [[ -d "${_FILE_PATH_INVOKE_DIR}/../.base" ]]; then
+  FILE_PATH="$(cd -- "${_FILE_PATH_INVOKE_DIR}/.." && pwd -P)"
+else
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+fi
+unset _FILE_PATH_INVOKE_DIR
 _chdir_i=1
 while (( _chdir_i <= $# )); do
   case "${!_chdir_i}" in

--- a/script/docker/setup_tui.sh
+++ b/script/docker/setup_tui.sh
@@ -17,7 +17,17 @@
 set -euo pipefail
 
 # ── Script / template paths (resolve symlink to locate siblings) ───────────
-FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# FILE_PATH detection covers root-symlink (pre-#330), script/-subfolder
+# (post-#330), and direct invocation — see build.sh for the heuristic.
+_FILE_PATH_INVOKE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+if [[ -d "${_FILE_PATH_INVOKE_DIR}/.base" ]]; then
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+elif [[ -d "${_FILE_PATH_INVOKE_DIR}/../.base" ]]; then
+  FILE_PATH="$(cd -- "${_FILE_PATH_INVOKE_DIR}/.." && pwd -P)"
+else
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+fi
+unset _FILE_PATH_INVOKE_DIR
 readonly FILE_PATH
 
 _TUI_SELF="$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || printf '%s' "${BASH_SOURCE[0]}")"

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -6,7 +6,17 @@ set -euo pipefail
 # `-C <dir>` / `--chdir <dir>` pre-pass — see build.sh for the full
 # rationale (refs docker_harness#53). Override FILE_PATH before _lib.sh
 # is sourced so all path-dependent operations honor the target repo.
-FILE_PATH="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# FILE_PATH detection covers root-symlink (pre-#330), script/-subfolder
+# (post-#330), and direct invocation — see build.sh for the heuristic.
+_FILE_PATH_INVOKE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+if [[ -d "${_FILE_PATH_INVOKE_DIR}/.base" ]]; then
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+elif [[ -d "${_FILE_PATH_INVOKE_DIR}/../.base" ]]; then
+  FILE_PATH="$(cd -- "${_FILE_PATH_INVOKE_DIR}/.." && pwd -P)"
+else
+  FILE_PATH="${_FILE_PATH_INVOKE_DIR}"
+fi
+unset _FILE_PATH_INVOKE_DIR
 _chdir_i=1
 while (( _chdir_i <= $# )); do
   case "${!_chdir_i}" in

--- a/test/integration/init_new_repo_spec.bats
+++ b/test/integration/init_new_repo_spec.bats
@@ -118,26 +118,27 @@ teardown() {
   assert [ -f "${REPO_DIR}/doc/changelog/CHANGELOG.md" ]
 }
 
-@test "new repo: build.sh symlink → .base/script/docker/build.sh" {
+@test "new repo: build.sh symlink lives under script/, not root (#330)" {
   bash .base/init.sh
-  assert [ -L "${REPO_DIR}/build.sh" ]
-  run readlink "${REPO_DIR}/build.sh"
-  assert_output ".base/script/docker/build.sh"
+  assert [ -L "${REPO_DIR}/script/build.sh" ]
+  run readlink "${REPO_DIR}/script/build.sh"
+  assert_output "../.base/script/docker/build.sh"
+  # Root must NOT have build.sh after #330.
+  assert [ ! -e "${REPO_DIR}/build.sh" ]
 }
 
-@test "new repo: run.sh / exec.sh / stop.sh / prune.sh / Makefile symlinks correct" {
+@test "new repo: 7 wrapper symlinks under script/, Makefile stays at root (#330)" {
   bash .base/init.sh
-  for f in run.sh exec.sh stop.sh prune.sh Makefile; do
-    assert [ -L "${REPO_DIR}/${f}" ]
+  # 7 wrappers under script/, each pointing to ../.base/script/docker/<name>.sh
+  for f in run.sh exec.sh stop.sh prune.sh setup.sh setup_tui.sh; do
+    assert [ -L "${REPO_DIR}/script/${f}" ]
+    run readlink "${REPO_DIR}/script/${f}"
+    assert_output "../.base/script/docker/${f}"
+    # And NOT at root.
+    assert [ ! -e "${REPO_DIR}/${f}" ]
   done
-  run readlink "${REPO_DIR}/run.sh"
-  assert_output ".base/script/docker/run.sh"
-  run readlink "${REPO_DIR}/exec.sh"
-  assert_output ".base/script/docker/exec.sh"
-  run readlink "${REPO_DIR}/stop.sh"
-  assert_output ".base/script/docker/stop.sh"
-  run readlink "${REPO_DIR}/prune.sh"
-  assert_output ".base/script/docker/prune.sh"
+  # Makefile retains the root location (the elevated user entry).
+  assert [ -L "${REPO_DIR}/Makefile" ]
   run readlink "${REPO_DIR}/Makefile"
   assert_output ".base/script/docker/Makefile"
 }
@@ -273,59 +274,77 @@ teardown() {
   assert_success
 }
 
-@test "new repo: init.sh creates setup_tui.sh symlink (not legacy tui.sh)" {
+@test "new repo: init.sh creates setup_tui.sh symlink under script/ (not legacy tui.sh)" {
   bash .base/init.sh
-  assert [ -L "${REPO_DIR}/setup_tui.sh" ]
-  run readlink "${REPO_DIR}/setup_tui.sh"
-  assert_output ".base/script/docker/setup_tui.sh"
+  assert [ -L "${REPO_DIR}/script/setup_tui.sh" ]
+  run readlink "${REPO_DIR}/script/setup_tui.sh"
+  assert_output "../.base/script/docker/setup_tui.sh"
+  # Neither old root-level setup_tui.sh nor pre-rename tui.sh.
   assert [ ! -e "${REPO_DIR}/tui.sh" ]
+  assert [ ! -e "${REPO_DIR}/setup_tui.sh" ]
 }
 
-@test "new repo: init.sh removes stale tui.sh symlink from earlier versions" {
+@test "new repo: init.sh removes stale tui.sh symlink from earlier versions (#330 stale-removal loop)" {
   bash .base/init.sh
-  # Simulate an upgrade from the old name by planting the legacy symlink
+  # Simulate a very old upgrade path: legacy tui.sh symlink at root.
   ln -sf ".base/script/docker/setup_tui.sh" "${REPO_DIR}/tui.sh"
   run bash .base/init.sh
   assert_success
   assert [ ! -e "${REPO_DIR}/tui.sh" ]
-  assert [ -L "${REPO_DIR}/setup_tui.sh" ]
+  assert [ -L "${REPO_DIR}/script/setup_tui.sh" ]
+}
+
+@test "new repo: init.sh removes stale root *.sh symlinks (#330 migration)" {
+  bash .base/init.sh
+  # Simulate a pre-#330 layout by planting the seven root-level symlinks
+  # an older init.sh would have produced. Re-running the post-#330
+  # init.sh must remove all of them and ensure script/ versions exist.
+  for f in build.sh run.sh exec.sh stop.sh prune.sh setup.sh setup_tui.sh; do
+    ln -sf ".base/script/docker/${f}" "${REPO_DIR}/${f}"
+  done
+  run bash .base/init.sh
+  assert_success
+  for f in build.sh run.sh exec.sh stop.sh prune.sh setup.sh setup_tui.sh; do
+    assert [ ! -e "${REPO_DIR}/${f}" ]
+    assert [ -L "${REPO_DIR}/script/${f}" ]
+  done
 }
 
 @test "new repo: build.sh -h works against the generated symlink" {
   bash .base/init.sh
-  run bash "${REPO_DIR}/build.sh" -h
+  run bash "${REPO_DIR}/script/build.sh" -h
   assert_success
   assert_output --partial "Usage"
 }
 
 @test "new repo: run.sh -h works against the generated symlink" {
   bash .base/init.sh
-  run bash "${REPO_DIR}/run.sh" -h
+  run bash "${REPO_DIR}/script/run.sh" -h
   assert_success
 }
 
 @test "new repo: exec.sh -h works against the generated symlink" {
   bash .base/init.sh
-  run bash "${REPO_DIR}/exec.sh" -h
+  run bash "${REPO_DIR}/script/exec.sh" -h
   assert_success
 }
 
 @test "new repo: stop.sh -h works against the generated symlink" {
   bash .base/init.sh
-  run bash "${REPO_DIR}/stop.sh" -h
+  run bash "${REPO_DIR}/script/stop.sh" -h
   assert_success
 }
 
-@test "new repo: setup.sh symlink → .base/script/docker/setup.sh" {
+@test "new repo: setup.sh symlink under script/ → ../.base/script/docker/setup.sh" {
   bash .base/init.sh
-  assert [ -L "${REPO_DIR}/setup.sh" ]
-  run readlink "${REPO_DIR}/setup.sh"
-  assert_output ".base/script/docker/setup.sh"
+  assert [ -L "${REPO_DIR}/script/setup.sh" ]
+  run readlink "${REPO_DIR}/script/setup.sh"
+  assert_output "../.base/script/docker/setup.sh"
 }
 
 @test "new repo: setup.sh -h works against the generated symlink" {
   bash .base/init.sh
-  run bash "${REPO_DIR}/setup.sh" -h
+  run bash "${REPO_DIR}/script/setup.sh" -h
   assert_success
   assert_output --partial "Usage"
 }

--- a/test/unit/init_spec.bats
+++ b/test/unit/init_spec.bats
@@ -207,22 +207,47 @@ REMOTE
 # _create_symlinks
 # ════════════════════════════════════════════════════════════════════
 
-@test "_create_symlinks: produces all seven docker-script symlinks" {
+@test "_create_symlinks: places 7 wrapper symlinks under script/, Makefile stays at root (#330)" {
   _source_init
   _create_symlinks
-  for _f in build.sh run.sh exec.sh stop.sh setup.sh setup_tui.sh Makefile; do
-    assert [ -L "${TMP_REPO}/${_f}" ]
-    run readlink "${TMP_REPO}/${_f}"
-    assert_output ".base/script/docker/${_f}"
+  # Seven wrappers under script/ with ../.base/script/docker/<name>.sh targets.
+  for _f in build.sh run.sh exec.sh stop.sh prune.sh setup.sh setup_tui.sh; do
+    assert [ -L "${TMP_REPO}/script/${_f}" ]
+    run readlink "${TMP_REPO}/script/${_f}"
+    assert_output "../.base/script/docker/${_f}"
+    # And must NOT exist at root.
+    assert [ ! -e "${TMP_REPO}/${_f}" ]
   done
+  # Makefile keeps the root location with the direct .base/ target.
+  assert [ -L "${TMP_REPO}/Makefile" ]
+  run readlink "${TMP_REPO}/Makefile"
+  assert_output ".base/script/docker/Makefile"
 }
 
-@test "_create_symlinks: replaces a stale file at the symlink path" {
-  # Pretend an earlier run left a regular file where the symlink should go
-  echo "stale" > "${TMP_REPO}/build.sh"
+@test "_create_symlinks: replaces a stale file at the new symlink path under script/ (#330)" {
+  # Pretend an earlier run left a regular file where the symlink should go.
+  # Post-#330 the symlinks live under script/, so the stale-replacement
+  # logic in _symlink runs against script/build.sh, not root build.sh.
+  mkdir -p "${TMP_REPO}/script"
+  echo "stale" > "${TMP_REPO}/script/build.sh"
   _source_init
   _create_symlinks
-  assert [ -L "${TMP_REPO}/build.sh" ]
+  assert [ -L "${TMP_REPO}/script/build.sh" ]
+}
+
+@test "_create_symlinks: removes stale root *.sh symlinks left by pre-#330 init (#330 migration loop)" {
+  # Plant the seven root-level symlinks an older init.sh would have made;
+  # the post-#330 loop must drop them all so the user-facing entry is the
+  # `script/` subfolder + root `Makefile`.
+  for _f in build.sh run.sh exec.sh stop.sh prune.sh setup.sh setup_tui.sh; do
+    ln -sf ".base/script/docker/${_f}" "${TMP_REPO}/${_f}"
+  done
+  _source_init
+  _create_symlinks
+  for _f in build.sh run.sh exec.sh stop.sh prune.sh setup.sh setup_tui.sh; do
+    assert [ ! -e "${TMP_REPO}/${_f}" ]
+    assert [ -L "${TMP_REPO}/script/${_f}" ]
+  done
 }
 
 @test "_create_symlinks: keeps custom .hadolint.yaml when it differs" {
@@ -317,14 +342,15 @@ REMOTE
   assert_equal "${TEMPLATE_REL}" ".base"
 }
 
-@test "_create_symlinks: targets follow TEMPLATE_REL through .base/" {
+@test "_create_symlinks: targets follow TEMPLATE_REL through .base/ (#330 script/ subfolder)" {
   # Companion to the auto-detect test above: when TEMPLATE_REL is `.base`,
-  # `_create_symlinks` must wire build.sh / run.sh / etc. through
-  # `.base/script/docker/...`.
+  # `_create_symlinks` must wire script/build.sh -> ../.base/script/docker/build.sh
+  # (sub-folder link target is relative to the link's directory), and
+  # Makefile / .hadolint.yaml at root keep the direct .base/ target.
   source "${TMP_REPO}/.base/init.sh"
   _create_symlinks
-  run readlink "${TMP_REPO}/build.sh"
-  assert_output ".base/script/docker/build.sh"
+  run readlink "${TMP_REPO}/script/build.sh"
+  assert_output "../.base/script/docker/build.sh"
   run readlink "${TMP_REPO}/Makefile"
   assert_output ".base/script/docker/Makefile"
   run readlink "${TMP_REPO}/.hadolint.yaml"

--- a/test/unit/makefile_user_spec.bats
+++ b/test/unit/makefile_user_spec.bats
@@ -1,0 +1,234 @@
+#!/usr/bin/env bats
+#
+# Unit tests for the user-facing Makefile at .base/script/docker/Makefile
+# (symlinked from downstream repo root). Each named wrapper target is a thin
+# 1:1 forward to ./script/<name>.sh, with positional sub-cmd args carried
+# via $(filter-out $@,$(MAKECMDGOALS)) and flags requiring the `--`
+# separator. A `%:` catch-all no-ops the forwarded tokens so Make does not
+# error on `make build test`. RFC #330.
+#
+# Strategy: each test sandboxes a sample repo with the Makefile symlinked
+# at root, the underlying wrapper scripts stubbed under script/, and the
+# upgrade script stubbed under .base/. Each stub appends its invocation
+# (target name + received args) to ${TMP_REPO}/.invocation_log so tests
+# can assert exactly what the underlying wrapper would have been called
+# with.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+
+  # shellcheck disable=SC2154
+  TMP_REPO="$(mktemp -d)"
+  export TMP_REPO
+
+  mkdir -p "${TMP_REPO}/.base/script/docker"
+  mkdir -p "${TMP_REPO}/script"
+
+  # Source under test: the user-facing Makefile, copied into the
+  # sandbox in the same relative location that init.sh would symlink.
+  cp /source/script/docker/Makefile "${TMP_REPO}/.base/script/docker/Makefile"
+  ln -s ".base/script/docker/Makefile" "${TMP_REPO}/Makefile"
+
+  # Stub recorders: each wrapper logs `<name> <args...>` so tests can
+  # check both the target script and the forwarded argv.
+  for _name in build run exec stop prune setup setup_tui; do
+    cat > "${TMP_REPO}/script/${_name}.sh" <<EOS
+#!/usr/bin/env bash
+printf '${_name}'
+for _arg in "\$@"; do printf ' %s' "\${_arg}"; done
+printf '\n'
+EOS
+    chmod +x "${TMP_REPO}/script/${_name}.sh"
+  done
+
+  cat > "${TMP_REPO}/.base/upgrade.sh" <<'EOS'
+#!/usr/bin/env bash
+printf 'upgrade'
+for _arg in "$@"; do printf ' %s' "${_arg}"; done
+printf '\n'
+EOS
+  chmod +x "${TMP_REPO}/.base/upgrade.sh"
+
+  cd "${TMP_REPO}"
+}
+
+teardown() {
+  rm -rf "${TMP_REPO}"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# .DEFAULT_GOAL + help
+# ════════════════════════════════════════════════════════════════════
+
+@test "bare \`make\` prints help (.DEFAULT_GOAL := help)" {
+  run make
+  assert_success
+  # help target greps for `:.*##` lines and pretty-prints them; the
+  # exact ANSI escapes are fragile so we just check a known target
+  # name appears, which proves the help recipe ran rather than build.
+  assert_line --partial "build"
+  assert_line --partial "help"
+  # Must NOT have invoked any wrapper.
+  refute_line --regexp '^build( |$)'
+}
+
+@test "\`make help\` lists the 10 user-facing targets" {
+  run make help
+  assert_success
+  for _target in build run exec stop prune setup setup-tui upgrade upgrade-check help; do
+    assert_line --partial "${_target}"
+  done
+}
+
+@test "\`make help\` does NOT list removed sub-cmd targets (test / runtime / run-detach)" {
+  run make help
+  assert_success
+  refute_line --regexp '^[[:space:]]+test[[:space:]]'
+  refute_line --regexp '^[[:space:]]+runtime[[:space:]]'
+  refute_line --regexp '^[[:space:]]+run-detach[[:space:]]'
+}
+
+# ════════════════════════════════════════════════════════════════════
+# 1:1 wrapper invocations (bare target → ./script/<name>.sh)
+# ════════════════════════════════════════════════════════════════════
+
+@test "\`make build\` invokes ./script/build.sh with no args" {
+  run make build
+  assert_success
+  assert_line "build"
+}
+
+@test "\`make run\` invokes ./script/run.sh with no args" {
+  run make run
+  assert_success
+  assert_line "run"
+}
+
+@test "\`make exec\` invokes ./script/exec.sh with no args" {
+  run make exec
+  assert_success
+  assert_line "exec"
+}
+
+@test "\`make stop\` invokes ./script/stop.sh with no args" {
+  run make stop
+  assert_success
+  assert_line "stop"
+}
+
+@test "\`make prune\` invokes ./script/prune.sh with no args" {
+  run make prune
+  assert_success
+  assert_line "prune"
+}
+
+@test "\`make setup\` invokes ./script/setup.sh with no args" {
+  run make setup
+  assert_success
+  assert_line "setup"
+}
+
+@test "\`make setup-tui\` invokes ./script/setup_tui.sh with no args" {
+  run make setup-tui
+  assert_success
+  assert_line "setup_tui"
+}
+
+@test "\`make upgrade\` invokes ./.base/upgrade.sh with no args" {
+  run make upgrade
+  assert_success
+  assert_line "upgrade"
+}
+
+@test "\`make upgrade-check\` invokes ./.base/upgrade.sh --check" {
+  run make upgrade-check
+  # upgrade.sh --check returns 1 when an update is available; the
+  # Makefile recipe swallows that as success via `|| [ $? -eq 1 ]`.
+  assert_success
+  assert_line "upgrade --check"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# Positional sub-cmd forwarding (no `--` required)
+# ════════════════════════════════════════════════════════════════════
+
+@test "\`make build test\` forwards 'test' to ./script/build.sh" {
+  run make build test
+  assert_success
+  assert_line "build test"
+}
+
+@test "\`make build runtime\` forwards 'runtime' to ./script/build.sh" {
+  run make build runtime
+  assert_success
+  assert_line "build runtime"
+}
+
+@test "\`make upgrade v0.30.0\` forwards the version arg to ./.base/upgrade.sh" {
+  run make upgrade v0.30.0
+  assert_success
+  assert_line "upgrade v0.30.0"
+}
+
+@test "\`make setup foo\` forwards 'foo' to ./script/setup.sh" {
+  run make setup foo
+  assert_success
+  assert_line "setup foo"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# `--` separator + flag forwarding
+# ════════════════════════════════════════════════════════════════════
+
+@test "\`make build -- --no-cache\` forwards the flag to ./script/build.sh" {
+  run make build -- --no-cache
+  assert_success
+  assert_line "build --no-cache"
+}
+
+@test "\`make build -- --no-cache test\` forwards flag + sub-cmd" {
+  run make build -- --no-cache test
+  assert_success
+  assert_line "build --no-cache test"
+}
+
+@test "\`make run -- -d\` forwards -d to ./script/run.sh (replaces removed run-detach)" {
+  run make run -- -d
+  assert_success
+  assert_line "run -d"
+}
+
+@test "\`make exec -- -t bats-src bash\` forwards -t / positional bash" {
+  run make exec -- -t bats-src bash
+  assert_success
+  assert_line "exec -t bats-src bash"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# Catch-all `%:` rule (silent no-op for unknown positional tokens)
+# ════════════════════════════════════════════════════════════════════
+
+@test "\`make foo\` is a silent no-op (catch-all, does not error)" {
+  # No target named foo → catch-all matches → @: runs → exit 0 with
+  # zero output. Trade-off for sub-cmd forwarding UX.
+  run make foo
+  assert_success
+  assert_output ""
+}
+
+@test "\`make build foo bar\` forwards 'foo bar' to ./script/build.sh (foo+bar also no-op via catch-all)" {
+  run make build foo bar
+  assert_success
+  assert_line "build foo bar"
+}
+
+@test "\`make\` without targets does NOT invoke wrappers" {
+  # Companion to the .DEFAULT_GOAL test — make sure nothing recorded.
+  run make
+  assert_success
+  refute_line --regexp '^build( |$)'
+  refute_line --regexp '^run( |$)'
+  refute_line --regexp '^upgrade( |$)'
+}

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -269,6 +269,9 @@ _upgrade() {
 
   # Step 3: re-run init.sh to sync symlinks (in case template structure changed)
   _log "Step 3/5: re-run init.sh to sync symlinks"
+  # #330: when upgrading from <v0.30.0, init.sh's stale-removal loop
+  # migrates the seven root *.sh symlinks into the script/ subfolder.
+  _log "  (init.sh migrates root *.sh -> script/*.sh on upgrades from pre-v0.30.0)"
   "./${TEMPLATE_REL}/init.sh"
 
   # Step 4: update main.yaml @tag references


### PR DESCRIPTION
## Summary

**BREAKING**: consolidate the seven user-facing wrappers from the downstream repo root into a `script/` subfolder, and rewrite the user-facing Makefile to a 1:1 forwarder with positional sub-cmd alignment and `--` separator for flags. Closes #330.

- 7 wrappers (`build.sh` / `run.sh` / `exec.sh` / `stop.sh` / `prune.sh` / `setup.sh` / `setup_tui.sh`) move to `script/<name>.sh -> ../.base/script/docker/<name>.sh`. `Makefile` stays at root.
- `init.sh _create_symlinks` produces the new layout and migrates pre-#330 repos automatically via a stale-root-symlink removal loop (model: existing `tui.sh` rename precedent). `upgrade.sh` Step 3 already re-runs `init.sh`, so `make -f Makefile.ci upgrade VERSION=v0.30.0` is the one-shot migration trigger.
- Makefile: 10 wrapper targets (added `prune` / `setup` / `setup-tui`; removed `test` / `runtime` / `run-detach` sub-cmd shims). `make build test` forwards `test` to `./script/build.sh test` via `$(filter-out $@,$(MAKECMDGOALS))`; flags need `--` (`make build -- --no-cache test`). `.DEFAULT_GOAL := help` flips bare `make` from build to help.
- 6 wrappers' `FILE_PATH` detection extended to cover both pre-#330 (root symlink) and post-#330 (script/ subfolder) layouts via a sibling `.base/` probe — required so `${FILE_PATH}/.base/script/docker/_lib.sh` still resolves when the wrapper is invoked from `<repo>/script/build.sh`.

## Scope

This PR is **template-only**. The plan locks downstream fanout (Phase 2 docker_harness self-config + Phase 3 active 2-downstream fanout) behind a manual ros_distro RC-tag validation step. After v0.30.0-rc1 ships and the migration passes end-to-end on `env/ros_distro`, the formal v0.30.0 tag goes out; Phase 2 / 3 are deferred until the cycle after that and tracked separately.

`.base/script/docker/Makefile.ci` is **unchanged** — the user-facing vs CI-facing split is intentional and preserved. CI continues to invoke `make -f Makefile.ci test` / `lint` / `upgrade VERSION=vX.Y.Z`.

## Migration table for downstream / external consumers

| Old | New |
|---|---|
| `./build.sh` | `make build` or `./script/build.sh` |
| `./build.sh test` | `make build test` or `./script/build.sh test` |
| `./build.sh --no-cache test` | `make build -- --no-cache test` or `./script/build.sh --no-cache test` |
| `./run.sh -d` | `make run -- -d` or `./script/run.sh -d` |
| `./exec.sh -t bats-src bash` | `make exec -- -t bats-src bash` or `./script/exec.sh -t bats-src bash` |
| `make test` (removed) | `make build test` |
| `make runtime` (removed) | `make build runtime` |
| `make run-detach` (removed) | `make run -- -d` |
| `make` (was: build) | `make` now prints help; use `make build` to build |

## Changes

**Code**
- `script/docker/Makefile` — rewritten to 10-target forwarder pattern with `%:` catch-all
- `init.sh` — `_create_symlinks` produces `script/<name>.sh` symlinks; stale-removal loop drops pre-#330 root `*.sh` + legacy `tui.sh`
- `upgrade.sh` — one-line log near Step 3 noting the migration applies on first upgrade through this version
- `script/docker/{build,run,exec,stop,prune,setup_tui}.sh` — `FILE_PATH` detection walks up one level when the wrapper lives in a `script/` subfolder (post-#330) and stays at the invocation dir for root-symlink (pre-#330) / direct / `/lint/` test-stage calls

**Tests**
- NEW `test/unit/makefile_user_spec.bats` (23 cases): 1:1 invocation across 10 targets, positional forwarding, `--` separator, `.DEFAULT_GOAL` behaviour, catch-all silent no-op
- `test/integration/init_new_repo_spec.bats` (+3 cases, 40 total): wrappers under `script/`, planted-old-layout migration
- `test/unit/init_spec.bats` (+1 case, 22 total): stale root `*.sh` removal loop
- `test/smoke/script_help.bats` unchanged — exercises `/lint/<name>.sh` (Dockerfile test-stage flat copy) not the consumer path

**Docs**
- `doc/changelog/CHANGELOG.md` `[Unreleased]` `### Changed` — 2 BREAKING entries + migration table
- `doc/test/TEST.md` totals synced: 1361 = 1299 unit + 62 integration
- `README.md` + 3 translations (`doc/readme/README.{zh-TW,zh-CN,ja}.md`) — mermaid layout diagram, Quick-Start examples, Makefile table row

## Test plan

- [x] `make -f Makefile.ci test` green in the Docker test stage (1361 / 1361)
- [x] New `makefile_user_spec.bats` exercises both bare invocation and `--`-separator flag forwarding
- [x] Integration test plants a pre-#330 layout and confirms `init.sh` migrates it idempotently
- [ ] After merge: tag `v0.30.0-rc1`, then `/batch-template-upgrade v0.30.0-rc1 --only env/ros_distro` and manually verify migration end-to-end (`./script/build.sh test` green, `make build test` forwards correctly, `make` prints help, `make foo` is silent)
- [ ] After RC validation: tag formal `v0.30.0` and wait `Self Test` + `Release test-tools image to GHCR` tag workflows green

## Followups

- Phase 2 (docker_harness self-config: `.claude/settings.json` `excludedCommands` swap, `.claude/scripts/*.sh` references, `check_prefer_dot_sh.sh` hint, CLAUDE.md "common commands" rewrite, 4-lang docker_harness README) — deferred to a separate issue, decided after RC validation
- Phase 3 (active downstream fanout for `env/ros_distro` + `env/ros2_distro` — 2 active consumers per `batch-template-upgrade.sh` `DEFAULT_REPOS`; the other 11 repos are commented out pending archive / rename / `.base` migration, refs `ycpss91255-docker/docker_harness#89`) — deferred to the cycle after v0.30.0 stable

Closes #330.
