### PR TITLE
fix(setup): emit per-service LOG_FILE_PATH on extends:devel stages (#367)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `script/docker/setup.sh`: emit per-stage `LOG_FILE_PATH` env var
+  and `[logging] local_path` volume mount on extends-based compose
+  services (the zero-diff `extends: service: devel` branch from
+  #215, used by auto-emitted Dockerfile stages like `builder` /
+  `runtime` / `test-tools-stage`). Closes #367. The v0.30.0 emit
+  was three-point (devel inline / standalone auto-emitted stages
+  with overrides / test); the zero-diff extends path was missing,
+  so compose's `extends` merge inherited devel's
+  `LOG_FILE_PATH=/var/log/<repo>/devel.log` into every extending
+  service. `./run.sh -d runtime` ended up tee'ing the runtime
+  container's stdout to `logs/devel.log` instead of
+  `logs/runtime.log`. Result: per-service file naming
+  (`runtime.log`, `builder.log`, ...) silently never materialised;
+  users running multiple services concurrently got interleaved
+  content in `logs/devel.log`. Fix is Option A from #367: every
+  service block now emits its own `LOG_FILE_PATH` +
+  `<resolved>:/var/log/<repo>` volume mount uniformly when
+  `local_path` is set, regardless of whether the service uses
+  `extends`. compose's `environment:` list merge concatenates entries
+  and last-wins resolution at runtime picks the override; the
+  duplicate volume mount string against the inherited one is
+  harmless because compose dedups identical bind strings.
+  Back-compat: when `local_path` is unset the zero-diff emit stays
+  byte-for-byte identical to pre-#367, so repos that haven't opted
+  into `[logging] local_path` see zero change. 3 new tests in
+  `compose_logging_spec.bats` (extending stage LOG_FILE_PATH emit,
+  volume mount emit, and back-compat no-emit when local_path
+  unset).
+
 - `init.sh` now default-sources `_entrypoint_logging.sh` from the
   stable in-image path `/usr/local/lib/base/_entrypoint_logging.sh`
   in the generated `script/entrypoint.sh`, closing the v0.30.0

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1369 tests** total (1305 unit + 64 integration).
+Template self-tests: **1372 tests** total (1308 unit + 64 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -581,7 +581,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `environment env_N supports multiple cross-references in one value (refs #236)` | multi-ref |
 | `environment env_N transitive cross-reference resolves through chain (refs #236)` | transitive |
 
-### test/unit/compose_logging_spec.bats (26)
+### test/unit/compose_logging_spec.bats (29)
 
 Covers `[logging]` + `[logging.<svc>]` support in
 `generate_compose_yaml` (#310). Tests the global emission on every
@@ -618,6 +618,9 @@ behaviour, and the two new setup.sh helpers `_parse_logging_svc_sections`
 | `_sync_logging_local_paths_gitignore collects from both global + per-svc (#328)` | Multi-source |
 | `_sync_logging_local_paths_gitignore is no-op when no local_path keys (#328)` | Empty no-op |
 | `setup.conf [logging] comment block references in-image helper path (/usr/local/lib/base/, #368)` | Documented adoption path matches in-image COPY |
+| `generate_compose_yaml emits per-stage LOG_FILE_PATH on extends:devel stage when [logging] local_path is set (#367)` | Per-svc LOG_FILE_PATH on auto-emitted extends-only stage |
+| `generate_compose_yaml emits per-stage volume mount on extends:devel stage when [logging] local_path is set (#367)` | Per-svc volume mount on auto-emitted extends-only stage |
+| `generate_compose_yaml does NOT emit LOG_FILE_PATH on extends:devel stage when [logging] local_path is unset (#367 back-compat)` | Zero-diff back-compat when feature unset |
 
 ### test/unit/entrypoint_logging_spec.bats (6)
 

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -2063,11 +2063,28 @@ YAML
     profiles:
       - ${_emit_stage}
 YAML
-        # Per-stage [logging.<stage>] override (if any). Without an
-        # override compose `extends: devel` already covers logging:
-        # compose extends merges mapping sub-keys so devel's logging
-        # block carries over — emit only when the stage actually
-        # diverges from devel.
+        # #328 / #367: per-stage LOG_FILE_PATH + volume mount when
+        # [logging] / [logging.<stage>] local_path is set. compose's
+        # `extends` merge inherits devel's `environment:` and
+        # `volumes:` lists, then concatenates the child's entries on
+        # top -- last-wins resolution at runtime means the per-stage
+        # override here takes effect. Volume mount is duplicated
+        # against devel's inherited mount but compose dedups
+        # identical bind strings (#367 Option A: emit uniformly on
+        # every service block, no extends-relationship detection).
+        local _stage_llp=""
+        _logging_svc_local_path_mount "${_emit_stage}" _stage_llp
+        if [[ -n "${_stage_llp}" ]]; then
+          echo "    environment:"
+          echo "      - LOG_FILE_PATH=/var/log/${_name}/${_emit_stage}.log"
+          echo "    volumes:"
+          echo "      - ${_stage_llp}"
+        fi
+        # Per-stage [logging.<stage>] driver / rotation override
+        # (if any). Without an override compose `extends: devel`
+        # already covers logging:: compose extends merges mapping
+        # sub-keys so devel's logging block carries over -- emit
+        # only when the stage actually diverges from devel.
         if [[ -n "${_logging_per_svc_str}" ]] && \
            grep -qE "^${_emit_stage}:" <<< "${_logging_per_svc_str}"; then
           _emit_logging_block "${_emit_stage}"

--- a/test/unit/compose_logging_spec.bats
+++ b/test/unit/compose_logging_spec.bats
@@ -403,3 +403,99 @@ CONF
   run grep -F '.base/script/docker/_entrypoint_logging.sh' "${_conf}"
   assert_failure
 }
+
+# ════════════════════════════════════════════════════════════════════
+# generate_compose_yaml: per-stage LOG_FILE_PATH on extends:devel
+# stages (#367)
+# ════════════════════════════════════════════════════════════════════
+
+@test "generate_compose_yaml emits per-stage LOG_FILE_PATH on extends:devel stage when [logging] local_path is set (#367)" {
+  # Without this fix, the zero-diff `extends: service: devel` branch
+  # (the minimal-shape emit for stages with no [stage:<name>] override,
+  # #215) only emits build / image / container_name / profiles. The
+  # extends merge then inherits devel's LOG_FILE_PATH=devel.log into
+  # every extending service, so `./run.sh -d runtime` ends up tee'ing
+  # the runtime container's stdout to logs/devel.log -- breaking the
+  # "one file per service" guarantee the original PR #356 framing
+  # promised. Fix is Option A: emit per-service LOG_FILE_PATH +
+  # volume mount uniformly on every service block; compose's extends
+  # merge concatenates environment arrays and last-wins resolution at
+  # runtime picks the override.
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM ubuntu:24.04 AS sys
+FROM sys AS devel
+FROM devel AS runtime
+EOF
+  local _extras=()
+  local _global
+  printf -v _global '%s\n%s' "driver=json-file" "local_path=./logs/"
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "" "" "" "" "" "" "" "" "" "${_global}" ""
+  # The runtime block must carry its OWN LOG_FILE_PATH override line
+  # alongside the inherited devel.log; runtime.log filename is unique
+  # to the runtime service so a single grep proves the override emit.
+  run grep -F 'LOG_FILE_PATH=/var/log/myrepo/runtime.log' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "generate_compose_yaml emits per-stage volume mount on extends:devel stage when [logging] local_path is set (#367)" {
+  # The host bind mount `<resolved>:/var/log/<repo>` must appear in
+  # the runtime block too so the per-service LOG_FILE_PATH path is
+  # writable from inside the extending container. compose's extends
+  # merge already inherits devel's mount string, but emitting it on
+  # the child block as well is harmless (compose dedups identical
+  # mount strings) and keeps the emit logic uniform across all
+  # services.
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM ubuntu:24.04 AS sys
+FROM sys AS devel
+FROM devel AS runtime
+EOF
+  local _extras=()
+  local _global
+  printf -v _global '%s\n%s' "driver=json-file" "local_path=./logs/"
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "" "" "" "" "" "" "" "" "" "${_global}" ""
+  # The bind mount string ends with `:/var/log/myrepo`. Expect at
+  # least 3 emits in compose.yaml: devel + test + runtime (the
+  # runtime emit is the regression guard -- pre-#367 only devel +
+  # test had it). The exact host-path prefix depends on _setup_base
+  # resolution of `./logs/` so anchor on the in-container target.
+  local _occurrences
+  _occurrences="$(grep -cF ':/var/log/myrepo' "${COMPOSE_OUT}" || true)"
+  (( _occurrences >= 3 )) || {
+    echo "expected >=3 :/var/log/myrepo mount strings, found ${_occurrences}"
+    echo "--- compose.yaml emitted ---"
+    cat "${COMPOSE_OUT}"
+    echo "--- /dump ---"
+    return 1
+  }
+}
+
+@test "generate_compose_yaml does NOT emit LOG_FILE_PATH on extends:devel stage when [logging] local_path is unset (#367 back-compat)" {
+  # Back-compat: stages with no overrides AND no local_path stay on
+  # the byte-for-byte pre-#220 minimal-shape emit. Specifically the
+  # runtime block must NOT acquire an environment / volumes line --
+  # the original v0.30.0 zero-diff promise must hold.
+  cat > "${TEMP_DIR}/Dockerfile" <<'EOF'
+FROM ubuntu:24.04 AS sys
+FROM sys AS devel
+FROM devel AS runtime
+EOF
+  local _extras=()
+  # No [logging] global_str at all; local_path unset entirely.
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "" "" "" "" "" "" "" "" "" "" ""
+  # Slice the runtime block: from `^  runtime:$` to the next top-level
+  # service header (`^  [a-z][a-z0-9_-]*:$`) and assert neither
+  # environment: nor volumes: appears inside it.
+  run awk '/^  runtime:$/{flag=1; next} /^  [a-z]/{flag=0} flag' \
+    "${COMPOSE_OUT}"
+  assert_success
+  refute_output --partial 'LOG_FILE_PATH'
+  refute_output --regexp '^    volumes:$'
+  refute_output --regexp '^    environment:$'
+}


### PR DESCRIPTION
## Summary

Option A fix for #367: every compose service block now emits its own
`LOG_FILE_PATH` env var and `[logging] local_path` volume mount when
`local_path` is set, regardless of whether the service uses
`extends: service: devel`.

Before #367, the v0.30.0 emit was three-point (devel inline /
standalone auto-emitted stages with overrides / test); the zero-diff
`extends: service: devel` branch (the minimal-shape emit for stages
without `[stage:<name>]` overrides, #215) was missing. compose's
`extends` merge then inherited devel's
`LOG_FILE_PATH=/var/log/<repo>/devel.log` into every extending
service, so `./run.sh -d runtime` tee'd the runtime container's
stdout to `logs/devel.log` instead of `logs/runtime.log`.

Result on every v0.30.0 adopter that uses `extends` for non-devel
stages (the standard pattern: `builder` / `runtime` /
`test-tools-stage`): per-service file naming
(`runtime.log`, `builder.log`, ...) silently never materialised;
users running multiple services concurrently saw interleaved
content in `logs/devel.log`. The feature worked at the daemon
level (`docker logs <c>` was preserved), but the user-facing
"one file per service" guarantee that PR #356 originally framed
was broken.

## Mechanism

compose's `environment:` list merge under `extends`:
- Concatenates entries from parent and child
- Last value of a key wins at variable-resolution time

So emitting `LOG_FILE_PATH=runtime.log` on the runtime child block
places it AFTER the inherited `LOG_FILE_PATH=devel.log`, and the
runtime container sees the runtime.log value.

For `volumes:`, the inherited mount string and the child's emit
are byte-identical (`<resolved>:/var/log/<repo>`); compose dedups
identical bind strings so the duplicate is harmless.

## Changes

- `script/docker/setup.sh` — in the zero-diff `extends: service: devel`
  branch, after the `profiles:` block, emit `LOG_FILE_PATH=<svc>.log`
  + the bind mount when `_logging_svc_local_path_mount` resolves a
  non-empty path for the stage. Gated on the same condition as
  every other LOG_FILE_PATH emit site, so back-compat holds.
- `doc/changelog/CHANGELOG.md` — `[Unreleased] ### Fixed` entry.
- `doc/test/TEST.md` — count bump (`1363 → 1366`), section count
  bump, 3 new rows.
- `test/unit/compose_logging_spec.bats` — 3 new tests.

## Test plan

- [x] `make -f Makefile.ci test` — 1366/1366 green
- [x] 3 new tests:
  - `generate_compose_yaml emits per-stage LOG_FILE_PATH on extends:devel stage when [logging] local_path is set (#367)`
  - `generate_compose_yaml emits per-stage volume mount on extends:devel stage when [logging] local_path is set (#367)`
  - `generate_compose_yaml does NOT emit LOG_FILE_PATH on extends:devel stage when [logging] local_path is unset (#367 back-compat)`
- [ ] CI green on PR (Self Test + Behavioural + actionlint)
- [ ] Auto-merge once green

## Back-compat

When `local_path` is unset the zero-diff emit stays byte-for-byte
identical to pre-#367; repos that haven't opted into
`[logging] local_path` see zero change. ros1_bridge#107 (the first
v0.30.0 adopter) and the 8 remaining v0.30.0 adopters all pick up
the fix transparently on `make upgrade VERSION=v0.32.0` once the
stable tag is cut.

## Cross-ref

- Closes #367
- Refs #356 (original `local_path` feature; three-point emit had a
  gap in the zero-diff extends path)
- Refs #328 (umbrella issue for `local_path`)
- Stacks on top of #368 (in-image helper path) — both fixes land
  before v0.32.0 stable so the feature is end-to-end usable by
  every v0.30.0 adopter after the `/batch-template-upgrade v0.32.0`
  fanout.
