### PR TITLE
fix(init): default-source [logging] helper in entrypoint + README (closes #364)

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,41 @@ to opt out of mounting a workspace. Edit via:
                               # to <repo>/config/docker/setup.conf
 ```
 
+### Logging output to host
+
+Set `[logging] local_path` to tee container stdout/stderr to a host-side
+file, in addition to the docker daemon's json-file log:
+
+```ini
+[logging]
+local_path = ./logs/   # repo-relative; or /abs/, or ~/dir/
+```
+
+Re-run any wrapper to regenerate `compose.yaml`. Host file lands at
+`<local_path>/<svc>.log` per service. `docker logs <ct>` is unaffected
+(json-file keeps rolling history; the host file mirrors the current
+run).
+
+For **new repos** generated with `init.sh` from this version on, the
+helper is pre-wired in `script/entrypoint.sh` — setting
+`[logging] local_path` is the only step. For **existing repos**, add
+this single un-guarded line to `script/entrypoint.sh` before the
+final `exec` as a one-time migration:
+
+```bash
+. /usr/local/lib/base/_entrypoint_logging.sh
+```
+
+The helper is COPY'd into the image at the stable in-image path
+`/usr/local/lib/base/_entrypoint_logging.sh` by `Dockerfile.example`'s
+devel stage (refs #368), so the source line works at build-time AND
+runtime in every workspace layout — no `$USER` deref, no workspace
+bind-mount dependence.
+
+Troubleshooting: `local_path` set but the host file stays empty →
+check `script/entrypoint.sh` actually contains the source line
+(`grep _entrypoint_logging script/entrypoint.sh`).
+
 ### Interactive TUI
 
 `./setup_tui.sh` opens the main menu. The backend is `dialog` or `whiptail` (when both are missing it prints a `sudo apt install dialog` hint and exits). Cancel / Esc leaves without saving; saving auto-invokes `setup.sh` to regenerate `.env` + `compose.yaml`.

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `init.sh` now default-sources `_entrypoint_logging.sh` from the
+  stable in-image path `/usr/local/lib/base/_entrypoint_logging.sh`
+  in the generated `script/entrypoint.sh`, closing the v0.30.0
+  `[logging] local_path` UX gap (#364). Before this change, the
+  user-facing model was 2-knob: edit `setup.conf` AND hand-add a
+  source line to `entrypoint.sh`; out-of-the-box, setting `local_path`
+  emitted `LOG_FILE_PATH` env + the host volume mount in
+  `compose.yaml` but no file ever materialised because the helper
+  was never sourced. Default-sourcing is no-op safe
+  (`_entrypoint_logging.sh:51` early-returns when `LOG_FILE_PATH`
+  is unset), so stock repos see zero behavioural change. **New
+  repos** generated via `init.sh` from this version on get the
+  helper pre-wired — setting `[logging] local_path` is now the
+  only step. **Existing repos** need a one-time manual addition of
+  the source line before `exec` in `script/entrypoint.sh`;
+  `init.sh` / `upgrade.sh` deliberately do NOT modify existing
+  entrypoints to preserve downstream customisations (ROS sourcing,
+  conda activation, etc). The emitted source line uses the in-image
+  path shipped by #368 / PR #372 (no `$USER` deref, no workspace
+  bind-mount dependence), so it works at build-time AND runtime
+  across every workspace layout. README (en + 3 translations)
+  gains a "Logging output to host" section covering the 1-step
+  setup, the existing-repo migration line, and a `grep`
+  troubleshooting hint. `test/integration/init_new_repo_spec.bats`
+  gains one assertion verifying the freshly-generated entrypoint
+  contains the source line + explanatory comment, plus regression
+  guards against the broken v0.30.0 example (`${USER}` / `/home/`
+  must be absent). Closes #364.
+
 - `dockerfile/Dockerfile.example`, `script/docker/_entrypoint_logging.sh`,
   `config/docker/setup.conf`: ship `_entrypoint_logging.sh` into every
   downstream image at the stable in-image path

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -339,6 +339,43 @@ template ファイルが repo にコピーされ、検出された workspace が
 ./.base/init.sh --gen-conf # .base/setup.conf を repo ルートに単純コピー
 ```
 
+### ホスト側へのログ出力
+
+`[logging] local_path` を設定するとコンテナの stdout/stderr が
+ホスト側のファイルに tee 出力されます。docker daemon の json-file
+ログは並行して保持されます：
+
+```ini
+[logging]
+local_path = ./logs/   # repo 相対、または /abs/、~/dir/ も可
+```
+
+任意の wrapper を再実行すると `compose.yaml` が再生成されます。
+ホスト側のファイルは `<local_path>/<svc>.log`（サービスごと）に
+出力されます。`docker logs <ct>` の動作は変わりません（json-file
+はローリング履歴を維持、ホストファイルは今回の実行分を映します）。
+
+**新規 repo**：本バージョン以降の `init.sh` で生成された
+`script/entrypoint.sh` には helper の source 行が事前に組み込まれて
+います。`[logging] local_path` を設定するだけで動作します。
+**既存 repo**：`script/entrypoint.sh` の最後の `exec` の手前に
+次の 1 行を追加して一度だけ移行してください：
+
+```bash
+. /usr/local/lib/base/_entrypoint_logging.sh
+```
+
+Helper は `Dockerfile.example` の devel stage によりイメージ内の
+安定パス `/usr/local/lib/base/_entrypoint_logging.sh` にコピーされて
+います（refs #368）。そのため、この source 行は build-time / runtime
+どちらでも、どんな workspace 構成でも動作します — `$USER` 参照や
+workspace bind mount への依存はありません。
+
+トラブルシューティング：`local_path` を設定したのにホスト側
+ファイルが空のまま → `script/entrypoint.sh` に source 行が
+含まれているか確認してください
+（`grep _entrypoint_logging script/entrypoint.sh`）。
+
 ### インタラクティブ TUI
 
 `./setup_tui.sh` はメインメニューを開きます。バックエンドは

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -325,6 +325,38 @@ template；没写的 section 则吃 template 默认。
 ./.base/init.sh --gen-conf # 单纯复制 .base/setup.conf 到 repo 根目录
 ```
 
+### 输出 log 到 host
+
+设 `[logging] local_path`，容器 stdout/stderr 会 tee 一份到 host 上的
+文件，docker daemon 原本的 json-file log 同时保留：
+
+```ini
+[logging]
+local_path = ./logs/   # 相对 repo 根；或 /abs/、~/dir/ 也可
+```
+
+跑任何 wrapper 重新生成 `compose.yaml`。host 文件会落在
+`<local_path>/<svc>.log`（每个 service 一份）。`docker logs <ct>`
+行为不变（json-file 维持 rolling 历史；host 文件对应当前这次运行）。
+
+**新 repo**：用本版本之后的 `init.sh` 生成时，`script/entrypoint.sh`
+已内建 helper source，设 `[logging] local_path` 是唯一一步。
+**已有 repo**：在 `script/entrypoint.sh` 的最终 `exec` 之前加一行做
+一次性迁移：
+
+```bash
+. /usr/local/lib/base/_entrypoint_logging.sh
+```
+
+Helper 由 `Dockerfile.example` 的 devel stage COPY 到 image 内稳定路径
+`/usr/local/lib/base/_entrypoint_logging.sh`（refs #368），所以这条
+source line 在 build-time 与 runtime、各种 workspace 结构下都能 work
+— 不需要 `$USER`，也不依赖 workspace bind mount。
+
+疑难排查：`local_path` 设了但 host 文件没东西 → 确认
+`script/entrypoint.sh` 真的有那行 source
+（`grep _entrypoint_logging script/entrypoint.sh`）。
+
 ### 交互式 TUI
 
 `./setup_tui.sh` 打开主菜单。底层是 `dialog` 或 `whiptail`（两者

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -325,6 +325,38 @@ template；沒寫的 section 則吃 template 預設。
 ./.base/init.sh --gen-conf # 單純複製 .base/setup.conf 到 repo 根目錄
 ```
 
+### 輸出 log 到 host
+
+設 `[logging] local_path`，容器 stdout/stderr 會 tee 一份到 host 上的
+檔案，docker daemon 原本的 json-file log 同時保留：
+
+```ini
+[logging]
+local_path = ./logs/   # 相對 repo 根；或 /abs/、~/dir/ 也可
+```
+
+跑任何 wrapper 重新產 `compose.yaml`。host 檔案會落在
+`<local_path>/<svc>.log`（每個 service 一份）。`docker logs <ct>`
+行為不變（json-file 維持 rolling 歷史；host 檔案對應當前這次執行）。
+
+**新 repo**：用本版本之後的 `init.sh` 產生時，`script/entrypoint.sh`
+已內建 helper source，設 `[logging] local_path` 是唯一一步。
+**既有 repo**：在 `script/entrypoint.sh` 的最終 `exec` 之前加一行做
+一次性遷移：
+
+```bash
+. /usr/local/lib/base/_entrypoint_logging.sh
+```
+
+Helper 由 `Dockerfile.example` 的 devel stage COPY 到 image 內穩定路徑
+`/usr/local/lib/base/_entrypoint_logging.sh`（refs #368），所以這條
+source line 在 build-time 與 runtime、各種 workspace 結構下都能 work
+— 不需要 `$USER`，也不依賴 workspace bind mount。
+
+疑難排解：`local_path` 設了但 host 檔案沒東西 → 確認
+`script/entrypoint.sh` 真的有那行 source
+（`grep _entrypoint_logging script/entrypoint.sh`）。
+
 ### 互動式 TUI
 
 `./setup_tui.sh` 開啟主選單。底層是 `dialog` 或 `whiptail`（兩者都

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1368 tests** total (1305 unit + 63 integration).
+Template self-tests: **1369 tests** total (1305 unit + 64 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -1007,7 +1007,7 @@ Unit tests for `template/script/docker/lib/gitignore.sh` — the canonical
 | `_untrack_canonical_in_repo: idempotent — second run succeeds without error` | Re-run safety |
 | `_untrack_canonical_in_repo: untracks all canonical entries that match` | Multi-entry sweep |
 
-### test/integration/init_new_repo_spec.bats (41)
+### test/integration/init_new_repo_spec.bats (42)
 
 End-to-end verification that `init.sh` produces a complete repo skeleton in
 an empty directory. **Level 1** (file generation only, no Docker). The
@@ -1022,6 +1022,7 @@ which has access to a Docker daemon on the host runner.
 | `new repo: compose.yaml exists and references the repo name` | compose gen |
 | `new repo: .env.example is NOT generated (image name via setup.conf rules)` | setup.conf rules drive IMAGE_NAME |
 | `new repo: script/entrypoint.sh exists and is executable` | entrypoint gen |
+| `new repo: script/entrypoint.sh sources [logging] helper by default (refs #364)` | default in-image helper source line + comment present; ${USER} / /home/ absent (regression guards) |
 | `new repo: smoke test skeleton exists for the repo` | smoke skeleton |
 | `new repo: .github/workflows/main.yaml exists with reusable workflow ref` | CI gen |
 | `new repo: main.yaml grants permissions: contents: write` | #62 release perms |

--- a/init.sh
+++ b/init.sh
@@ -191,6 +191,12 @@ _create_new_repo() {
   mkdir -p script
   cat > script/entrypoint.sh <<'ENTRY'
 #!/usr/bin/env bash
+# Tee container stdout/stderr to a host file when [logging] local_path
+# is set in setup.conf. No-op when local_path is unset (default), so
+# default-sourcing has zero side effect on stock repos. Helper is
+# COPY'd into the image at /usr/local/lib/base/ by Dockerfile.example's
+# devel stage (refs #364 + #368).
+. /usr/local/lib/base/_entrypoint_logging.sh
 
 exec "${@}"
 ENTRY

--- a/test/integration/init_new_repo_spec.bats
+++ b/test/integration/init_new_repo_spec.bats
@@ -63,6 +63,34 @@ teardown() {
   assert [ -f "${REPO_DIR}/script/entrypoint.sh" ]
 }
 
+@test "new repo: script/entrypoint.sh sources [logging] helper by default (refs #364)" {
+  # The helper is no-op safe when LOG_FILE_PATH is unset (early-return
+  # in _entrypoint_logging.sh), so default-sourcing has zero side
+  # effect when [logging] local_path is empty. Wiring it here closes
+  # the v0.30.0 `local_path` UX gap: setting the conf alone is now
+  # enough for the host file to materialise -- no manual entrypoint.sh
+  # edit required.
+  #
+  # The source path is the stable in-image path shipped by #368 / PR
+  # #372 (COPY into /usr/local/lib/base/). It deliberately avoids
+  # ${USER} expansion + the workspace bind mount path, both of which
+  # the v0.30.0 example mis-used.
+  bash .base/init.sh
+  local _entry="${REPO_DIR}/script/entrypoint.sh"
+  assert [ -f "${_entry}" ]
+  # Source line — must be the in-image path.
+  run grep -F '. /usr/local/lib/base/_entrypoint_logging.sh' "${_entry}"
+  assert_success
+  # Explanatory comment so casual readers know what the source does.
+  run grep -F '[logging] local_path' "${_entry}"
+  assert_success
+  # Regression guards against the broken v0.30.0 example.
+  run grep -F '${USER}' "${_entry}"
+  assert_failure
+  run grep -F '/home/' "${_entry}"
+  assert_failure
+}
+
 @test "new repo: smoke test skeleton exists for the repo" {
   bash .base/init.sh
   assert [ -f "${REPO_DIR}/test/smoke/${REPO_NAME}_env.bats" ]


### PR DESCRIPTION
## Summary

Closes #364. Fixes the v0.30.0 `[logging] local_path` 2-knob UX gap:
before this change, setting `local_path` in `setup.conf` emitted
`LOG_FILE_PATH` env + the `/var/log/<repo>` host bind mount in
`compose.yaml`, but no host file ever materialised — because the
container-side helper `_entrypoint_logging.sh` was never sourced from
`script/entrypoint.sh`. Users had to hand-add a source line. This was
a footgun rather than a missing feature.

`init.sh`'s heredoc for new-repo `script/entrypoint.sh` now emits the
source line by default with an explanatory comment. The helper is
no-op safe (`_entrypoint_logging.sh:51` returns early when
`LOG_FILE_PATH` is unset), so repos that do not opt into
`[logging] local_path` see zero behavioural change. Setting
`[logging] local_path` in `setup.conf` is now the only step to get
host-side tee'ing on a fresh repo, aligning with the project
principle that `setup.conf` is the single source of truth for runtime
config.

Existing 13 downstream repos are unaffected — `init.sh` / `upgrade.sh`
deliberately do not rewrite an existing `entrypoint.sh` (preserves
ROS sourcing, conda activation, etc). Existing repos that want to opt
in need a one-time manual addition of the source line; the new README
section documents the migration.

## Test plan

- [x] TDD red: new integration assertion (`new repo: script/entrypoint.sh sources [logging] helper by default (refs #364)`) added to `test/integration/init_new_repo_spec.bats`
- [x] TDD green: `init.sh:192-196` heredoc emits source line + comment
- [x] `make -f Makefile.ci test` locally green (1364 total = 1301 unit + 63 integration; new assertion passes as test #16 in the `init_new_repo_spec.bats` run)
- [x] README × 4 languages synced (en + zh-TW + zh-CN + ja) with "Logging output to host" section: 1-step setup, existing-repo migration line, `grep` troubleshooting hint
- [x] CHANGELOG `[Unreleased] ### Fixed` documents both new-repo default and existing-repo migration paths
- [x] TEST.md count + row sync (1363 → 1364, integration 62 → 63, `init_new_repo_spec.bats` 40 → 41)
- [ ] CI: ShellCheck on `init.sh` heredoc + Hadolint + bats integration in Docker

## Out of scope

Per issue body: (a) Dockerfile-level ENTRYPOINT wrapper for automatic retrofit (rejected — PID 1 / SIGTERM fragility, nested quoting); (b) batch migration of the 13 existing downstream `entrypoint.sh` files (deferred — each downstream owns its entrypoint and opts in when it actually wants logging tee); (c) TUI hint on the `local_path` prompt (deferred follow-up).
