### PR TITLE
ci(self-test): add ci-rollup aggregator (#337)

### DIFF
--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -381,6 +381,46 @@ jobs:
           TEST_TOOLS_IMAGE: test-tools:local
         run: docker compose run --rm ci-behavioural
 
+  ci-rollup:
+    # Single aggregator required by branch protection. Sub-jobs (#376
+    # shellcheck/hadolint, #377 bats-unit/bats-integration, …) can join
+    # this `needs:` list without further branch-protection churn —
+    # the only required check stays `ci-rollup`. Pattern mirrors
+    # ros1_bridge's `ci-summary` and env/* `ci-passed`.
+    #
+    # Hard-mandatory jobs (actionlint / classify / test) must succeed:
+    # SKIPPED there indicates a workflow bug, not an intentional gate.
+    # Conditionally-gated jobs (integration-e2e / behavioural) carry
+    # job-level `if:` so they SKIP on doc-only / non-behavioural PRs
+    # (#317 P1/P3); the rollup must collapse SKIPPED into pass for those
+    # two, otherwise doc-only PRs cannot merge.
+    needs: [actionlint, classify, test, integration-e2e, behavioural]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify upstream jobs
+        env:
+          ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
+          CLASSIFY_RESULT: ${{ needs.classify.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          INTEGRATION_RESULT: ${{ needs.integration-e2e.result }}
+          BEHAVIOURAL_RESULT: ${{ needs.behavioural.result }}
+        run: |
+          set -euo pipefail
+          echo "actionlint:      ${ACTIONLINT_RESULT}"
+          echo "classify:        ${CLASSIFY_RESULT}"
+          echo "test:            ${TEST_RESULT}"
+          echo "integration-e2e: ${INTEGRATION_RESULT}"
+          echo "behavioural:     ${BEHAVIOURAL_RESULT}"
+          fail=0
+          for r in "${ACTIONLINT_RESULT}" "${CLASSIFY_RESULT}" "${TEST_RESULT}"; do
+            [[ "${r}" == "success" ]] || fail=1
+          done
+          for r in "${INTEGRATION_RESULT}" "${BEHAVIOURAL_RESULT}"; do
+            [[ "${r}" == "success" || "${r}" == "skipped" ]] || fail=1
+          done
+          exit "${fail}"
+
   release:
     needs: [test, integration-e2e, behavioural]
     if: startsWith(github.ref, 'refs/tags/')

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ci-rollup` aggregator job in `self-test.yaml`** (#337). A single
+  always-running job sits downstream of `[actionlint, classify, test,
+  integration-e2e, behavioural]` and collapses their results into one
+  pass/fail signal. `actionlint` / `classify` / `test` must succeed;
+  `integration-e2e` / `behavioural` are allowed to be SKIPPED (their
+  job-level `if:` gates fire on doc-only / non-behavioural PRs per
+  #317 P1/P3). Enables follow-up sub-jobs (#376 shellcheck / hadolint,
+  #377 bats-unit / bats-integration / coverage) to join the rollup's
+  `needs:` list without further branch-protection churn. **Branch
+  protection switch from `test` → `ci-rollup` happens in a separate
+  step after this PR merges**; the workflow change here is forwards-
+  compatible with both states (both checks pass on a green PR).
+
 ## [v0.32.0] - 2026-05-15
 
 Stable v0.32.0 minor feature release, promoting v0.32.0-rc1 (#371)

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1372 tests** total (1308 unit + 64 integration).
+Template self-tests: **1378 tests** total (1314 unit + 64 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -219,10 +219,10 @@ on doc-only PRs).
 | #272 GHA buildx cache: `cache_variant` input declared with empty default, `Compute cache scope` step emits `id: cache` + scope key into `GITHUB_OUTPUT`, 4 build steps set `cache-from: type=gha,scope=...`, 4 build steps set `cache-to: ...,mode=max`, default preserves zero-diff for single-call callers | 5 |
 | #273 doc-only PR fast-pass (Phase 1 + Phase 2 shell rewrite): `path-filter` job declared, classifier is pure shell (`git diff --name-only base...head` + `case` glob; no `dorny/paths-filter` dependency), reads EVENT_NAME / BASE_SHA / HEAD_SHA from env: keys so the case body stays portable, non-PR event short-circuits before git diff (BASE_SHA / HEAD_SHA empty on push / tag / workflow_dispatch), 6-path allowlist (`**/*.md`, `doc/**`, `LICENSE`, `.gitignore`, `.github/CODEOWNERS`, `.github/dependabot.yml`) in a single `case` arm, `compute-matrix` + `build` jobs gated on `code_changed == 'true'` (2 occurrences), `docker-build` aggregator handles `code_changed == 'false'` short-circuit + `needs: [path-filter, build]`, non-PR triggers always set `code_changed=true` | 8 |
 
-### test/unit/self_test_yaml_spec.bats (26)
+### test/unit/self_test_yaml_spec.bats (32)
 
 Structural assertions for `.github/workflows/self-test.yaml`. Locks
-five cumulative invariants:
+six cumulative invariants:
 
 1. **#305 actionlint gate** — `actionlint` job declared, runs
    `rhysd/actionlint` via Docker pinned to an explicit version
@@ -285,6 +285,19 @@ five cumulative invariants:
    compose service exercises end-to-end, so they must invalidate
    the behavioural-skip optimization.
 
+6. **#337 `ci-rollup` aggregator** — a single always-running
+   (`if: always()`) `ci-rollup` job sits downstream of
+   `[actionlint, classify, test, integration-e2e, behavioural]`
+   and collapses their results into one pass/fail signal that
+   branch protection can require. The verifier shell step consumes
+   every `${{ needs.<job>.result }}` and applies a 2-tier rule:
+   `actionlint` / `classify` / `test` must be `success`;
+   `integration-e2e` / `behavioural` may be `success` or `skipped`
+   (their job-level `if:` legitimately skips on doc-only / non-
+   behavioural PRs per #317 P1/P3). Adding sub-jobs (#376, #377)
+   to the rollup's `needs:` list becomes a workflow-internal
+   change with no branch-protection update required.
+
 | Category | Tests |
 |----------|-------|
 | `actionlint` job declared | 1 |
@@ -301,6 +314,8 @@ five cumulative invariants:
 | `behavioural` Obtain step with 3-layer fallback (#317 P2) | 1 |
 | Obtain steps pre-fetch base ref (4 occurrences: classify + 3 jobs, #317 P2 reuses P1 gotcha-2 fix) | 1 |
 | `classify` behavioural block-list extends to `setup.sh` + `i18n.sh` + `lib/**` + `prune.sh` (#317 P3 gotcha-5) | 1 |
+| `ci-rollup` declared + `needs: [actionlint, classify, test, integration-e2e, behavioural]` + `if: always()` (#337) | 3 |
+| `ci-rollup` verify step consumes every `needs.<job>.result` + SKIPPED treated as pass for `integration-e2e`/`behavioural` + `success` required for hard-mandatory jobs (#337) | 3 |
 
 ### test/unit/release_test_tools_yaml_spec.bats (10)
 

--- a/test/unit/self_test_yaml_spec.bats
+++ b/test/unit/self_test_yaml_spec.bats
@@ -3,7 +3,7 @@
 # self_test_yaml_spec.bats — structural assertions for the
 # `.github/workflows/self-test.yaml` workflow.
 #
-# Locks two cumulative invariants:
+# Locks three cumulative invariants:
 #
 # 1. #305 actionlint gate (original): an `actionlint` job runs
 #    rhysd/actionlint via Docker against the workflows tree, and the
@@ -18,6 +18,14 @@
 #    SUCCESS on doc-only PRs; `integration-e2e` + `behavioural` gate
 #    via job-level `if:`. All three test-tools image builds use
 #    docker/build-push-action with shared `scope=test-tools` GHA cache.
+#
+# 3. #337 ci-rollup aggregator: a single `ci-rollup` job aggregates
+#    [actionlint, classify, test, integration-e2e, behavioural] under
+#    `if: always()`, treating SKIPPED as pass-equivalent for the two
+#    conditionally-gated jobs (integration-e2e + behavioural). Branch
+#    protection requires only `ci-rollup`, so sub-jobs (#376
+#    shellcheck/hadolint, #377 bats-unit/bats-integration) can join
+#    its `needs:` without further branch-protection churn.
 
 bats_require_minimum_version 1.5.0
 
@@ -258,4 +266,64 @@ setup() {
   run grep -c 'git fetch origin' "${WF}"
   assert_success
   assert_output '4'
+}
+
+# ── ci-rollup aggregator (#337) ───────────────────────────────────────
+
+@test "self-test.yaml: declares ci-rollup job (#337)" {
+  run grep -E '^  ci-rollup:' "${WF}"
+  assert_success
+}
+
+@test "self-test.yaml: ci-rollup needs all sibling jobs that branch protection used to require (#337)" {
+  # The aggregator must wait on actionlint + classify + test +
+  # integration-e2e + behavioural so its result reflects every PR
+  # check. New sub-jobs (#376 shellcheck/hadolint, #377 bats-*) join
+  # this list later.
+  run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'needs: [actionlint, classify, test, integration-e2e, behavioural]'
+}
+
+@test "self-test.yaml: ci-rollup runs unconditionally via if: always() (#337)" {
+  # Without `if: always()` the rollup would skip when any upstream
+  # need failed, masking the failure as SKIPPED — branch protection
+  # treats SKIPPED as missing, so the merge gate would lift falsely.
+  run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'if: always()'
+}
+
+@test "self-test.yaml: ci-rollup verify step consumes every needs result (#337)" {
+  # The shell verifier must inspect each upstream's ${{ needs.<job>.result }}
+  # to translate the parallel job graph into a single pass/fail signal.
+  run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'needs.actionlint.result'
+  assert_output --partial 'needs.classify.result'
+  assert_output --partial 'needs.test.result'
+  assert_output --partial 'needs.integration-e2e.result'
+  assert_output --partial 'needs.behavioural.result'
+}
+
+@test "self-test.yaml: ci-rollup treats SKIPPED as pass for conditionally-gated jobs (#337)" {
+  # integration-e2e + behavioural carry job-level `if:` gates that skip
+  # on doc-only / non-behavioural PRs (#317 P1/P3). The rollup must not
+  # fail those skips, otherwise doc-only PRs cannot merge — SKIPPED is
+  # only treated as missing by branch protection at the JOB level, but
+  # ci-rollup is itself a single SUCCESS step so it must collapse
+  # SKIPPED upstream into pass.
+  run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'skipped'
+}
+
+@test "self-test.yaml: ci-rollup requires hard-mandatory jobs to be success (#337)" {
+  # actionlint / classify / test always run — SKIPPED there indicates
+  # a workflow bug, not an intentional gate. Hard-fail those.
+  # Verified indirectly by asserting the success comparison appears in
+  # the rollup's shell step.
+  run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'success'
 }


### PR DESCRIPTION
## Summary

Adds a `ci-rollup` aggregator job to `.github/workflows/self-test.yaml`
that sits downstream of `[actionlint, classify, test, integration-e2e,
behavioural]` and collapses their results into a single pass/fail
signal that branch protection can require.

This unblocks **#376** (split shellcheck/hadolint into parallel jobs)
and **#377** (split bats unit/integration + move kcov to coverage job)
— both have a `ci-rollup` prerequisite per their respective issue
bodies. Once this lands and branch protection switches from `test` →
`ci-rollup`, future sub-jobs can join the rollup's `needs:` list
without admin-level branch-protection churn.

Pattern mirrors `app/ros1_bridge`'s `ci-summary` and
`env/{ros_distro,ros2_distro}`'s `ci-passed` aggregators per CLAUDE.md's
status-check table.

## Why "SKIPPED == pass" for the two conditional jobs

`integration-e2e` and `behavioural` carry job-level `if:` gates from
#317 P1/P3 — they SKIP on doc-only / non-behavioural PRs. The rollup
verifier's two-tier rule keeps them merge-able:

- Hard-mandatory: `actionlint` / `classify` / `test` MUST be `success`.
  These always run; SKIPPED indicates a workflow bug.
- Soft: `integration-e2e` / `behavioural` may be `success` OR `skipped`.
  Their job-level gates fire legitimately on certain PR shapes.

## Forwards compatibility

Both the existing required check (`test`) and the new `ci-rollup` will
report pass on a green PR, so this PR can merge under the current
`required_status_checks.contexts: ["test"]` and the protection switch
is a separate post-merge admin step.

## Follow-up admin steps (after merge)

1. Flip branch protection: `required_status_checks.contexts` from
   `["test"]` → `["ci-rollup"]` (one `gh api ... -X PATCH` call).
2. Update `wait-pr-ci` skill filter table + CLAUDE.md status-check
   table in `docker_harness` to reflect the new required check name
   (template + multi_run row: `test` → `ci-rollup`).

These two are deliberately out of this PR's scope so the workflow
change can be reviewed independently of the protection / doc edits.

## Tests

6 new structural assertions in `test/unit/self_test_yaml_spec.bats`
lock the new job's shape (26 → 32 cases):

- `ci-rollup` job declared
- `needs:` covers all 5 sibling jobs
- `if: always()` set
- Verifier consumes every `needs.<job>.result`
- SKIPPED treated as pass for `integration-e2e` / `behavioural`
- `success` required for hard-mandatory jobs

Full suite: 1314 unit + 64 integration = 1378 tests green
(`make -f Makefile.ci test`).

`doc/test/TEST.md` and `doc/changelog/CHANGELOG.md` updated.

## Test plan

- [ ] CI: `actionlint` job passes (new yaml block is syntactically valid)
- [ ] CI: existing `test` job still passes (forwards compatibility)
- [ ] CI: new `ci-rollup` job passes (rollup collapses to success)
- [ ] CI: `integration-e2e` + `behavioural` still gate via job-level `if:`
- [ ] Post-merge: flip branch protection + open follow-up doc PR

Refs #337.
