### PR TITLE
fix(scripts): align build.sh/run.sh -h with auto-apply behaviour (#365)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `build.sh -h` / `run.sh -h` usage strings (all 4 languages — en /
+  zh-TW / zh-CN / ja) claimed pre-#88 "warn on drift" semantics that
+  were superseded by #88's auto-apply behavior (`build.sh:453-477` /
+  `run.sh:442-456` already call `setup.sh apply` automatically when
+  `setup.sh check-drift` reports drift). Help text now describes the
+  default as auto-regeneration of `.env` + `compose.yaml` when
+  `setup.conf` / Dockerfile stages / GPU / GUI / USER_UID change, and
+  clarifies that `-s` is for forcing a rerun (opens the TUI on an
+  interactive TTY, otherwise non-interactive apply). Two new smoke
+  tests in `test/smoke/script_help.bats` lock the new phrasing
+  (`auto-regenerate` present, `warn on drift` absent) for both
+  scripts. Closes #365.
+
 ## [v0.31.0-rc1] - 2026-05-15
 
 Release Candidate for v0.31.0 minor feature release. Bundles a single

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1155,7 +1155,7 @@ so the shared specs and any per-repo `test/smoke/` overlay execute
 together. `display_env.bats` self-skips on headless repos by detecting
 the absence of GUI lines in the generated `compose.yaml`.
 
-### test/smoke/script_help.bats (25)
+### test/smoke/script_help.bats (27)
 
 Locks the `-h` / `--help` invariants on the four wrapper scripts
 (`build.sh` / `run.sh` / `exec.sh` / `stop.sh`) plus the `_LANG`
@@ -1170,9 +1170,11 @@ usage, not English).
 | `build.sh -h exits 0` | Wrapper smoke |
 | `build.sh --help exits 0` | Long flag |
 | `build.sh -h prints usage` | Output sanity |
+| `build.sh -h describes auto-apply default (no stale 'warn on drift', #365)` | Help text describes auto-apply, not stale warn-on-drift |
 | `run.sh -h exits 0` | Wrapper smoke |
 | `run.sh --help exits 0` | Long flag |
 | `run.sh -h prints usage` | Output sanity |
+| `run.sh -h describes auto-apply default (no stale 'warn on drift', #365)` | Help text describes auto-apply, not stale warn-on-drift |
 | `exec.sh -h exits 0` | Wrapper smoke |
 | `exec.sh --help exits 0` | Long flag |
 | `exec.sh -h prints usage` | Output sanity |

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -128,8 +128,9 @@ usage() {
   -C, --chdir DIR
                  對 DIR 下的 repo 執行（不改變呼叫者 cwd），類似 git -C / make -C。
                  須在其他選項與 TARGET 之前指定。
-  -s, --setup    強制重跑 setup.sh 重新生成 .env + compose.yaml
-                 （預設：.env 不存在時自動 bootstrap；存在時僅印 drift warning）
+  -s, --setup    強制重跑 setup.sh（互動式 TTY 開 TUI，否則非互動式 apply）。
+                 預設（無此旗標）：當 setup.conf / Dockerfile stages / GPU /
+                 GUI / USER_UID 漂移時，.env + compose.yaml 自動重新生成 (#88)。
   --reset-conf   用 template 預設值覆蓋 setup.conf（先備份到 setup.conf.bak
                  + .env.bak；需確認，可用 -y 跳過）。之後會自動重跑 setup。
   -y, --yes      略過 --reset-conf 的互動確認
@@ -161,8 +162,9 @@ EOF
   -C, --chdir DIR
                  对 DIR 下的 repo 执行（不改变调用者 cwd），类似 git -C / make -C。
                  须在其他选项与 TARGET 之前指定。
-  -s, --setup    强制重跑 setup.sh 重新生成 .env + compose.yaml
-                 （默认：.env 不存在时自动 bootstrap；存在时仅打印 drift warning）
+  -s, --setup    强制重跑 setup.sh（交互式 TTY 开 TUI，否则非交互式 apply）。
+                 默认（无此旗标）：当 setup.conf / Dockerfile stages / GPU /
+                 GUI / USER_UID 漂移时，.env + compose.yaml 自动重新生成 (#88)。
   --reset-conf   用 template 默认值覆盖 setup.conf（先备份到 setup.conf.bak
                  + .env.bak；需确认，可用 -y 跳过）。之后会自动重跑 setup。
   -y, --yes      跳过 --reset-conf 的交互确认
@@ -194,8 +196,10 @@ EOF
   -C, --chdir DIR
                  DIR 配下の repo に対して実行（呼び出し側の cwd は変えない）。
                  git -C / make -C と同様。他のオプションや TARGET より前に指定。
-  -s, --setup    setup.sh を強制実行して .env + compose.yaml を再生成
-                 （デフォルト：.env が無ければ自動 bootstrap、あれば drift warning のみ）
+  -s, --setup    setup.sh を強制実行（インタラクティブ TTY なら TUI、それ以外は
+                 非インタラクティブ apply）。デフォルト（フラグ無し）：setup.conf
+                 / Dockerfile stages / GPU / GUI / USER_UID が drift した時、
+                 .env + compose.yaml が自動再生成されます (#88)。
   --reset-conf   setup.conf をテンプレのデフォルトで上書き（setup.conf.bak
                  + .env.bak にバックアップ；確認プロンプト、-y でスキップ）。
                  その後 setup を再実行。
@@ -230,8 +234,10 @@ Options:
                  Operate on the repo at DIR without changing the caller's cwd.
                  Mirrors git -C / make -C. Must come before other options and
                  the TARGET.
-  -s, --setup    Force rerun setup.sh to regenerate .env + compose.yaml
-                 (default: auto-bootstrap if .env missing; warn on drift if present)
+  -s, --setup    Force rerun setup.sh (opens the TUI on an interactive TTY,
+                 otherwise non-interactive apply). Default (no flag):
+                 auto-regenerate .env + compose.yaml when setup.conf /
+                 Dockerfile stages / GPU / GUI / USER_UID drift (#88).
   --reset-conf   Overwrite setup.conf with template defaults (backs up the
                  existing setup.conf → setup.conf.bak and .env → .env.bak
                  first). Prompts for confirmation; pass -y to skip. Triggers

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -154,8 +154,9 @@ usage() {
                     若 CMD 中需要字面 -C，可用 -- 分隔。類似 git -C / make -C。
   -t, --target T    Compose service 名稱（預設: devel；例: runtime）
   -d, --detach      背景執行（docker compose up -d，不接受 CMD）
-  -s, --setup       強制重跑 setup.sh 重新生成 .env + compose.yaml
-                    （預設：.env 不存在時自動 bootstrap；存在時僅印 drift warning）
+  -s, --setup       強制重跑 setup.sh（互動式 TTY 開 TUI，否則非互動式 apply）。
+                    預設（無此旗標）：當 setup.conf / Dockerfile stages / GPU /
+                    GUI / USER_UID 漂移時，.env + compose.yaml 自動重新生成 (#88)。
   --build           在 compose up 前先跑 ./build.sh test（lint + smoke），
                     取得本機 / CI 一致驗證；預設行為依賴 compose auto-build
                     時會跳過 lint+smoke gate (#216)
@@ -185,8 +186,9 @@ EOF
                     若 CMD 中需要字面 -C，可用 -- 分隔。类似 git -C / make -C。
   -t, --target T    Compose service 名称（默认: devel；例: runtime）
   -d, --detach      后台运行（docker compose up -d，不接受 CMD）
-  -s, --setup       强制重跑 setup.sh 重新生成 .env + compose.yaml
-                    （默认：.env 不存在时自动 bootstrap；存在时仅打印 drift warning）
+  -s, --setup       强制重跑 setup.sh（交互式 TTY 开 TUI，否则非交互式 apply）。
+                    默认（无此旗标）：当 setup.conf / Dockerfile stages / GPU /
+                    GUI / USER_UID 漂移时，.env + compose.yaml 自动重新生成 (#88)。
   --build           在 compose up 前先跑 ./build.sh test（lint + smoke），
                     取得本机 / CI 一致验证；默认行为依赖 compose auto-build
                     时会跳过 lint+smoke gate (#216)
@@ -217,8 +219,10 @@ EOF
                     git -C / make -C と同様。
   -t, --target T    Compose サービス名（デフォルト: devel；例: runtime）
   -d, --detach      バックグラウンド実行（docker compose up -d、CMD は受け付けない）
-  -s, --setup       setup.sh を強制実行して .env + compose.yaml を再生成
-                    （デフォルト：.env が無ければ自動 bootstrap、あれば drift warning のみ）
+  -s, --setup       setup.sh を強制実行（インタラクティブ TTY なら TUI、それ以外
+                    は非インタラクティブ apply）。デフォルト（フラグ無し）：setup.conf
+                    / Dockerfile stages / GPU / GUI / USER_UID が drift した時、
+                    .env + compose.yaml が自動再生成されます (#88)。
   --build           compose up の前に ./build.sh test（lint + smoke）を実行し、
                     ローカル / CI の検証を一致させます。デフォルト動作は
                     compose auto-build に依存しており、lint + smoke gate を
@@ -251,8 +255,10 @@ Options:
                     need a literal -C inside CMD. Mirrors git -C / make -C.
   -t, --target T    Compose service name (default: devel; e.g. runtime)
   -d, --detach      Run in background (docker compose up -d; no CMD accepted)
-  -s, --setup       Force rerun setup.sh to regenerate .env + compose.yaml
-                    (default: auto-bootstrap if .env missing; warn on drift if present)
+  -s, --setup       Force rerun setup.sh (opens the TUI on an interactive TTY,
+                    otherwise non-interactive apply). Default (no flag):
+                    auto-regenerate .env + compose.yaml when setup.conf /
+                    Dockerfile stages / GPU / GUI / USER_UID drift (#88).
   --build           Run ./build.sh test (lint + smoke) before compose up
                     so local matches CI; default path relies on Compose
                     auto-build which skips the lint + smoke gate (#216)

--- a/test/smoke/script_help.bats
+++ b/test/smoke/script_help.bats
@@ -21,6 +21,13 @@ setup() {
   assert_line --partial "Usage:"
 }
 
+@test "build.sh -h describes auto-apply default (no stale 'warn on drift', #365)" {
+  run bash /lint/build.sh -h
+  assert_success
+  assert_line --partial "auto-regenerate"
+  refute_line --partial "warn on drift"
+}
+
 # -------------------- run.sh --------------------
 
 @test "run.sh -h exits 0" {
@@ -36,6 +43,13 @@ setup() {
 @test "run.sh -h prints usage" {
   run bash /lint/run.sh -h
   assert_line --partial "Usage:"
+}
+
+@test "run.sh -h describes auto-apply default (no stale 'warn on drift', #365)" {
+  run bash /lint/run.sh -h
+  assert_success
+  assert_line --partial "auto-regenerate"
+  refute_line --partial "warn on drift"
 }
 
 # -------------------- exec.sh --------------------


### PR DESCRIPTION
## Summary

Doc-only fix. The `-s, --setup` help text in `build.sh` and `run.sh`
(4 languages each, 8 occurrences total) still claimed pre-#88
"warn on drift" semantics, even though the actual code at
`build.sh:453-477` / `run.sh:442-456` has been calling `setup.sh
apply` automatically on detected drift since #88 (commit `295ebaf`).

That stale claim is what caused #362 — Proposal B asked for the
existing behaviour, and "When this hurts" omitted plain `./build.sh`
(the option that already does the right thing) because the docs
said it did not exist.

## What changed

- 8 usage strings (build.sh + run.sh × en / zh-TW / zh-CN / ja)
  rewritten. Now state:
  - `-s, --setup` force-reruns `setup.sh` (opens the TUI on an
    interactive TTY, otherwise non-interactive apply).
  - Default (no flag): when `setup.conf` / Dockerfile stages / GPU /
    GUI / USER_UID drift, `.env` + `compose.yaml` are auto-regenerated
    (`#88`).
- Two new smoke tests in `test/smoke/script_help.bats` lock the new
  phrasing so the doc cannot silently regress again:
  - `build.sh -h describes auto-apply default (no stale 'warn on drift', #365)`
  - `run.sh -h describes auto-apply default (no stale 'warn on drift', #365)`
- `doc/test/TEST.md` smoke section count updated 25 → 27 (smoke tests
  are not part of the 1361 self-test total, so the top-line is
  unchanged).
- `CHANGELOG.md` `[Unreleased] ### Fixed` entry.

## Out of scope

- No behaviour change. `build.sh:453-477` / `run.sh:442-456` /
  `check-drift` are untouched.
- README / `doc/readme/*` carry no stale "warn on drift" prose
  (`grep` clean).
- Proposal A from #362 (`-Y` / `--apply` flag) — closed in that
  thread.

## Test plan

- [x] `make -f Makefile.ci test` → 1361 / 1361 green (unit +
      integration).
- [x] `bash script/docker/build.sh -h --lang {en,zh-TW,zh-CN,ja}`
      and `bash script/docker/run.sh -h ...` — all 8 outputs show
      the new phrasing; no string contains "warn on drift".
- [ ] CI: `test` + `Integration E2E` + `Behavioural` + `actionlint`
      green.

Closes #365
Refs #88 #362

## Auto-merge note

Keeping auto-merge OFF — `test` is the only branch-protection-
required check on base (#337 tracks the systemic fix). Will manually
merge after `wait-pr-ci`'s `ALL_DONE`.
