### PR TITLE
feat(ci): N-D matrix dispatcher via include-shape inputs (BREAKING, #344)

### DIFF
--- a/.github/workflows/multi-distro-build-worker.yaml
+++ b/.github/workflows/multi-distro-build-worker.yaml
@@ -1,72 +1,64 @@
 name: Multi-distro build dispatcher
 
-# Two-job dispatcher reusable workflow (#325 B-1). Resolves a per-event
-# distro subset and fans it out across `build-worker.yaml` matrix shards,
-# so multi-distro callers (`env/ros_distro`, `env/ros2_distro`,
-# `app/ros1_bridge`) don't have to copy-paste a
+# Two-job dispatcher reusable workflow (#325 B-1, extended to N-D via
+# #344). Resolves a per-event matrix (full JSON `include`-shape array)
+# and fans it out across `build-worker.yaml` matrix shards, so
+# multi-distro / multi-variant callers (`env/ros_distro`,
+# `env/ros2_distro`, `app/ros1_bridge`) don't have to copy-paste a
 # `${{ github.event_name == 'pull_request' && fromJSON('[...]') || ... }}`
 # expression into every main.yaml.
 #
-# Pull-request events use `pr_distros`; tag pushes, main pushes, and
-# workflow_dispatch use `tag_distros` (the full validation matrix).
-# Callers express the policy once per repo via two JSON-array inputs.
+# Pull-request events use `pr_matrix`; tag pushes, main pushes, and
+# workflow_dispatch use `tag_matrix` (the full validation matrix).
+# Each matrix entry is an `include`-shape object with REQUIRED `name`
+# (used for image_name suffix + cache scope) and `build_args` (forwarded
+# verbatim to build-worker.yaml). Callers may include arbitrary other
+# fields per entry — the dispatcher ignores them.
 #
 # A `ci-passed` rollup job aggregates the matrix result for branch
 # protection — matches the existing rollup naming used by env/ros_distro
 # / env/ros2_distro per CLAUDE.md's status-check table, so downstream
 # branch protection contexts don't need to change when adopting this
 # dispatcher.
+#
+# BREAKING vs v0.31.x (#344): the 1D inputs `pr_distros` / `tag_distros`
+# / `distro_input_name` / `extra_build_args` are removed; callers must
+# migrate to `pr_matrix` / `tag_matrix` with explicit `name` +
+# `build_args` per entry. Migration guide: include one entry per cell
+# with `{"name": "<distro>", "build_args": "<distro_input_name>=<distro>"}`.
 
 on:
   workflow_call:
-    # === Multi-distro specific ===
     inputs:
-      pr_distros:
-        required: true
-        type: string
-        description: |
-          JSON-array string of distro values to build on `pull_request`
-          events. Typically a subset of `tag_distros` to keep PR CI
-          fast — e.g. `'["humble"]'` while `tag_distros: '["humble",
-          "jazzy"]'` for `app/ros1_bridge`. Tag-time still validates the
-          full matrix.
-      tag_distros:
-        required: true
-        type: string
-        description: |
-          JSON-array string of distro values to build on tag push, main
-          push, and `workflow_dispatch`. This is the "release-validation"
-          matrix — everything that ships needs to pass here.
-      distro_input_name:
-        required: true
-        type: string
-        description: |
-          Name of the Dockerfile `ARG` (and corresponding `build_args`
-          key) that consumes the per-shard distro value. The dispatcher
-          emits `<distro_input_name>=<matrix.distro>` as the first
-          build_args line for each shard. Example values: `ROS_DISTRO`
-          (ROS 1), `ROS2_DISTRO` (ROS 2 / bridge), `ROS_DISTRO` etc.
-    # === Forwarded to build-worker.yaml (mirror keep build-worker
-    # defaults so existing semantics are preserved when caller omits) ===
       image_name:
         required: true
         type: string
         description: |
           Base image name. The dispatcher derives each shard's image
-          name as `<image_name>-<matrix.distro>` so multi-distro callers
-          don't have to template that expression themselves. E.g.
-          caller sets `image_name: ros1_bridge`, dispatcher passes
-          `ros1_bridge-humble` / `ros1_bridge-jazzy` to build-worker —
-          matching the existing org convention (`app/ros1_bridge`'s
-          pre-dispatcher main.yaml shipped `ros1_bridge-${distro}`).
-      extra_build_args:
-        required: false
+          name as `<image_name>-<matrix.name>` so multi-cell callers
+          don't have to template that expression themselves. Hyphen
+          matches the existing org convention (#339 / v0.29.1 fix).
+      pr_matrix:
+        required: true
         type: string
-        default: ""
         description: |
-          Multi-line KEY=VALUE build_args appended after the
-          dispatcher-emitted `<distro_input_name>=<distro>` line.
-          Forwarded as-is to build-worker.yaml's `build_args` input.
+          JSON array of `include`-shape entries used on `pull_request`
+          events. Each entry MUST include `name` (used for image_name
+          suffix + cache scope) and `build_args` (forwarded verbatim
+          to build-worker.yaml as the per-shard build_args). Arbitrary
+          other fields are allowed but ignored by the dispatcher.
+          Example: `'[{"name":"humble","build_args":"ROS2_DISTRO=humble"}]'`
+      tag_matrix:
+        required: true
+        type: string
+        description: |
+          JSON array of `include`-shape entries used on tag push, main
+          push, and `workflow_dispatch` events. Same per-entry contract
+          as `pr_matrix`: each entry MUST include `name` + `build_args`
+          (arbitrary other fields ignored). This is the "release-
+          validation" matrix — everything that ships needs to pass here.
+      # === Forwarded to build-worker.yaml (defaults mirror build-worker
+      # so existing semantics are preserved when caller omits) ===
       build_runtime:
         required: false
         type: boolean
@@ -96,24 +88,24 @@ jobs:
   resolve-matrix:
     runs-on: ubuntu-latest
     outputs:
-      distros: ${{ steps.r.outputs.distros }}
+      matrix: ${{ steps.r.outputs.matrix }}
     steps:
       - id: r
         env:
           EVENT_NAME: ${{ github.event_name }}
-          PR_DISTROS: ${{ inputs.pr_distros }}
-          TAG_DISTROS: ${{ inputs.tag_distros }}
-        # PR event -> pr_distros subset. Every other event
+          PR_MATRIX: ${{ inputs.pr_matrix }}
+          TAG_MATRIX: ${{ inputs.tag_matrix }}
+        # PR event -> pr_matrix subset. Every other event
         # (push to main, push of a v* tag, workflow_dispatch) ->
-        # tag_distros full matrix. Tag pushes specifically benefit
+        # tag_matrix full matrix. Tag pushes specifically benefit
         # from full validation since they cut releases; main pushes
         # benefit because the same code path is what tag-cut will see.
         run: |
           set -euo pipefail
           if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            echo "distros=${PR_DISTROS}" >> "${GITHUB_OUTPUT}"
+            echo "matrix=${PR_MATRIX}" >> "${GITHUB_OUTPUT}"
           else
-            echo "distros=${TAG_DISTROS}" >> "${GITHUB_OUTPUT}"
+            echo "matrix=${TAG_MATRIX}" >> "${GITHUB_OUTPUT}"
           fi
 
   call-build:
@@ -121,29 +113,27 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ${{ fromJSON(needs.resolve-matrix.outputs.distros) }}
+        include: ${{ fromJSON(needs.resolve-matrix.outputs.matrix) }}
     uses: ./.github/workflows/build-worker.yaml
     with:
-      # Per-shard image_name includes the distro so the GHCR tag
-      # disambiguates multi-distro builds from the same caller repo
-      # (e.g. ros1_bridge-humble vs ros1_bridge-jazzy). Hyphen
-      # matches the existing org convention; env/ros{,2}_distro use
-      # a single-image-multi-variant shape that is out of scope for
-      # this 1D dispatcher (tracked at #344 for 2D extension).
-      image_name: ${{ inputs.image_name }}-${{ matrix.distro }}
-      build_args: |
-        ${{ inputs.distro_input_name }}=${{ matrix.distro }}
-        ${{ inputs.extra_build_args }}
+      # Per-shard image_name includes the matrix cell name so the GHCR
+      # tag disambiguates multi-cell builds from the same caller repo
+      # (e.g. ros1_bridge-humble, ros_distro-noetic-ros-base). Hyphen
+      # matches the existing org convention (#339 v0.29.1 fix).
+      image_name: ${{ inputs.image_name }}-${{ matrix.name }}
+      # Caller fully owns per-cell build_args. Multi-line KEY1=v1\nKEY2=v2
+      # works because build_args is a string passed straight to
+      # docker/build-push-action.
+      build_args: ${{ matrix.build_args }}
       build_runtime: ${{ inputs.build_runtime }}
       test_tools_version: ${{ inputs.test_tools_version }}
       platforms: ${{ inputs.platforms }}
       context_path: ${{ inputs.context_path }}
       dockerfile_path: ${{ inputs.dockerfile_path }}
       build_contexts: ${{ inputs.build_contexts }}
-      # Per-distro buildx cache scope so e.g. humble and jazzy shards
-      # don't evict each other's cache. Matches the `cache_variant`
-      # contract added in #272 for env/ros{,2}_distro's variant matrix.
-      cache_variant: ${{ matrix.distro }}
+      # Per-cell buildx cache scope so cells don't evict each other's
+      # cache. Matches the `cache_variant` contract added in #272.
+      cache_variant: ${{ matrix.name }}
 
   ci-passed:
     name: ci-passed
@@ -166,4 +156,4 @@ jobs:
             echo "call-build matrix did not all succeed: ${NEEDS_RESULT}"
             exit 1
           fi
-          echo "All distro shards passed."
+          echo "All matrix cells passed."

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING** (#344) — `multi-distro-build-worker.yaml` dispatcher
+  rewritten from 1D scalar-axis to N-D `include`-shape matrix-mode.
+  Legacy inputs `pr_distros` / `tag_distros` / `distro_input_name` /
+  `extra_build_args` are removed; callers must use `pr_matrix` /
+  `tag_matrix` (full JSON arrays of `{name, build_args, ...}` entries).
+  Each cell's `name` field is REQUIRED and drives both the per-shard
+  `image_name` suffix (`<inputs.image_name>-<matrix.name>`, hyphen
+  per #339 v0.29.1 convention) and the buildx cache scope
+  (`cache_variant: ${{ matrix.name }}`, #272 contract). `build_args`
+  is forwarded verbatim — caller fully owns per-cell args. Motivation:
+  the 1D dispatcher cannot represent `env/ros_distro` /
+  `env/ros2_distro`'s 4-cell shape (strong cross-axis correlations
+  between distro/variant/registry/ubuntu suffix); switching to
+  GitHub matrix's native `include` form unlocks both env repos as
+  callers and any future N-axis case without dispatcher changes.
+
+  Migration table for the only existing 1D caller (`app/ros1_bridge`):
+
+  | Old (v0.29.x — v0.31.x) | New (v0.32.0+) |
+  |---|---|
+  | `pr_distros: '["humble"]'` | `pr_matrix: '[{"name":"humble","build_args":"ROS2_DISTRO=humble"}]'` |
+  | `tag_distros: '["humble", "jazzy"]'` | `tag_matrix: '[{"name":"humble","build_args":"ROS2_DISTRO=humble"},{"name":"jazzy","build_args":"ROS2_DISTRO=jazzy"}]'` |
+  | `distro_input_name: ROS2_DISTRO` | (removed — encoded per-cell in `build_args`) |
+  | `extra_build_args: ...` | (removed — append directly in each cell's `build_args` via multi-line) |
+
+  Per-shard GHCR tag shape unchanged (`<image_name>-<cell-name>`),
+  so registry artifacts produced by existing callers stay compatible
+  after migration. `ci-passed` rollup job unchanged — branch
+  protection contexts don't move. Existing inline-matrix callers
+  (`env/ros_distro` / `env/ros2_distro`) can now adopt the dispatcher
+  for the first time. Test spec
+  `multi_distro_build_worker_yaml_spec.bats` rewritten (14 → 16
+  tests; new negative assertion verifies the 1D inputs are gone).
+  Closes #344.
+
 ## [v0.31.0] - 2026-05-15
 
 Promoted from `v0.31.0-rc1` (#363). RC tag CI green: `Self Test`

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1361 tests** total (1299 unit + 62 integration).
+Template self-tests: **1363 tests** total (1301 unit + 62 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -332,48 +332,57 @@ which would leave a freshly-pushed `:main` unverified).
 | Smoke step pulls trigger's tag via `steps.tags.outputs.smoke` (#317 P2) | 1 |
 | Build step pushes multi-arch (amd64 + arm64) + declares `packages: write` permission | 2 |
 
-### test/unit/multi_distro_build_worker_yaml_spec.bats (14)
+### test/unit/multi_distro_build_worker_yaml_spec.bats (16)
 
 Structural assertions for `.github/workflows/multi-distro-build-worker.yaml`
-(#325 B-1 dispatcher). The dispatcher fans a per-event distro
-subset across `build-worker.yaml` matrix shards so multi-distro
+(#325 B-1 dispatcher, extended to N-D matrix-mode via #344 in v0.32.0).
+The dispatcher fans a per-event `include`-shape matrix across
+`build-worker.yaml` matrix shards so multi-distro / multi-variant
 caller `main.yaml`s (`env/ros_distro`, `env/ros2_distro`,
 `app/ros1_bridge`) stop copy-pasting a
 `${{ github.event_name == 'pull_request' && ... || ... }}`
 expression. Three jobs:
 
-1. **`resolve-matrix`** — pure-shell selector emitting a `distros`
-   JSON-array output. `pull_request` -> `pr_distros` (subset);
-   anything else (tag push, main push, `workflow_dispatch`) ->
-   `tag_distros` (release validation matrix).
+1. **`resolve-matrix`** — pure-shell selector emitting a `matrix`
+   JSON-array output (`include`-shape, each entry has `name` +
+   `build_args` plus arbitrary additional fields). `pull_request` ->
+   `pr_matrix` (subset); anything else (tag push, main push,
+   `workflow_dispatch`) -> `tag_matrix` (release validation matrix).
 
 2. **`call-build`** — strategy.matrix job invoking the local
-   `build-worker.yaml` per distro shard. Derives per-shard
-   `image_name` as `<image_name>_<distro>`, passes
-   `<distro_input_name>=<distro>` as the first `build_args` line,
-   and shards buildx GHA cache by distro via
-   `cache_variant: ${{ matrix.distro }}` (reuses #272's per-variant
-   scope contract). `fail-fast: false` so one shard's failure
-   doesn't cancel siblings.
+   `build-worker.yaml` per matrix cell. Derives per-shard
+   `image_name` as `<image_name>-<matrix.name>`, forwards
+   `matrix.build_args` verbatim as `build_args`, and shards buildx
+   GHA cache by name via `cache_variant: ${{ matrix.name }}`
+   (reuses #272's per-variant scope contract). `fail-fast: false`
+   so one shard's failure doesn't cancel siblings.
 
 3. **`ci-passed`** — rollup gate for branch protection. Matches the
    existing `ci-passed` rollup naming used by env/ros_distro /
    env/ros2_distro per CLAUDE.md's status-check table, so
    downstream branch-protection contexts don't change on adoption.
 
+**BREAKING since v0.32.0 (#344)**: legacy 1D inputs `pr_distros` /
+`tag_distros` / `distro_input_name` / `extra_build_args` were removed;
+the 14 v0.29-era tests covering those inputs are replaced by 16 tests
+covering the new matrix-mode shape (incl. a negative assertion that
+the 1D inputs are gone).
+
 | Category | Tests |
 |----------|-------|
 | Declares `workflow_call` | 1 |
-| Required inputs: `pr_distros`, `tag_distros`, `distro_input_name`, `image_name` | 1 |
+| Required inputs: `pr_matrix`, `tag_matrix`, `image_name` | 1 |
+| Legacy 1D inputs gone (no `pr_distros` / `tag_distros` / `distro_input_name` / `extra_build_args`) | 1 |
+| `pr_matrix` description documents required `name` + `build_args` fields | 1 |
+| `tag_matrix` description documents required `name` + `build_args` fields | 1 |
 | Passthrough inputs mirror build-worker (build_runtime / test_tools_version / platforms / context_path / dockerfile_path / build_contexts) | 1 |
-| Defines `extra_build_args` passthrough | 1 |
-| `resolve-matrix` emits `distros` output | 1 |
+| `resolve-matrix` emits `matrix` output (include-shape) | 1 |
 | `resolve-matrix` branches on `github.event_name == 'pull_request'` | 1 |
 | `call-build` `uses: ./.github/workflows/build-worker.yaml` | 1 |
-| `call-build` matrix `fromJSON(needs.resolve-matrix.outputs.distros)` | 1 |
-| `call-build` per-shard `image_name: <image_name>_<distro>` | 1 |
-| `call-build` `build_args` line `<distro_input_name>=<distro>` | 1 |
-| `call-build` `cache_variant: ${{ matrix.distro }}` (per-distro cache scope) | 1 |
+| `call-build` matrix `include: fromJSON(needs.resolve-matrix.outputs.matrix)` | 1 |
+| `call-build` per-shard `image_name: <image_name>-<matrix.name>` (hyphen) | 1 |
+| `call-build` forwards `build_args: ${{ matrix.build_args }}` verbatim | 1 |
+| `call-build` `cache_variant: ${{ matrix.name }}` (per-cell cache scope) | 1 |
 | `call-build` `fail-fast: false` | 1 |
 | `ci-passed` rollup depends on `call-build`, runs with `if: always()` | 1 |
 | `ci-passed` declares `name: ci-passed` to satisfy branch protection contract | 1 |

--- a/test/unit/multi_distro_build_worker_yaml_spec.bats
+++ b/test/unit/multi_distro_build_worker_yaml_spec.bats
@@ -1,29 +1,36 @@
 #!/usr/bin/env bats
 #
 # multi_distro_build_worker_yaml_spec.bats — structural assertions for
-# `.github/workflows/multi-distro-build-worker.yaml` (#325 B-1 dispatcher).
+# `.github/workflows/multi-distro-build-worker.yaml` (#325 B-1 dispatcher
+# extended to N-D matrix-mode via #344).
 #
 # The dispatcher is a two-job reusable workflow on top of
 # build-worker.yaml:
 #
-# 1. `resolve-matrix` — pure-shell selector that emits a `distros` JSON
-#    array output based on `github.event_name`. `pull_request` ->
-#    `pr_distros` (subset); everything else (tag push, main push,
-#    workflow_dispatch) -> `tag_distros` (full release matrix).
+# 1. `resolve-matrix` — pure-shell selector that emits a `matrix`
+#    `include`-shape JSON array output based on `github.event_name`.
+#    `pull_request` -> `pr_matrix` (subset); everything else (tag push,
+#    main push, workflow_dispatch) -> `tag_matrix` (full release matrix).
 #
 # 2. `call-build` — strategy.matrix job invoking
-#    `./.github/workflows/build-worker.yaml` per distro shard. Derives
-#    per-shard `image_name` as `<image_name>_<distro>` so GHCR tags
-#    disambiguate across distros, and passes
-#    `<distro_input_name>=<distro>` as the first `build_args` line.
-#    Per-distro `cache_variant: ${{ matrix.distro }}` so buildx GHA
-#    cache shards by distro (matches #272's per-variant scope pattern).
+#    `./.github/workflows/build-worker.yaml` per matrix cell. Each cell
+#    MUST have `name` (used for image_name suffix + cache scope) and
+#    `build_args` (forwarded verbatim to build-worker.yaml). Derives
+#    per-shard `image_name` as `<image_name>-<matrix.name>` so GHCR tags
+#    disambiguate across cells. Per-cell
+#    `cache_variant: ${{ matrix.name }}` so buildx GHA cache shards by
+#    cell name (matches #272's per-variant scope pattern).
 #
 # 3. `ci-passed` — rollup aggregating the matrix result for branch
 #    protection. Matches the existing rollup naming used by
 #    env/ros_distro / env/ros2_distro per CLAUDE.md's status-check
 #    table, so downstream branch-protection contexts don't change when
 #    adopting this dispatcher.
+#
+# BREAKING since v0.32.0 (#344): the 1D inputs `pr_distros` /
+# `tag_distros` / `distro_input_name` / `extra_build_args` are removed;
+# callers must use `pr_matrix` / `tag_matrix` (full JSON include-shape)
+# instead.
 
 bats_require_minimum_version 1.5.0
 
@@ -40,13 +47,35 @@ setup() {
   assert_success
 }
 
-@test "multi-distro-build-worker.yaml: required inputs include pr_distros + tag_distros + distro_input_name + image_name (#325 B-1)" {
+@test "multi-distro-build-worker.yaml: required inputs include pr_matrix + tag_matrix + image_name (#344 matrix-mode)" {
   run awk '/^on:/{flag=1} /^jobs:/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial 'pr_distros:'
-  assert_output --partial 'tag_distros:'
-  assert_output --partial 'distro_input_name:'
+  assert_output --partial 'pr_matrix:'
+  assert_output --partial 'tag_matrix:'
   assert_output --partial 'image_name:'
+}
+
+@test "multi-distro-build-worker.yaml: legacy 1D inputs are gone (no pr_distros / tag_distros / distro_input_name / extra_build_args) (#344 BREAKING)" {
+  run awk '/^on:/{flag=1} /^jobs:/{flag=0} flag' "${WF}"
+  assert_success
+  refute_output --partial 'pr_distros:'
+  refute_output --partial 'tag_distros:'
+  refute_output --partial 'distro_input_name:'
+  refute_output --partial 'extra_build_args:'
+}
+
+@test "multi-distro-build-worker.yaml: pr_matrix description mentions required name + build_args fields per entry (#344)" {
+  run awk '/^      pr_matrix:/{flag=1; next} /^      [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'name'
+  assert_output --partial 'build_args'
+}
+
+@test "multi-distro-build-worker.yaml: tag_matrix description mentions required name + build_args fields per entry (#344)" {
+  run awk '/^      tag_matrix:/{flag=1; next} /^      [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'name'
+  assert_output --partial 'build_args'
 }
 
 @test "multi-distro-build-worker.yaml: passthrough inputs mirror build-worker (build_runtime / test_tools_version / platforms / context_path / dockerfile_path / build_contexts) (#325 B-1)" {
@@ -60,27 +89,21 @@ setup() {
   assert_output --partial 'build_contexts:'
 }
 
-@test "multi-distro-build-worker.yaml: defines extra_build_args passthrough (caller can append KEY=VALUE after the dispatcher's distro arg) (#325 B-1)" {
-  run awk '/^on:/{flag=1} /^jobs:/{flag=0} flag' "${WF}"
-  assert_success
-  assert_output --partial 'extra_build_args:'
-}
-
 # ── resolve-matrix job ───────────────────────────────────────────────
 
-@test "multi-distro-build-worker.yaml: resolve-matrix job emits distros output (#325 B-1)" {
+@test "multi-distro-build-worker.yaml: resolve-matrix job emits matrix output (#344 include-shape)" {
   run awk '/^  resolve-matrix:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial 'distros: ${{ steps.r.outputs.distros }}'
+  assert_output --partial 'matrix: ${{ steps.r.outputs.matrix }}'
 }
 
-@test "multi-distro-build-worker.yaml: resolve-matrix branches on github.event_name == pull_request (#325 B-1)" {
+@test "multi-distro-build-worker.yaml: resolve-matrix branches on github.event_name == pull_request (#344)" {
   run awk '/^  resolve-matrix:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
   assert_output --partial 'EVENT_NAME: ${{ github.event_name }}'
   assert_output --partial '"${EVENT_NAME}" == "pull_request"'
-  assert_output --partial 'distros=${PR_DISTROS}'
-  assert_output --partial 'distros=${TAG_DISTROS}'
+  assert_output --partial 'matrix=${PR_MATRIX}'
+  assert_output --partial 'matrix=${TAG_MATRIX}'
 }
 
 # ── call-build matrix job ────────────────────────────────────────────
@@ -91,34 +114,32 @@ setup() {
   assert_output --partial 'uses: ./.github/workflows/build-worker.yaml'
 }
 
-@test "multi-distro-build-worker.yaml: call-build matrix is fromJSON(needs.resolve-matrix.outputs.distros) (#325 B-1)" {
+@test "multi-distro-build-worker.yaml: call-build matrix is include: fromJSON(needs.resolve-matrix.outputs.matrix) (#344 N-D)" {
   run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial 'distro: ${{ fromJSON(needs.resolve-matrix.outputs.distros) }}'
+  assert_output --partial 'include: ${{ fromJSON(needs.resolve-matrix.outputs.matrix) }}'
 }
 
-@test "multi-distro-build-worker.yaml: call-build derives per-shard image_name as <image_name>-<distro> (hyphen, v0.29.1 fix matches org convention)" {
+@test "multi-distro-build-worker.yaml: call-build derives per-shard image_name as <image_name>-<matrix.name> (hyphen, #344)" {
   # Hyphen separator chosen to match the existing org pattern (e.g.
   # app/ros1_bridge's pre-dispatcher main.yaml shipped
-  # `ros1_bridge-${distro}`). Underscore was used in the v0.29.0
-  # initial implementation but never adopted by any consumer; v0.29.1
-  # corrects it before the first downstream migration lands.
+  # `ros1_bridge-${distro}`). #339 v0.29.1 fix carried over.
   run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial 'image_name: ${{ inputs.image_name }}-${{ matrix.distro }}'
-  refute_output --partial 'image_name: ${{ inputs.image_name }}_${{ matrix.distro }}'
+  assert_output --partial 'image_name: ${{ inputs.image_name }}-${{ matrix.name }}'
+  refute_output --partial 'image_name: ${{ inputs.image_name }}_${{ matrix.name }}'
 }
 
-@test "multi-distro-build-worker.yaml: call-build passes <distro_input_name>=<distro> as build_args (#325 B-1)" {
+@test "multi-distro-build-worker.yaml: call-build passes matrix.build_args verbatim as build_args (#344)" {
   run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial '${{ inputs.distro_input_name }}=${{ matrix.distro }}'
+  assert_output --partial 'build_args: ${{ matrix.build_args }}'
 }
 
-@test "multi-distro-build-worker.yaml: call-build splits buildx cache by distro via cache_variant: matrix.distro (#272 reuse, #325 B-1)" {
+@test "multi-distro-build-worker.yaml: call-build splits buildx cache by name via cache_variant: matrix.name (#272 reuse, #344)" {
   run awk '/^  call-build:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial 'cache_variant: ${{ matrix.distro }}'
+  assert_output --partial 'cache_variant: ${{ matrix.name }}'
 }
 
 @test "multi-distro-build-worker.yaml: call-build has fail-fast: false so one shard's failure doesn't cancel siblings (#325 B-1)" {


### PR DESCRIPTION
## Summary

`multi-distro-build-worker.yaml` rewritten from 1D scalar-axis to N-D
`include`-shape matrix-mode. Legacy 1D inputs (`pr_distros` /
`tag_distros` / `distro_input_name` / `extra_build_args`) removed;
callers use `pr_matrix` / `tag_matrix` (full JSON arrays of
`{name, build_args, ...}` entries).

Closes #344.

## Motivation

The 1D dispatcher (shipped in #339 / v0.29.0) cannot represent
`env/ros_distro` / `env/ros2_distro`'s 4-cell matrix because of strong
cross-axis correlations:

| cell | distro | variant | registry | ubuntu |
|---|---|---|---|---|
| `noetic-desktop-full` | noetic | desktop-full | osrf/ros: | focal |
| `noetic-ros-base` | noetic | ros-base | ros: | focal |
| `kinetic-desktop-full` | kinetic | desktop-full | osrf/ros: | xenial |
| `kinetic-ros-base` | kinetic | ros-base | ros: | xenial |

`variant`↔`registry` and `distro`↔`ubuntu_suffix` are not independent
axes, so a named-2D-axes dispatcher (Option A in the #344 thread)
cannot derive `BASE_IMAGE` without hardcoded lookup tables or
`exclude` blocks that defeat readability. GitHub matrix's native
`include` form (Option B) handles this naturally — each cell is an
independent object, fields are arbitrary.

## What changed

- **Inputs** (`multi-distro-build-worker.yaml`):
  - **Removed (BREAKING)**: `pr_distros`, `tag_distros`,
    `distro_input_name`, `extra_build_args`
  - **Added**: `pr_matrix`, `tag_matrix` (both required, JSON
    `include`-shape array string)
  - Passthrough inputs (`build_runtime` / `test_tools_version` /
    `platforms` / `context_path` / `dockerfile_path` /
    `build_contexts`) unchanged
- **`resolve-matrix` job**: emits `matrix` output (was `distros`).
  Picks `pr_matrix` on `pull_request`, `tag_matrix` otherwise.
- **`call-build` job**:
  - `strategy.matrix.include: ${{ fromJSON(needs.resolve-matrix.outputs.matrix) }}`
    (was `matrix.distro: scalar`)
  - `image_name: <inputs.image_name>-${{ matrix.name }}` (hyphen,
    preserves #339 v0.29.1 GHCR tag convention)
  - `build_args: ${{ matrix.build_args }}` (verbatim passthrough)
  - `cache_variant: ${{ matrix.name }}` (#272 contract)
- **`ci-passed` rollup**: unchanged. Branch protection contexts don't
  move.

## Migration table for the only 1D caller (`app/ros1_bridge`)

```diff
  uses: ycpss91255-docker/base/.github/workflows/multi-distro-build-worker.yaml@<tag>
  with:
    image_name: ros1_bridge
-   pr_distros: '["humble"]'
-   tag_distros: '["humble", "jazzy"]'
-   distro_input_name: ROS2_DISTRO
+   pr_matrix: '[{"name":"humble","build_args":"ROS2_DISTRO=humble"}]'
+   tag_matrix: |
+     [
+       {"name": "humble", "build_args": "ROS2_DISTRO=humble"},
+       {"name": "jazzy",  "build_args": "ROS2_DISTRO=jazzy"}
+     ]
```

Per-shard GHCR tag shape preserved (`ros1_bridge-humble` etc.) so
registry artifacts stay compatible.

## Tests

- `test/unit/multi_distro_build_worker_yaml_spec.bats`:
  - 14 v0.29-era tests covering 1D inputs replaced
  - 16 new tests cover matrix-mode shape
  - New **negative assertion** verifies the 1D inputs are gone
    (defends against partial reverts / merge conflicts re-introducing them)
- `make -f Makefile.ci test` → 1363 / 1363 green
  (1301 unit + 62 integration)
- TEST.md spec count + grand total synced

## Release plan

- This PR merges → tag `v0.32.0-rc1` (RC discipline)
- Phase 1.5: 3 caller migration tracking issues filed
  (`ros1_bridge` / `ros_distro` / `ros2_distro`)
- Phase 3: 3 caller migration PRs against `@v0.32.0-rc1` to validate
- Phase 4: tag `v0.32.0` stable after all 3 caller PRs CI-green
- Phase 5: `/batch-template-upgrade v0.32.0` fanout to remaining 10
  active downstream repos (which don't use the dispatcher)

## Out of scope

- `publish-worker.yaml` still takes inline matrix (separate follow-up
  if needed; env/*'s `call-publish` job is untouched here)
- No other 1D callers exist beyond `ros1_bridge`
- `wait-pr-ci` skill filter table unchanged (`ci-passed` rollup name
  preserved)

## Auto-merge note

Keeping auto-merge OFF — `test` is the only branch-protection-
required check on base (#337 tracks the systemic fix). Will manually
merge after `wait-pr-ci`'s `ALL_DONE`.
