### PR TITLE
fix(dockerfile): ship _entrypoint_logging.sh into image at /usr/local/lib/base/ (#368)

### DIFF
--- a/config/docker/setup.conf
+++ b/config/docker/setup.conf
@@ -130,8 +130,15 @@ mount_1 =
 #
 # local_path (#328): when non-empty, setup.sh emits a per-service
 # host bind mount `<resolved>:/var/log/<repo>` so container stdout
-# can be tee'd to a host-side file (via the .base/script/docker/_entrypoint_logging.sh
-# helper sourced from the repo entrypoint). Path semantics:
+# can be tee'd to a host-side file. The helper that performs the
+# tee is shipped into every image at the stable in-image path
+# `/usr/local/lib/base/_entrypoint_logging.sh` (#368; COPY'd by
+# Dockerfile.example's devel stage). Source it from the repo's
+# `script/entrypoint.sh` with a single un-guarded line:
+#   . /usr/local/lib/base/_entrypoint_logging.sh
+# The helper is a no-op when LOG_FILE_PATH is unset, so the source
+# line is safe to add unconditionally. Path semantics for the
+# local_path value:
 #   ./logs/     relative to repo root
 #   /abs/path/  absolute, used verbatim
 #   ~/dir/      ~ expanded to $HOME

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `dockerfile/Dockerfile.example`, `script/docker/_entrypoint_logging.sh`,
+  `config/docker/setup.conf`: ship `_entrypoint_logging.sh` into every
+  downstream image at the stable in-image path
+  `/usr/local/lib/base/_entrypoint_logging.sh` so the documented
+  source-line works at build-time AND runtime in every workspace
+  layout (#368). The v0.30.0 example
+  `. /home/${USER}/work/.base/script/docker/_entrypoint_logging.sh`
+  had two failure modes that hit every adopter: (a) `$USER` is unset
+  in the Dockerfile test stage, so `set -u` entrypoints crashed
+  during build-time bats smoke (`USER: unbound variable`); (b) on
+  multi-repo workspace layouts (the org-wide norm), `WS_PATH` resolves
+  to the workspace parent rather than the repo root, so the bind mount
+  `<WS_PATH>:/home/<user>/work` places the repo's `.base/` at
+  `/home/<user>/work/<repo>/.base/`, not the documented
+  `/home/<user>/work/.base/` -- the helper silently never ran and
+  no host-side log file was ever produced. Path A fix: Dockerfile.example's
+  devel stage now COPYs `.base/script/docker/_entrypoint_logging.sh`
+  into `/usr/local/lib/base/_entrypoint_logging.sh`, the commented-out
+  runtime stage block carries a matching COPY example, and the helper
+  header + setup.conf `[logging]` comment block both document the
+  in-image source-line. Downstream entrypoints can adopt the helper
+  with a single un-guarded line:
+  ```
+  . /usr/local/lib/base/_entrypoint_logging.sh
+  ```
+  The line is safe to add unconditionally because the helper is a
+  no-op when `LOG_FILE_PATH` is unset; repos that haven't opted into
+  `[logging] local_path` stay unaffected. Existing downstream guards
+  (e.g. ros1_bridge#107's `if [[ -f ... ]]` + `${USER:-root}`) become
+  unnecessary and can be simplified in a follow-up PR. 5 new tests:
+  3 in `template_spec.bats` (Dockerfile.example devel COPY directive +
+  stage placement, commented runtime stage COPY example, helper header
+  positive + negative regression guards), 1 in `compose_logging_spec.bats`
+  (setup.conf `[logging]` comment block path reference + negative guard),
+  1 in `init_new_repo_spec.bats` (init.sh-generated Dockerfile contains
+  the helper COPY).
+
 ## [v0.32.0-rc1] - 2026-05-15
 
 Release Candidate for v0.32.0 minor feature release. Bundles a

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1363 tests** total (1301 unit + 62 integration).
+Template self-tests: **1368 tests** total (1305 unit + 63 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -581,7 +581,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `environment env_N supports multiple cross-references in one value (refs #236)` | multi-ref |
 | `environment env_N transitive cross-reference resolves through chain (refs #236)` | transitive |
 
-### test/unit/compose_logging_spec.bats (25)
+### test/unit/compose_logging_spec.bats (26)
 
 Covers `[logging]` + `[logging.<svc>]` support in
 `generate_compose_yaml` (#310). Tests the global emission on every
@@ -617,6 +617,7 @@ behaviour, and the two new setup.sh helpers `_parse_logging_svc_sections`
 | `_sync_logging_local_paths_gitignore is idempotent (#328)` | Re-run no-op |
 | `_sync_logging_local_paths_gitignore collects from both global + per-svc (#328)` | Multi-source |
 | `_sync_logging_local_paths_gitignore is no-op when no local_path keys (#328)` | Empty no-op |
+| `setup.conf [logging] comment block references in-image helper path (/usr/local/lib/base/, #368)` | Documented adoption path matches in-image COPY |
 
 ### test/unit/entrypoint_logging_spec.bats (6)
 
@@ -637,7 +638,7 @@ the host file content and the inherited stdout (preserving
 | `entrypoint_logging warns + continues when target is a directory (#328)` | Failure-mode fallback |
 | `entrypoint_logging captures stderr along with stdout (#328)` | 2>&1 redirect |
 
-### test/unit/template_spec.bats (147)
+### test/unit/template_spec.bats (150)
 
 | Test | Description |
 |------|-------------|
@@ -767,6 +768,9 @@ the host file content and the inherited stdout (preserving
 | `run.sh contains xhost +local: for X11` | X11 xhost |
 | `setup.sh default _base_path uses /..` | Path resolution |
 | `setup.sh default _base_path uses double parent traversal` | Repo root traversal |
+| `Dockerfile.example copies _entrypoint_logging.sh to /usr/local/lib/base/ in devel stage (#368)` | In-image helper COPY + devel-stage placement |
+| `Dockerfile.example commented runtime stage shows _entrypoint_logging.sh COPY example (#368)` | Runtime opt-in scaffold |
+| `_entrypoint_logging.sh header documents in-image source-line (no $USER, no work/.base) (#368)` | Helper Usage docstring positive + negative regression guards |
 
 ### test/unit/bashrc_spec.bats (10)
 
@@ -1003,7 +1007,7 @@ Unit tests for `template/script/docker/lib/gitignore.sh` — the canonical
 | `_untrack_canonical_in_repo: idempotent — second run succeeds without error` | Re-run safety |
 | `_untrack_canonical_in_repo: untracks all canonical entries that match` | Multi-entry sweep |
 
-### test/integration/init_new_repo_spec.bats (40)
+### test/integration/init_new_repo_spec.bats (41)
 
 End-to-end verification that `init.sh` produces a complete repo skeleton in
 an empty directory. **Level 1** (file generation only, no Docker). The
@@ -1034,6 +1038,7 @@ which has access to a Docker daemon on the host runner.
 | `Dockerfile.example has layered config COPY chain (template#254)` | layered COPY order |
 | `Dockerfile.example declares ENV HOME before WORKDIR ${HOME}/work (#334)` | HOME env directive |
 | `Dockerfile.example sets up bashrc.d drop-in directory (template#254)` | bashrc.d setup |
+| `new repo: Dockerfile contains _entrypoint_logging.sh in-image COPY (#368)` | End-to-end check on init.sh-generated repo |
 | `new repo: .base/.version exists (no legacy VERSION / .template_version)` | version file |
 | `new repo: re-running init.sh on the result is idempotent` | idempotent |
 | `new repo: init.sh creates setup_tui.sh symlink under script/ (not legacy tui.sh)` | setup_tui under script/ |

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -146,6 +146,16 @@ ARG CONFIG_SRC="config"
 #     rm -rf /var/lib/apt/lists/*
 
 COPY --chmod=0755 "./${ENTRYPOINT_FILE}" "/entrypoint.sh"
+# Host-side log tee helper (#328 / #368). Source from
+# script/entrypoint.sh with a single un-guarded line:
+#   . /usr/local/lib/base/_entrypoint_logging.sh
+# The helper is a no-op when LOG_FILE_PATH is unset, so the source
+# line is safe to add unconditionally -- repos that haven't opted
+# into [logging] local_path stay unaffected. In-image path (vs the
+# bind-mounted .base/) avoids two failure modes: build-time smoke
+# crashes when $USER is unset, and multi-repo workspaces where
+# WS_PATH is the workspace parent rather than the repo root.
+COPY --chmod=0755 .base/script/docker/_entrypoint_logging.sh /usr/local/lib/base/_entrypoint_logging.sh
 # Layer 1: .base/config/ defaults (subtree-managed, updates with
 # .base/upgrade.sh).
 COPY --chown="${USER}":"${GROUP}" --chmod=0755 .base/config "${CONFIG_DIR}"
@@ -373,6 +383,13 @@ RUN bats /smoke_test/
 # COPY --from=builder /build_ws/install /opt/app/install
 #
 # COPY --chmod=0755 script/entrypoint.sh /entrypoint.sh
+# # Host-side log tee helper (#328 / #368). Runtime starts from a
+# # fresh BASE_IMAGE so the devel stage's helper COPY is NOT
+# # inherited -- repos that ship a runtime image and want to opt
+# # into [logging] local_path tee must repeat the COPY here so
+# # `. /usr/local/lib/base/_entrypoint_logging.sh` works in the
+# # runtime image too.
+# COPY --chmod=0755 .base/script/docker/_entrypoint_logging.sh /usr/local/lib/base/_entrypoint_logging.sh
 # USER "${USER}"
 # # WORKDIR interpolates only build-time ARG / ENV (not shell $HOME);
 # # see #334 for why the explicit ENV is required.

--- a/script/docker/_entrypoint_logging.sh
+++ b/script/docker/_entrypoint_logging.sh
@@ -36,12 +36,28 @@
 #   - tee binary missing -> warn, no-op (BusyBox-based minimal images
 #     should still have it; warn covers the edge case)
 #
-# Usage:
+# Usage (downstream `script/entrypoint.sh`):
 #   #!/usr/bin/env bash
-#   # script/entrypoint.sh
 #   set -euo pipefail
-#   . /home/${USER}/work/.base/script/docker/_entrypoint_logging.sh
+#   # shellcheck source=/dev/null
+#   . /usr/local/lib/base/_entrypoint_logging.sh
 #   exec "$@"
+#
+# Why the in-image path (#368, supersedes the PR #356 example that
+# tried to source the helper through the workspace bind mount via
+# the entrypoint user's `$HOME` and the `.base/` subtree):
+#   - `USER` is unset in the Dockerfile test stage (no login env),
+#     so the old source-line crashed `set -u` entrypoints during
+#     build-time bats smoke with `USER: unbound variable`.
+#   - On multi-repo workspace layouts (the org-wide norm), the
+#     workspace bind mount maps the workspace parent dir into the
+#     container, so the repo's `.base/` subtree lives one extra
+#     directory deeper than the original example assumed and the
+#     runtime tee silently never wrote the host-side log file.
+#   - The helper is COPY'd into /usr/local/lib/base/ by
+#     Dockerfile.example's devel stage, so the source-line works the
+#     same at build-time, runtime, and across every workspace layout
+#     with no `$USER` deref or path arithmetic.
 
 # Allow safe sourcing under any shell mode. We don't propagate strict
 # mode locally because the caller may set its own and we shouldn't

--- a/test/integration/init_new_repo_spec.bats
+++ b/test/integration/init_new_repo_spec.bats
@@ -257,6 +257,21 @@ teardown() {
   assert_success
 }
 
+@test "new repo: Dockerfile contains _entrypoint_logging.sh in-image COPY (#368)" {
+  # End-to-end check that a fresh init.sh-generated repo includes the
+  # Dockerfile COPY for the helper. The helper must land at the
+  # stable in-image path so downstream entrypoints can source it
+  # with a clean `. /usr/local/lib/base/_entrypoint_logging.sh`
+  # one-liner -- no $USER deref, no WS_PATH dependence, works at
+  # build-time smoke AND runtime on multi-repo workspaces. Pin the
+  # COPY here so init.sh seeding regressions are caught.
+  bash .base/init.sh
+  local _df="${REPO_DIR}/Dockerfile"
+  assert [ -f "${_df}" ]
+  run grep -F 'COPY --chmod=0755 .base/script/docker/_entrypoint_logging.sh /usr/local/lib/base/_entrypoint_logging.sh' "${_df}"
+  assert_success
+}
+
 @test "new repo: .base/.version exists (no legacy VERSION / .template_version)" {
   bash .base/init.sh
   assert [ -f "${REPO_DIR}/.base/.version" ]

--- a/test/unit/compose_logging_spec.bats
+++ b/test/unit/compose_logging_spec.bats
@@ -379,3 +379,27 @@ CONF
   # File should be unchanged (still empty).
   [[ ! -s "${_gitignore}" ]]
 }
+
+# ════════════════════════════════════════════════════════════════════
+# setup.conf [logging] section: in-image helper path reference (#368)
+# ════════════════════════════════════════════════════════════════════
+
+@test "setup.conf [logging] comment block references in-image helper path (/usr/local/lib/base/, #368)" {
+  # The [logging] section in the template default setup.conf is the
+  # primary surface where downstream maintainers learn about the
+  # local_path feature + the entrypoint helper. PR #356 originally
+  # pointed at `.base/script/docker/_entrypoint_logging.sh` (the
+  # subtree path inside the workspace bind mount), which crashes on
+  # build-time smoke ($USER unset) and is wrong on multi-repo
+  # workspaces (WS_PATH = workspace parent, not repo root). Path A
+  # ships the helper into the image at /usr/local/lib/base/; the
+  # comment must point there so the documented adoption path matches
+  # the COPY in Dockerfile.example.
+  local _conf="/source/config/docker/setup.conf"
+  [[ -f "${_conf}" ]] || skip "config/docker/setup.conf not present"
+  run grep -F '/usr/local/lib/base/_entrypoint_logging.sh' "${_conf}"
+  assert_success
+  # Negative guard: the broken pre-#368 path must not reappear.
+  run grep -F '.base/script/docker/_entrypoint_logging.sh' "${_conf}"
+  assert_failure
+}

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -665,6 +665,70 @@ _stage_lint_layout() {
   assert_success
 }
 
+@test "Dockerfile.example copies _entrypoint_logging.sh to /usr/local/lib/base/ in devel stage (#368)" {
+  # PR #356 documented the source-line example as
+  # `. /home/${USER}/work/.base/script/docker/_entrypoint_logging.sh`,
+  # which has two failure modes that broke every v0.30.0 adopter:
+  # (1) $USER is unset/empty in the Dockerfile test stage, crashing
+  # `set -u` entrypoints; (2) on multi-repo workspaces WS_PATH is the
+  # workspace parent, not the repo root, so .base/ is never at the
+  # documented path. Path A: COPY the helper into a stable in-image
+  # location so downstream entrypoints can source it unconditionally
+  # without $USER deref or path arithmetic. Refs #368.
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  run grep -F 'COPY --chmod=0755 .base/script/docker/_entrypoint_logging.sh /usr/local/lib/base/_entrypoint_logging.sh' "${_df}"
+  assert_success
+  # COPY must sit in devel stage (between `FROM ... AS devel` and the
+  # devel-test FROM line); a placement inside the commented runtime
+  # block is also documented but devel is the canonical site.
+  local _devel_line _test_line _copy_line
+  _devel_line="$(grep -nE '^FROM devel-base AS devel$' "${_df}" | head -1 | cut -d: -f1)"
+  _test_line="$(grep -nE '^FROM \$\{TEST_TOOLS_IMAGE\} AS test-tools-stage' "${_df}" | head -1 | cut -d: -f1)"
+  _copy_line="$(grep -nF 'COPY --chmod=0755 .base/script/docker/_entrypoint_logging.sh /usr/local/lib/base/_entrypoint_logging.sh' "${_df}" | head -1 | cut -d: -f1)"
+  [[ -n "${_devel_line}" && -n "${_test_line}" && -n "${_copy_line}" ]]
+  (( _devel_line < _copy_line ))
+  (( _copy_line < _test_line ))
+}
+
+@test "Dockerfile.example commented runtime stage shows _entrypoint_logging.sh COPY example (#368)" {
+  # The optional runtime stage starts from a fresh BASE_IMAGE, not
+  # FROM devel, so the helper is NOT inherited. Repos that ship a
+  # runtime image and want host-side log tee must opt in via a
+  # second COPY in the runtime stage. The commented-out scaffold
+  # documents it so downstream maintainers see the requirement at
+  # the moment they uncomment the runtime block.
+  local _df="/source/dockerfile/Dockerfile.example"
+  [[ -f "${_df}" ]] || skip "Dockerfile.example not present in /source"
+  # The example line must be commented (leading '# ') so it doesn't
+  # accidentally activate in repos that haven't enabled the runtime
+  # stage. Either inside the runtime-base/runtime block or the
+  # documentation block above it.
+  run grep -E '^# COPY --chmod=0755 \.base/script/docker/_entrypoint_logging\.sh /usr/local/lib/base/_entrypoint_logging\.sh' "${_df}"
+  assert_success
+}
+
+@test "_entrypoint_logging.sh header documents in-image source-line (no \$USER, no work/.base) (#368)" {
+  # The helper's own Usage block is the canonical reference downstream
+  # entrypoint authors copy from. Pre-#368 the example was
+  # `. /home/${USER}/work/.base/script/docker/_entrypoint_logging.sh`
+  # which only works on a single-repo workspace AND only at runtime
+  # AFTER the compose bind mount lands -- failing at build-time smoke
+  # and on multi-repo workspace layouts. Header must show the
+  # in-image path instead, with no $USER deref and no work/.base
+  # prefix.
+  local _h="/source/script/docker/_entrypoint_logging.sh"
+  # Positive: header documents the stable in-image path.
+  run grep -F '#   . /usr/local/lib/base/_entrypoint_logging.sh' "${_h}"
+  assert_success
+  # Negative regression guards: the broken pre-#368 patterns must not
+  # reappear anywhere in the helper file (header, comments, or code).
+  run grep -F '${USER}/work/.base/script/docker/_entrypoint_logging.sh' "${_h}"
+  assert_failure
+  run grep -F '/home/${USER}/work/.base' "${_h}"
+  assert_failure
+}
+
 @test "no inline _detect_lang fallbacks remain after dedupe (issue #104)" {
   # Lock in: only i18n.sh defines _detect_lang. build.sh / run.sh /
   # exec.sh / stop.sh / _lib.sh previously shipped their own copies,


### PR DESCRIPTION
## Summary

Path A fix for #368: `_entrypoint_logging.sh` is now COPY'd into every
downstream image at the stable in-image path
`/usr/local/lib/base/_entrypoint_logging.sh`. Downstream
`script/entrypoint.sh` can adopt the helper with a single un-guarded
line:

```bash
. /usr/local/lib/base/_entrypoint_logging.sh
```

The PR #356 example that read from the workspace bind mount
(`/home/${USER}/work/.base/script/docker/_entrypoint_logging.sh`) had
two failure modes that hit every v0.30.0 adopter:

1. **Build-time smoke crash** — `USER` is unset in the Dockerfile
   test stage (no login env). `set -u` entrypoints crashed with
   `USER: unbound variable` the moment they reached the source-line.
   ros1_bridge#107 already worked around this with a `${USER:-root}`
   + `if [[ -f ... ]]` guard pair; every other v0.30.0 adopter would
   have to repeat the workaround.
2. **Runtime no-op on multi-repo workspaces** — `setup.sh`'s `WS_PATH`
   detection picks the workspace parent (where multiple sibling Docker
   repos live), not the repo root. The bind mount
   `<WS_PATH>:/home/<user>/work` therefore places the repo's `.base/`
   at `/home/<user>/work/<repo>/.base/`, not the documented
   `/home/<user>/work/.base/`. The helper silently never ran and no
   host-side log file was produced — verified on ros1_bridge after
   PR #107 landed.

Both failure modes go away when the helper lives at a stable in-image
path. The source-line works at build-time, runtime, and across every
workspace layout with no `$USER` deref or path arithmetic.

## Changes

- `dockerfile/Dockerfile.example` — devel stage now COPYs
  `.base/script/docker/_entrypoint_logging.sh` to
  `/usr/local/lib/base/_entrypoint_logging.sh`. The commented-out
  runtime stage block carries a matching COPY example because runtime
  starts from a fresh `BASE_IMAGE` and does not inherit devel's helper.
- `script/docker/_entrypoint_logging.sh` — header Usage block now
  documents the in-image source-line and explains why the prior
  workspace-bind-mount path failed.
- `config/docker/setup.conf` — `[logging]` comment block points at
  the in-image path so the documented adoption surface matches the
  Dockerfile COPY destination.
- `doc/changelog/CHANGELOG.md` — `[Unreleased] ### Fixed` entry
  captures the full incident + ros1_bridge#107 follow-up note.
- `doc/test/TEST.md` — counts bumped (`1363 → 1368`, three spec
  sections updated, table rows added for the 5 new tests).

## Test plan

- [x] `make -f Makefile.ci test` — 1368/1368 green
- [x] 5 new tests cover the fix:
  - `template_spec.bats: Dockerfile.example copies _entrypoint_logging.sh to /usr/local/lib/base/ in devel stage (#368)`
  - `template_spec.bats: Dockerfile.example commented runtime stage shows _entrypoint_logging.sh COPY example (#368)`
  - `template_spec.bats: _entrypoint_logging.sh header documents in-image source-line (no $USER, no work/.base) (#368)`
  - `compose_logging_spec.bats: setup.conf [logging] comment block references in-image helper path (/usr/local/lib/base/, #368)`
  - `init_new_repo_spec.bats: new repo: Dockerfile contains _entrypoint_logging.sh in-image COPY (#368)`
- [ ] CI green on PR (Self Test + Behavioural + actionlint)
- [ ] Auto-merge once green
- [ ] After merge: ros1_bridge#107's `${USER:-root}` + file-existence
      guards can be simplified in a follow-up PR (out of scope here)
- [ ] After merge: 8 remaining v0.30.0 adopters get the fix via
      `/batch-template-upgrade v0.32.0` once stable is cut

## Cross-ref

- Closes #368
- Refs #356 (original `_entrypoint_logging.sh` ship — superseded
  by this fix on the source-line surface only; the helper itself is
  unchanged)
- Refs ros1_bridge#107 (first adopter; entrypoint guards can be
  dropped in a follow-up after this lands + fanout reaches the repo)
