### PR TITLE
ci(self-test): split shellcheck + hadolint into parallel jobs (#376)

### DIFF
--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -116,18 +116,62 @@ jobs:
             echo "behavioural_relevant=true" >> "${GITHUB_OUTPUT}"
           fi
 
+  shellcheck:
+    # Dedicated ShellCheck job (#376). Runs on plain ubuntu-latest where
+    # shellcheck is pre-installed, no buildx / test-tools image needed.
+    # A 30s shellcheck regression now surfaces in ~45s wall time instead
+    # of waiting for the full bats suite inside the `test` job. The
+    # `test` job passes --bats-only so the shellcheck phase doesn't run
+    # twice; local `make test` keeps the full pipeline.
+    needs: [actionlint, classify]
+    if: needs.classify.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run ShellCheck
+        run: ./script/ci/ci.sh --shellcheck-only
+
+  hadolint:
+    # Dedicated Hadolint job (#376). Statically lints the two
+    # template-owned Dockerfiles. Hadolint historically only ran in
+    # downstream repos' Dockerfile `test` stages during their own
+    # builds; this job adds a lint pass for template's own
+    # Dockerfile.example + Dockerfile.test-tools so a regression to
+    # either surfaces here before downstream CI fans out.
+    needs: [actionlint, classify]
+    if: needs.classify.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Hadolint — Dockerfile.example
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: dockerfile/Dockerfile.example
+          config: .hadolint.yaml
+
+      - name: Hadolint — Dockerfile.test-tools
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: dockerfile/Dockerfile.test-tools
+          config: .hadolint.yaml
+
   test:
     needs: [actionlint, classify]
     runs-on: ubuntu-latest
     steps:
-      # Doc-only short-circuit: `test` is the only branch-protection-required
-      # status check on `main`, so we must always REPORT a SUCCESS result.
-      # `skipped` is NOT `success` for required checks. The pattern is: keep
-      # the job in the graph, branch internally, exit 0 on doc-only PRs.
+      # Doc-only short-circuit: kept so the `test` job always REPORTS a
+      # SUCCESS result on doc-only PRs (the rollup expects `test ==
+      # success`; SKIPPED would be treated as a workflow bug). Post-#376
+      # ShellCheck moved to its own job; this job now runs Bats only via
+      # `ci.sh --bats-only`.
       - name: Doc-only short-circuit
         if: needs.classify.outputs.code_changed == 'false'
         run: |
-          echo "Doc-only PR — bats / shellcheck / kcov skipped; reporting SUCCESS for branch protection."
+          echo "Doc-only PR — bats / kcov skipped; reporting SUCCESS for branch protection."
 
       - name: Checkout
         if: needs.classify.outputs.code_changed == 'true'
@@ -185,11 +229,11 @@ jobs:
           cache-from: type=gha,scope=test-tools
           cache-to: type=gha,scope=test-tools,mode=max
 
-      - name: Run CI (ShellCheck + Bats + Kcov)
+      - name: Run CI (Bats; ShellCheck moved to dedicated parallel job, #376)
         if: needs.classify.outputs.code_changed == 'true'
         env:
           TEST_TOOLS_IMAGE: test-tools:local
-        run: ./script/ci/ci.sh
+        run: ./script/ci/ci.sh --bats-only
 
       - name: Upload coverage to Codecov
         if: ${{ needs.classify.outputs.code_changed == 'true' && always() }}
@@ -383,18 +427,18 @@ jobs:
 
   ci-rollup:
     # Single aggregator required by branch protection. Sub-jobs (#376
-    # shellcheck/hadolint, #377 bats-unit/bats-integration, …) can join
+    # shellcheck/hadolint, #377 bats-unit/bats-integration, …) join
     # this `needs:` list without further branch-protection churn —
     # the only required check stays `ci-rollup`. Pattern mirrors
     # ros1_bridge's `ci-summary` and env/* `ci-passed`.
     #
     # Hard-mandatory jobs (actionlint / classify / test) must succeed:
     # SKIPPED there indicates a workflow bug, not an intentional gate.
-    # Conditionally-gated jobs (integration-e2e / behavioural) carry
-    # job-level `if:` so they SKIP on doc-only / non-behavioural PRs
-    # (#317 P1/P3); the rollup must collapse SKIPPED into pass for those
-    # two, otherwise doc-only PRs cannot merge.
-    needs: [actionlint, classify, test, integration-e2e, behavioural]
+    # Conditionally-gated jobs (shellcheck / hadolint / integration-e2e
+    # / behavioural) carry job-level `if:` so they SKIP on doc-only /
+    # non-behavioural PRs (#317 P1/P3, #376); the rollup must collapse
+    # SKIPPED into pass for those, otherwise doc-only PRs cannot merge.
+    needs: [actionlint, classify, shellcheck, hadolint, test, integration-e2e, behavioural]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -402,6 +446,8 @@ jobs:
         env:
           ACTIONLINT_RESULT: ${{ needs.actionlint.result }}
           CLASSIFY_RESULT: ${{ needs.classify.result }}
+          SHELLCHECK_RESULT: ${{ needs.shellcheck.result }}
+          HADOLINT_RESULT: ${{ needs.hadolint.result }}
           TEST_RESULT: ${{ needs.test.result }}
           INTEGRATION_RESULT: ${{ needs.integration-e2e.result }}
           BEHAVIOURAL_RESULT: ${{ needs.behavioural.result }}
@@ -409,6 +455,8 @@ jobs:
           set -euo pipefail
           echo "actionlint:      ${ACTIONLINT_RESULT}"
           echo "classify:        ${CLASSIFY_RESULT}"
+          echo "shellcheck:      ${SHELLCHECK_RESULT}"
+          echo "hadolint:        ${HADOLINT_RESULT}"
           echo "test:            ${TEST_RESULT}"
           echo "integration-e2e: ${INTEGRATION_RESULT}"
           echo "behavioural:     ${BEHAVIOURAL_RESULT}"
@@ -416,13 +464,13 @@ jobs:
           for r in "${ACTIONLINT_RESULT}" "${CLASSIFY_RESULT}" "${TEST_RESULT}"; do
             [[ "${r}" == "success" ]] || fail=1
           done
-          for r in "${INTEGRATION_RESULT}" "${BEHAVIOURAL_RESULT}"; do
+          for r in "${SHELLCHECK_RESULT}" "${HADOLINT_RESULT}" "${INTEGRATION_RESULT}" "${BEHAVIOURAL_RESULT}"; do
             [[ "${r}" == "success" || "${r}" == "skipped" ]] || fail=1
           done
           exit "${fail}"
 
   release:
-    needs: [test, integration-e2e, behavioural]
+    needs: [shellcheck, hadolint, test, integration-e2e, behavioural]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -9,18 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Dedicated `shellcheck` + `hadolint` parallel jobs in
+  `self-test.yaml`** (#376). ShellCheck runs on plain ubuntu-latest
+  (pre-installed binary, no buildx, no test-tools image) via
+  `script/ci/ci.sh --shellcheck-only` — a 30s regression now surfaces
+  in ~45s wall time instead of waiting for the full bats suite inside
+  the `test` job. Hadolint uses
+  `hadolint/hadolint-action@v3.1.0` to lint
+  `dockerfile/Dockerfile.example` + `dockerfile/Dockerfile.test-tools`
+  (template-owned; downstream consumers inherit). Both jobs gate on
+  `needs.classify.outputs.code_changed == 'true'` so doc-only PRs SKIP
+  them. `ci-rollup`'s `needs:` and the `release` job's `needs:` both
+  extend to include these two jobs.
 - **`ci-rollup` aggregator job in `self-test.yaml`** (#337). A single
-  always-running job sits downstream of `[actionlint, classify, test,
-  integration-e2e, behavioural]` and collapses their results into one
-  pass/fail signal. `actionlint` / `classify` / `test` must succeed;
-  `integration-e2e` / `behavioural` are allowed to be SKIPPED (their
+  always-running job sits downstream of every PR check and collapses
+  results into one pass/fail signal. Hard-mandatory jobs (actionlint /
+  classify / test) must succeed; conditionally-gated jobs (shellcheck
+  / hadolint / integration-e2e / behavioural) may be SKIPPED (their
   job-level `if:` gates fire on doc-only / non-behavioural PRs per
-  #317 P1/P3). Enables follow-up sub-jobs (#376 shellcheck / hadolint,
-  #377 bats-unit / bats-integration / coverage) to join the rollup's
-  `needs:` list without further branch-protection churn. **Branch
-  protection switch from `test` → `ci-rollup` happens in a separate
-  step after this PR merges**; the workflow change here is forwards-
-  compatible with both states (both checks pass on a green PR).
+  #317 P1/P3, #376). Enables follow-up sub-jobs (#377 bats-unit /
+  bats-integration / coverage) to join the rollup's `needs:` list
+  without further branch-protection churn. **Branch protection
+  switched from `test` → `ci-rollup` post-merge** (admin step,
+  separate from the workflow change).
+
+### Changed
+
+- **`script/ci/ci.sh` gained `--shellcheck-only` and `--bats-only`
+  flags** (#376). `--shellcheck-only` short-circuits before any mode
+  dispatch and runs the lint phase directly on the host (no compose,
+  no apt-install) — caller must have `shellcheck` in PATH. `--bats-only`
+  plumbs `BATS_ONLY=1` through `_run_via_compose` to the inner `--ci`
+  dispatch, which then skips the `_run_shellcheck` step. Local
+  `make test` keeps the full pipeline (shellcheck + bats) unchanged
+  because neither flag is set by default.
+- **`self-test.yaml`'s `test` job now invokes `ci.sh --bats-only`**
+  (#376) so the shellcheck phase doesn't run twice (once in the
+  dedicated `shellcheck` job + once inside the `test` job's compose
+  container). Removes ~30s from the `test` job's wall time.
 
 ## [v0.32.0] - 2026-05-15
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1378 tests** total (1314 unit + 64 integration).
+Template self-tests: **1386 tests** total (1322 unit + 64 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -219,10 +219,10 @@ on doc-only PRs).
 | #272 GHA buildx cache: `cache_variant` input declared with empty default, `Compute cache scope` step emits `id: cache` + scope key into `GITHUB_OUTPUT`, 4 build steps set `cache-from: type=gha,scope=...`, 4 build steps set `cache-to: ...,mode=max`, default preserves zero-diff for single-call callers | 5 |
 | #273 doc-only PR fast-pass (Phase 1 + Phase 2 shell rewrite): `path-filter` job declared, classifier is pure shell (`git diff --name-only base...head` + `case` glob; no `dorny/paths-filter` dependency), reads EVENT_NAME / BASE_SHA / HEAD_SHA from env: keys so the case body stays portable, non-PR event short-circuits before git diff (BASE_SHA / HEAD_SHA empty on push / tag / workflow_dispatch), 6-path allowlist (`**/*.md`, `doc/**`, `LICENSE`, `.gitignore`, `.github/CODEOWNERS`, `.github/dependabot.yml`) in a single `case` arm, `compute-matrix` + `build` jobs gated on `code_changed == 'true'` (2 occurrences), `docker-build` aggregator handles `code_changed == 'false'` short-circuit + `needs: [path-filter, build]`, non-PR triggers always set `code_changed=true` | 8 |
 
-### test/unit/self_test_yaml_spec.bats (32)
+### test/unit/self_test_yaml_spec.bats (40)
 
 Structural assertions for `.github/workflows/self-test.yaml`. Locks
-six cumulative invariants:
+seven cumulative invariants:
 
 1. **#305 actionlint gate** — `actionlint` job declared, runs
    `rhysd/actionlint` via Docker pinned to an explicit version
@@ -286,17 +286,32 @@ six cumulative invariants:
    the behavioural-skip optimization.
 
 6. **#337 `ci-rollup` aggregator** — a single always-running
-   (`if: always()`) `ci-rollup` job sits downstream of
-   `[actionlint, classify, test, integration-e2e, behavioural]`
-   and collapses their results into one pass/fail signal that
+   (`if: always()`) `ci-rollup` job sits downstream of every PR
+   check and collapses their results into one pass/fail signal that
    branch protection can require. The verifier shell step consumes
    every `${{ needs.<job>.result }}` and applies a 2-tier rule:
    `actionlint` / `classify` / `test` must be `success`;
-   `integration-e2e` / `behavioural` may be `success` or `skipped`
+   conditionally-gated jobs (`shellcheck` / `hadolint` /
+   `integration-e2e` / `behavioural`) may be `success` or `skipped`
    (their job-level `if:` legitimately skips on doc-only / non-
-   behavioural PRs per #317 P1/P3). Adding sub-jobs (#376, #377)
+   behavioural PRs per #317 P1/P3, #376). Adding sub-jobs (#377)
    to the rollup's `needs:` list becomes a workflow-internal
    change with no branch-protection update required.
+
+7. **#376 ShellCheck + Hadolint dedicated jobs** — `shellcheck` runs
+   on plain ubuntu-latest with the pre-installed binary (no buildx,
+   no test-tools image, ~30s feedback on a regression) via
+   `ci.sh --shellcheck-only`. `hadolint` uses
+   `hadolint/hadolint-action@v3.1.0` to lint
+   `dockerfile/Dockerfile.example` + `dockerfile/Dockerfile.test-tools`
+   (both template-owned; downstream Dockerfile.example consumers
+   inherit the lint pass). Both gate on
+   `needs.classify.outputs.code_changed == 'true'` so doc-only PRs
+   SKIP them. The existing `test` job's "Run CI" step now invokes
+   `ci.sh --bats-only` to skip its own ShellCheck phase (no
+   duplication). Both new jobs join `ci-rollup`'s `needs:` list, and
+   `release` also gates on them so a tag with a lint regression
+   doesn't publish a Release.
 
 | Category | Tests |
 |----------|-------|
@@ -314,8 +329,12 @@ six cumulative invariants:
 | `behavioural` Obtain step with 3-layer fallback (#317 P2) | 1 |
 | Obtain steps pre-fetch base ref (4 occurrences: classify + 3 jobs, #317 P2 reuses P1 gotcha-2 fix) | 1 |
 | `classify` behavioural block-list extends to `setup.sh` + `i18n.sh` + `lib/**` + `prune.sh` (#317 P3 gotcha-5) | 1 |
-| `ci-rollup` declared + `needs: [actionlint, classify, test, integration-e2e, behavioural]` + `if: always()` (#337) | 3 |
-| `ci-rollup` verify step consumes every `needs.<job>.result` + SKIPPED treated as pass for `integration-e2e`/`behavioural` + `success` required for hard-mandatory jobs (#337) | 3 |
+| `ci-rollup` declared + `needs: [actionlint, classify, shellcheck, hadolint, test, integration-e2e, behavioural]` + `if: always()` (#337 + #376) | 3 |
+| `ci-rollup` verify step consumes every `needs.<job>.result` + SKIPPED treated as pass for conditional jobs + `success` required for hard-mandatory jobs (#337 + #376) | 3 |
+| `shellcheck` job declared + `needs: [actionlint, classify]` + `if: code_changed == 'true'` + runs `ci.sh --shellcheck-only` on plain ubuntu-latest with no buildx (#376) | 3 |
+| `hadolint` job declared + `needs: [actionlint, classify]` + `if: code_changed == 'true'` + lints both template-owned Dockerfiles via `hadolint-action` (#376) | 3 |
+| `test` job's CI step passes `--bats-only` after #376 split | 1 |
+| `release` job gates on `shellcheck` + `hadolint` pass before publishing a tag (#376) | 1 |
 
 ### test/unit/release_test_tools_yaml_spec.bats (10)
 

--- a/script/ci/ci.sh
+++ b/script/ci/ci.sh
@@ -2,11 +2,18 @@
 # ci.sh - Run CI pipeline (ShellCheck + Bats [+ Kcov])
 #
 # Usage:
-#   ./ci.sh              # Run ShellCheck + Bats (fast dev loop)
-#   ./ci.sh --ci         # Run inside CI container (called by compose)
-#   ./ci.sh --lint-only  # Run ShellCheck only (via docker compose)
-#   ./ci.sh --coverage   # Run ShellCheck + Bats + Kcov coverage
-#   ./ci.sh -h, --help   # Show this help
+#   ./ci.sh                   # Run ShellCheck + Bats (fast dev loop)
+#   ./ci.sh --ci              # Run inside CI container (called by compose)
+#   ./ci.sh --lint-only       # Run ShellCheck only (via docker compose)
+#   ./ci.sh --shellcheck-only # Run ShellCheck only, no compose, no bats deps
+#                             # (used by self-test.yaml's dedicated shellcheck
+#                             # job, #376; plain ubuntu-latest runner with
+#                             # pre-installed shellcheck)
+#   ./ci.sh --bats-only       # Run Bats only inside compose (skip ShellCheck)
+#                             # (used by self-test.yaml's `test` job once the
+#                             # dedicated shellcheck job exists, #376)
+#   ./ci.sh --coverage        # Run ShellCheck + Bats + Kcov coverage
+#   ./ci.sh -h, --help        # Show this help
 #
 # Kcov instrumentation wraps every bats command and slows the suite
 # 2-5x, so the default no longer runs it. Run `--coverage` (or
@@ -34,22 +41,32 @@ Usage: ./ci.sh [OPTIONS]
 Run CI pipeline: ShellCheck + Bats [+ Kcov coverage].
 
 Options:
-  --ci          Run directly inside CI container (called by compose);
-                honors $COVERAGE=1 to include kcov (else bats only)
-  --lint-only   Run ShellCheck only
-  --coverage    Run tests with Kcov coverage (slow; CI / release check)
-  -h, --help    Show this help
+  --ci              Run directly inside CI container (called by compose);
+                    honors $COVERAGE=1 to include kcov (else bats only),
+                    and $BATS_ONLY=1 to skip the ShellCheck phase
+  --lint-only       Run ShellCheck only (via docker compose)
+  --shellcheck-only Run ShellCheck only, directly, no compose; relies on
+                    shellcheck already being in PATH (e.g. plain
+                    ubuntu-latest GHA runner). Used by self-test.yaml's
+                    dedicated shellcheck job (#376)
+  --bats-only       Run Bats only inside compose (skip the ShellCheck
+                    phase). Used by self-test.yaml's `test` job once the
+                    dedicated shellcheck job exists (#376)
+  --coverage        Run tests with Kcov coverage (slow; CI / release check)
+  -h, --help        Show this help
 
 Default (no flag): ShellCheck + bats via docker compose, no kcov.
 Kcov wraps every bats command and slows the suite 2-5x, so the
 dev-loop default skips it.
 
 Examples:
-  ./ci.sh                # Fast: ShellCheck + Bats (no kcov)
-  make test              # Same as above
-  ./ci.sh --coverage     # Full: ShellCheck + Bats + Kcov
-  make coverage          # Same as above
-  make lint              # ShellCheck only
+  ./ci.sh                  # Fast: ShellCheck + Bats (no kcov)
+  make test                # Same as above
+  ./ci.sh --coverage       # Full: ShellCheck + Bats + Kcov
+  make coverage            # Same as above
+  make lint                # ShellCheck only
+  ./ci.sh --shellcheck-only # Direct shellcheck, no compose (GHA shellcheck job)
+  ./ci.sh --bats-only      # Compose-bats only, skip ShellCheck (GHA test job)
 EOF
   exit 0
 }
@@ -186,12 +203,18 @@ _run_via_compose() {
   #                no apt-install on each run; fast dev loop)
   #   `coverage` — kcov/kcov (debian; needs apt-install via _install_deps,
   #                opt-in APT_MIRROR_DEBIAN rewrite for unreachable mirrors)
+  #
+  # BATS_ONLY is forwarded so the inner `--ci` dispatch can skip
+  # _run_shellcheck when the dedicated GHA shellcheck job (#376) is
+  # covering it in parallel. Default 0 keeps the local `make test`
+  # path unchanged (full shellcheck + bats).
   local _service="${1:-ci}"
   local _coverage="${2:-0}"
   docker compose -f "${REPO_ROOT}/compose.yaml" run --rm \
     -e HOST_UID="$(id -u)" \
     -e HOST_GID="$(id -g)" \
     -e COVERAGE="${_coverage}" \
+    -e BATS_ONLY="${BATS_ONLY:-0}" \
     "${_service}"
 }
 
@@ -247,17 +270,31 @@ _run_behavioural() {
 main() {
   local mode="compose"
   local behavioural=0
+  local bats_only=0
+  local shellcheck_only=0
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -h|--help) usage ;;
       --ci) mode="ci"; shift ;;
       --lint-only) mode="lint"; shift ;;
+      --shellcheck-only) shellcheck_only=1; shift ;;
+      --bats-only) bats_only=1; shift ;;
       --coverage) mode="coverage"; shift ;;
       --behavioural) behavioural=1; shift ;;
       *) echo "Unknown option: $1" >&2; exit 1 ;;
     esac
   done
+
+  # --shellcheck-only short-circuits before any mode dispatch. It runs
+  # the lint phase directly on the host (no compose, no apt-install).
+  # Caller is responsible for having the linter binary in PATH — the
+  # dedicated self-test.yaml shellcheck job (#376) uses plain
+  # ubuntu-latest, which ships it pre-installed.
+  if [[ "${shellcheck_only}" == "1" ]]; then
+    _run_shellcheck
+    return 0
+  fi
 
   case "${mode}" in
     ci)
@@ -266,6 +303,9 @@ main() {
       # Pass COVERAGE=1 via the outer `--coverage` flag to include it.
       # `--behavioural` swaps the bats invocation to drive
       # `docker buildx build` against runtime-test fixtures (#249).
+      # BATS_ONLY=1 (set by `--bats-only` outer flag, plumbed via
+      # `_run_via_compose`) skips the ShellCheck phase — the dedicated
+      # self-test.yaml shellcheck job covers it in parallel (#376).
       if [[ "${behavioural}" == "1" ]]; then
         _install_deps
         _run_behavioural
@@ -273,7 +313,9 @@ main() {
         return 0
       fi
       _install_deps
-      _run_shellcheck
+      if [[ "${BATS_ONLY:-0}" != "1" ]]; then
+        _run_shellcheck
+      fi
       if [[ "${COVERAGE:-0}" == "1" ]]; then
         _run_coverage
         _fix_permissions
@@ -292,8 +334,15 @@ main() {
       ;;
     compose)
       # Default: fast CI (shellcheck + bats, no kcov) via the alpine
-      # test-tools-based `ci` service.
-      _run_via_compose ci 0
+      # test-tools-based `ci` service. `--bats-only` plumbs BATS_ONLY=1
+      # to the container so the inner `--ci` dispatch skips
+      # _run_shellcheck (the dedicated GHA shellcheck job covers it,
+      # #376). Local `make test` keeps the full pipeline.
+      if [[ "${bats_only}" == "1" ]]; then
+        BATS_ONLY=1 _run_via_compose ci 0
+      else
+        _run_via_compose ci 0
+      fi
       ;;
   esac
 }

--- a/test/unit/self_test_yaml_spec.bats
+++ b/test/unit/self_test_yaml_spec.bats
@@ -275,14 +275,14 @@ setup() {
   assert_success
 }
 
-@test "self-test.yaml: ci-rollup needs all sibling jobs that branch protection used to require (#337)" {
-  # The aggregator must wait on actionlint + classify + test +
-  # integration-e2e + behavioural so its result reflects every PR
-  # check. New sub-jobs (#376 shellcheck/hadolint, #377 bats-*) join
-  # this list later.
+@test "self-test.yaml: ci-rollup needs all sibling jobs that branch protection used to require (#337 + #376)" {
+  # The aggregator must wait on actionlint + classify + shellcheck +
+  # hadolint + test + integration-e2e + behavioural so its result
+  # reflects every PR check. New sub-jobs (#377 bats-*) join this
+  # list later.
   run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial 'needs: [actionlint, classify, test, integration-e2e, behavioural]'
+  assert_output --partial 'needs: [actionlint, classify, shellcheck, hadolint, test, integration-e2e, behavioural]'
 }
 
 @test "self-test.yaml: ci-rollup runs unconditionally via if: always() (#337)" {
@@ -294,13 +294,15 @@ setup() {
   assert_output --partial 'if: always()'
 }
 
-@test "self-test.yaml: ci-rollup verify step consumes every needs result (#337)" {
+@test "self-test.yaml: ci-rollup verify step consumes every needs result (#337 + #376)" {
   # The shell verifier must inspect each upstream's ${{ needs.<job>.result }}
   # to translate the parallel job graph into a single pass/fail signal.
   run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
   assert_output --partial 'needs.actionlint.result'
   assert_output --partial 'needs.classify.result'
+  assert_output --partial 'needs.shellcheck.result'
+  assert_output --partial 'needs.hadolint.result'
   assert_output --partial 'needs.test.result'
   assert_output --partial 'needs.integration-e2e.result'
   assert_output --partial 'needs.behavioural.result'
@@ -326,4 +328,82 @@ setup() {
   run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
   assert_output --partial 'success'
+}
+
+# ── shellcheck + hadolint dedicated jobs (#376) ───────────────────────
+
+@test "self-test.yaml: declares shellcheck job (#376)" {
+  run grep -E '^  shellcheck:' "${WF}"
+  assert_success
+}
+
+@test "self-test.yaml: shellcheck job needs actionlint + classify and gates on code_changed (#376)" {
+  # Same upstream pattern as the test/integration-e2e jobs so the
+  # actionlint workflow-validator gate still fires first, and the
+  # doc-only short-circuit still skips lint runs.
+  run awk '/^  shellcheck:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'needs: [actionlint, classify]'
+  assert_output --partial "if: needs.classify.outputs.code_changed == 'true'"
+}
+
+@test "self-test.yaml: shellcheck job runs ci.sh --shellcheck-only on plain ubuntu-latest (#376)" {
+  # Goal: ~30s feedback on a shellcheck regression. Plain ubuntu-latest
+  # ships shellcheck pre-installed so no apt-install / no buildx /
+  # no test-tools image is needed — keeps the job cold-startup cost
+  # near zero.
+  run awk '/^  shellcheck:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'runs-on: ubuntu-latest'
+  assert_output --partial './script/ci/ci.sh --shellcheck-only'
+  # No buildx setup / no docker pull / no compose run in this job.
+  refute_output --partial 'docker/setup-buildx-action'
+  refute_output --partial 'docker pull'
+}
+
+@test "self-test.yaml: declares hadolint job (#376)" {
+  run grep -E '^  hadolint:' "${WF}"
+  assert_success
+}
+
+@test "self-test.yaml: hadolint job needs actionlint + classify and gates on code_changed (#376)" {
+  run awk '/^  hadolint:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'needs: [actionlint, classify]'
+  assert_output --partial "if: needs.classify.outputs.code_changed == 'true'"
+}
+
+@test "self-test.yaml: hadolint lints both template-owned Dockerfiles (#376)" {
+  # template owns Dockerfile.example (the new-repo scaffold copied by
+  # init.sh) + Dockerfile.test-tools (the alpine test image consumed by
+  # downstream Dockerfile.example `FROM ${TEST_TOOLS_IMAGE}`). A
+  # regression to either should surface here before downstream CI
+  # fans out.
+  run awk '/^  hadolint:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'hadolint/hadolint-action'
+  assert_output --partial 'dockerfile: dockerfile/Dockerfile.example'
+  assert_output --partial 'dockerfile: dockerfile/Dockerfile.test-tools'
+  assert_output --partial 'config: .hadolint.yaml'
+}
+
+@test "self-test.yaml: test job's CI step passes --bats-only after #376 split" {
+  # Once the dedicated shellcheck job exists, the `test` job no longer
+  # needs to run shellcheck inside its compose container — it would
+  # just duplicate work. The wrapper flag plumbs BATS_ONLY=1 through
+  # _run_via_compose to the inner --ci dispatch, which skips
+  # _run_shellcheck.
+  run awk '/^  test:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial './script/ci/ci.sh --bats-only'
+  refute_output --partial './script/ci/ci.sh\n'  # not the no-flag form alone
+}
+
+@test "self-test.yaml: release job gates on shellcheck + hadolint pass before publishing a tag (#376)" {
+  # release fires on tag push only, but if shellcheck / hadolint fail
+  # the tag should NOT produce a Release. Pre-#376 the release job
+  # didn't list either; post-#376 both join the chain.
+  run awk '/^  release:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'needs: [shellcheck, hadolint, test, integration-e2e, behavioural]'
 }


### PR DESCRIPTION
## Summary

Adds two dedicated parallel jobs to `self-test.yaml`:

- **`shellcheck`** — plain `ubuntu-latest`, pre-installed binary, no
  buildx / no test-tools image / no compose. Invokes
  `./script/ci/ci.sh --shellcheck-only`. A 30s shellcheck regression
  now fails in ~45s wall time instead of waiting on the full ~5min
  bats suite inside the `test` job.
- **`hadolint`** — `hadolint/hadolint-action@v3.1.0` lints
  `dockerfile/Dockerfile.example` + `dockerfile/Dockerfile.test-tools`
  (template-owned; downstream `Dockerfile.example` consumers inherit
  the lint pass). New layer of coverage for the template's own
  Dockerfiles, previously only linted in downstream `test` stages.

Both jobs gate on `needs.classify.outputs.code_changed == 'true'` so
doc-only PRs SKIP them (rollup treats SKIPPED as pass for these per
#337's two-tier rule).

`test` job's `Run CI` step changes from `./script/ci/ci.sh` to
`./script/ci/ci.sh --bats-only` so the shellcheck phase doesn't run
twice (drops ~30s from `test` job wall time).

Unblocks #377 (bats unit/integration matrix split + kcov coverage
move) — that PR slots its new `bats-unit` + `bats-integration` jobs
into the same `ci-rollup needs:` list pattern this PR establishes for
`shellcheck` / `hadolint`.

## ci.sh flag additions

- `--shellcheck-only` — short-circuits before any mode dispatch and
  runs the lint phase directly on the host (no compose, no
  apt-install). Caller must have `shellcheck` in PATH.
- `--bats-only` — plumbs `BATS_ONLY=1` via `_run_via_compose` to the
  inner `--ci` dispatch, which skips `_run_shellcheck`. Local
  `make test` keeps the full pipeline (neither flag set by default).

## ci-rollup + release `needs:` extended

Both new jobs join `ci-rollup`'s `needs:` list (post-#337 they're
conditionally-gated → SKIPPED counts as pass). `release` job's
`needs:` extends to include them too so a tag push with a lint
regression doesn't publish a Release.

## Tests

8 new structural assertions in `test/unit/self_test_yaml_spec.bats`
lock the new jobs' shape (32 → 40):

- `shellcheck` declared + `needs:` + `if:` + `--shellcheck-only`
  invocation + no buildx/no docker pull (3 assertions)
- `hadolint` declared + `needs:` + `if:` + lints both Dockerfiles via
  `hadolint-action` (3 assertions)
- `test` job's CI step passes `--bats-only` (1 assertion)
- `release` `needs:` includes shellcheck + hadolint (1 assertion)

Full suite: 1322 unit + 64 integration = **1386 tests green** via
`make -f Makefile.ci test`. TEST.md count + invariant 7 section added.
CHANGELOG `[Unreleased]` entries under `### Added` (jobs) and
`### Changed` (ci.sh + test job invocation).

## Test plan

- [ ] CI: `actionlint` green (new yaml blocks are syntactically valid)
- [ ] CI: new `shellcheck` job runs and passes on a green tree (~45s)
- [ ] CI: new `hadolint` job runs and passes on a green tree
- [ ] CI: `test` job runs `ci.sh --bats-only` (shellcheck not in its log)
- [ ] CI: `ci-rollup` aggregator pass collapses all 7 upstream
      results
- [ ] No branch-protection change required this PR (rollup name
      unchanged from #337)

Refs #376; depends on #337 (PR #380, merged).
