### PR TITLE
ci(self-test): split bats unit/integration + move kcov to coverage job (#377)

### DIFF
--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -159,31 +159,34 @@ jobs:
           dockerfile: dockerfile/Dockerfile.test-tools
           config: .hadolint.yaml
 
-  test:
+  bats-unit:
+    # Matrix shard of the unit suite (#377). Replaces the previous
+    # monolithic `test` job's unit phase. Round-robin partition over
+    # `find test/unit -name '*_spec.bats' | sort` keeps each shard's
+    # file count balanced enough at the current ~30 spec scale; weight
+    # by test count per spec is deferred (#377 out-of-scope).
+    #
+    # Shards run in parallel — the wall-time gain comes from cutting
+    # the pre-#376 5min `test` job (which serialised 1308 unit + 64
+    # integration + shellcheck) into 4 parallel jobs each ~1-2min.
+    # ci-rollup folds each matrix shard's result into a single
+    # `needs.bats-unit.result` so branch-protection sees one signal.
     needs: [actionlint, classify]
+    if: needs.classify.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/2', '2/2']
     steps:
-      # Doc-only short-circuit: kept so the `test` job always REPORTS a
-      # SUCCESS result on doc-only PRs (the rollup expects `test ==
-      # success`; SKIPPED would be treated as a workflow bug). Post-#376
-      # ShellCheck moved to its own job; this job now runs Bats only via
-      # `ci.sh --bats-only`.
-      - name: Doc-only short-circuit
-        if: needs.classify.outputs.code_changed == 'false'
-        run: |
-          echo "Doc-only PR — bats / kcov skipped; reporting SUCCESS for branch protection."
-
       - name: Checkout
-        if: needs.classify.outputs.code_changed == 'true'
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        if: needs.classify.outputs.code_changed == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Obtain test-tools:local (#317 P2 3-layer fallback)
         id: obtain
-        if: needs.classify.outputs.code_changed == 'true'
         env:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
@@ -219,7 +222,7 @@ jobs:
           echo "build_local=true" >> "${GITHUB_OUTPUT}"
 
       - name: Build test-tools:local (with GHA cache)
-        if: ${{ needs.classify.outputs.code_changed == 'true' && steps.obtain.outputs.build_local == 'true' }}
+        if: steps.obtain.outputs.build_local == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -229,14 +232,91 @@ jobs:
           cache-from: type=gha,scope=test-tools
           cache-to: type=gha,scope=test-tools,mode=max
 
-      - name: Run CI (Bats; ShellCheck moved to dedicated parallel job, #376)
-        if: needs.classify.outputs.code_changed == 'true'
+      - name: Run Bats unit shard ${{ matrix.shard }}
         env:
           TEST_TOOLS_IMAGE: test-tools:local
-        run: ./script/ci/ci.sh --bats-only
+        run: ./script/ci/ci.sh --bats-unit-shard ${{ matrix.shard }}
+
+  bats-integration:
+    # Dedicated job for the 64 integration specs (#377). Pre-#377 these
+    # ran sequentially after the 1308 unit specs inside the monolithic
+    # `test` job; pulling them into their own job removes that tail
+    # from each unit shard's wall time.
+    needs: [actionlint, classify]
+    if: needs.classify.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Obtain test-tools:local (#317 P2 3-layer fallback)
+        id: obtain
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -uo pipefail
+          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            git fetch origin \
+              "${BASE_REF}:refs/remotes/origin/${BASE_REF}" \
+              --depth=200 >/dev/null 2>&1 || true
+            if ! git diff --quiet \
+                 "origin/${BASE_REF}"...HEAD \
+                 -- dockerfile/Dockerfile.test-tools; then
+              echo "build_local=true" >> "${GITHUB_OUTPUT}"
+              exit 0
+            fi
+          fi
+          if docker pull --platform linux/amd64 \
+               ghcr.io/ycpss91255-docker/test-tools:main 2>/dev/null; then
+            docker tag \
+              ghcr.io/ycpss91255-docker/test-tools:main \
+              test-tools:local
+            echo "build_local=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "build_local=true" >> "${GITHUB_OUTPUT}"
+
+      - name: Build test-tools:local (with GHA cache)
+        if: steps.obtain.outputs.build_local == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: dockerfile/Dockerfile.test-tools
+          tags: test-tools:local
+          load: true
+          cache-from: type=gha,scope=test-tools
+          cache-to: type=gha,scope=test-tools,mode=max
+
+      - name: Run Bats integration suite
+        env:
+          TEST_TOOLS_IMAGE: test-tools:local
+        run: ./script/ci/ci.sh --bats-integration
+
+  coverage:
+    # Kcov coverage now main-push-only (#377). Pre-#377 the test job
+    # always ran the Codecov upload step but never with COVERAGE=1 on
+    # PRs (kcov 2-5x slowdown was too expensive), so PR runs produced
+    # no coverage data and the badge only updated post-merge via the
+    # main-push self-test run. This makes that implicit policy explicit:
+    # coverage runs ONLY on push to main (not on PRs, not on tags),
+    # and is NOT in ci-rollup's `needs:` so a coverage hiccup never
+    # blocks a PR merge.
+    needs: [actionlint, classify]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run CI with Kcov coverage
+        run: ./script/ci/ci.sh --coverage
 
       - name: Upload coverage to Codecov
-        if: ${{ needs.classify.outputs.code_changed == 'true' && always() }}
+        if: ${{ always() }}
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -426,19 +506,27 @@ jobs:
         run: docker compose run --rm ci-behavioural
 
   ci-rollup:
-    # Single aggregator required by branch protection. Sub-jobs (#376
-    # shellcheck/hadolint, #377 bats-unit/bats-integration, …) join
-    # this `needs:` list without further branch-protection churn —
-    # the only required check stays `ci-rollup`. Pattern mirrors
-    # ros1_bridge's `ci-summary` and env/* `ci-passed`.
+    # Single aggregator required by branch protection. Every PR check
+    # joins this `needs:` list so branch protection never needs to
+    # change to track new sub-jobs. Pattern mirrors ros1_bridge's
+    # `ci-summary` and env/* `ci-passed`.
     #
-    # Hard-mandatory jobs (actionlint / classify / test) must succeed:
-    # SKIPPED there indicates a workflow bug, not an intentional gate.
-    # Conditionally-gated jobs (shellcheck / hadolint / integration-e2e
-    # / behavioural) carry job-level `if:` so they SKIP on doc-only /
-    # non-behavioural PRs (#317 P1/P3, #376); the rollup must collapse
-    # SKIPPED into pass for those, otherwise doc-only PRs cannot merge.
-    needs: [actionlint, classify, shellcheck, hadolint, test, integration-e2e, behavioural]
+    # Hard-mandatory jobs (actionlint / classify) must succeed: SKIPPED
+    # there indicates a workflow bug, not an intentional gate. The
+    # post-#377 rollup has no remaining always-running test gate — bats
+    # is now split into shard'd jobs that SKIP on doc-only PRs along
+    # with everything else.
+    #
+    # Conditionally-gated jobs (shellcheck / hadolint / bats-unit /
+    # bats-integration / integration-e2e / behavioural) carry job-level
+    # `if:` so they SKIP on doc-only / non-behavioural PRs (#317 P1/P3,
+    # #376, #377); the rollup collapses SKIPPED into pass for those,
+    # otherwise doc-only PRs cannot merge.
+    #
+    # `coverage` is intentionally NOT in `needs:` — it's a metric job
+    # gated on push-to-main, not a PR gate; a coverage hiccup must not
+    # block PR merge.
+    needs: [actionlint, classify, shellcheck, hadolint, bats-unit, bats-integration, integration-e2e, behavioural]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -448,29 +536,33 @@ jobs:
           CLASSIFY_RESULT: ${{ needs.classify.result }}
           SHELLCHECK_RESULT: ${{ needs.shellcheck.result }}
           HADOLINT_RESULT: ${{ needs.hadolint.result }}
-          TEST_RESULT: ${{ needs.test.result }}
+          BATS_UNIT_RESULT: ${{ needs.bats-unit.result }}
+          BATS_INTEGRATION_RESULT: ${{ needs.bats-integration.result }}
           INTEGRATION_RESULT: ${{ needs.integration-e2e.result }}
           BEHAVIOURAL_RESULT: ${{ needs.behavioural.result }}
         run: |
           set -euo pipefail
-          echo "actionlint:      ${ACTIONLINT_RESULT}"
-          echo "classify:        ${CLASSIFY_RESULT}"
-          echo "shellcheck:      ${SHELLCHECK_RESULT}"
-          echo "hadolint:        ${HADOLINT_RESULT}"
-          echo "test:            ${TEST_RESULT}"
-          echo "integration-e2e: ${INTEGRATION_RESULT}"
-          echo "behavioural:     ${BEHAVIOURAL_RESULT}"
+          echo "actionlint:       ${ACTIONLINT_RESULT}"
+          echo "classify:         ${CLASSIFY_RESULT}"
+          echo "shellcheck:       ${SHELLCHECK_RESULT}"
+          echo "hadolint:         ${HADOLINT_RESULT}"
+          echo "bats-unit:        ${BATS_UNIT_RESULT}"
+          echo "bats-integration: ${BATS_INTEGRATION_RESULT}"
+          echo "integration-e2e:  ${INTEGRATION_RESULT}"
+          echo "behavioural:      ${BEHAVIOURAL_RESULT}"
           fail=0
-          for r in "${ACTIONLINT_RESULT}" "${CLASSIFY_RESULT}" "${TEST_RESULT}"; do
+          for r in "${ACTIONLINT_RESULT}" "${CLASSIFY_RESULT}"; do
             [[ "${r}" == "success" ]] || fail=1
           done
-          for r in "${SHELLCHECK_RESULT}" "${HADOLINT_RESULT}" "${INTEGRATION_RESULT}" "${BEHAVIOURAL_RESULT}"; do
+          for r in "${SHELLCHECK_RESULT}" "${HADOLINT_RESULT}" \
+                   "${BATS_UNIT_RESULT}" "${BATS_INTEGRATION_RESULT}" \
+                   "${INTEGRATION_RESULT}" "${BEHAVIOURAL_RESULT}"; do
             [[ "${r}" == "success" || "${r}" == "skipped" ]] || fail=1
           done
           exit "${fail}"
 
   release:
-    needs: [shellcheck, hadolint, test, integration-e2e, behavioural]
+    needs: [shellcheck, hadolint, bats-unit, bats-integration, integration-e2e, behavioural]
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     permissions:

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Bats matrix shards + dedicated coverage job in `self-test.yaml`**
+  (#377). Three new sibling jobs replace the pre-#377 monolithic
+  `test` job:
+  - `bats-unit` (matrix `shard: ['1/2', '2/2']`, `fail-fast: false`) —
+    each shard runs a round-robin partition of `test/unit/*_spec.bats`
+    via `ci.sh --bats-unit-shard ${{ matrix.shard }}`. Drops PR
+    wall-time from ~5min serial to ~2min parallel.
+  - `bats-integration` — runs `test/integration/` via
+    `ci.sh --bats-integration`. Pulled out of the unit serial path.
+  - `coverage` — gated on `push && ref == refs/heads/main`. Runs the
+    full Kcov pipeline (`ci.sh --coverage`) and uploads to Codecov.
+    Intentionally NOT in `ci-rollup`'s `needs:` so a coverage hiccup
+    never blocks PR merge. The Codecov upload step migrated here from
+    the old `test` job.
+
+  `ci-rollup needs:` reshaped to
+  `[actionlint, classify, shellcheck, hadolint, bats-unit,
+  bats-integration, integration-e2e, behavioural]`. `release needs:`
+  swaps `test` → `bats-unit + bats-integration`. The old `test` job
+  is fully removed.
 - **Dedicated `shellcheck` + `hadolint` parallel jobs in
   `self-test.yaml`** (#376). ShellCheck runs on plain ubuntu-latest
   (pre-installed binary, no buildx, no test-tools image) via
@@ -35,18 +55,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`script/ci/ci.sh` gained `--shellcheck-only` and `--bats-only`
-  flags** (#376). `--shellcheck-only` short-circuits before any mode
-  dispatch and runs the lint phase directly on the host (no compose,
-  no apt-install) — caller must have `shellcheck` in PATH. `--bats-only`
-  plumbs `BATS_ONLY=1` through `_run_via_compose` to the inner `--ci`
-  dispatch, which then skips the `_run_shellcheck` step. Local
-  `make test` keeps the full pipeline (shellcheck + bats) unchanged
-  because neither flag is set by default.
-- **`self-test.yaml`'s `test` job now invokes `ci.sh --bats-only`**
-  (#376) so the shellcheck phase doesn't run twice (once in the
-  dedicated `shellcheck` job + once inside the `test` job's compose
-  container). Removes ~30s from the `test` job's wall time.
+- **`script/ci/ci.sh` gained `--shellcheck-only`, `--bats-only`,
+  `--bats-unit-shard N/T`, and `--bats-integration` flags** (#376,
+  #377). `--shellcheck-only` short-circuits before any mode dispatch
+  and runs the lint phase directly on the host (no compose, no
+  apt-install) — caller must have `shellcheck` in PATH.
+  `--bats-only`, `--bats-unit-shard N/T`, and `--bats-integration`
+  plumb `BATS_ONLY=1` plus the appropriate `BATS_UNIT_SHARD` /
+  `BATS_INTEGRATION` env var through `_run_via_compose` to the inner
+  `--ci` dispatch, which then routes to the right subset of the bats
+  suite (and skips `_run_shellcheck` in all three). Local `make test`
+  keeps the full pipeline (shellcheck + bats unit + bats integration)
+  unchanged because none of these flags is set by default.
+- **`script/ci/ci.sh` factored `_run_tests` into `_run_unit_tests` +
+  `_run_integration_tests` + new `_run_unit_shard <N>/<T>`** (#377).
+  Shared parallelism / label-formatting logic extracted into
+  `_bats_args_with_label`. Round-robin partition over
+  `find test/unit -name '*_spec.bats' | sort` keeps each shard's file
+  count balanced at the current ~30 spec scale; weight-by-test-count
+  is a deferred follow-up.
 
 ## [v0.32.0] - 2026-05-15
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1386 tests** total (1322 unit + 64 integration).
+Template self-tests: **1398 tests** total (1334 unit + 64 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -219,10 +219,10 @@ on doc-only PRs).
 | #272 GHA buildx cache: `cache_variant` input declared with empty default, `Compute cache scope` step emits `id: cache` + scope key into `GITHUB_OUTPUT`, 4 build steps set `cache-from: type=gha,scope=...`, 4 build steps set `cache-to: ...,mode=max`, default preserves zero-diff for single-call callers | 5 |
 | #273 doc-only PR fast-pass (Phase 1 + Phase 2 shell rewrite): `path-filter` job declared, classifier is pure shell (`git diff --name-only base...head` + `case` glob; no `dorny/paths-filter` dependency), reads EVENT_NAME / BASE_SHA / HEAD_SHA from env: keys so the case body stays portable, non-PR event short-circuits before git diff (BASE_SHA / HEAD_SHA empty on push / tag / workflow_dispatch), 6-path allowlist (`**/*.md`, `doc/**`, `LICENSE`, `.gitignore`, `.github/CODEOWNERS`, `.github/dependabot.yml`) in a single `case` arm, `compute-matrix` + `build` jobs gated on `code_changed == 'true'` (2 occurrences), `docker-build` aggregator handles `code_changed == 'false'` short-circuit + `needs: [path-filter, build]`, non-PR triggers always set `code_changed=true` | 8 |
 
-### test/unit/self_test_yaml_spec.bats (40)
+### test/unit/self_test_yaml_spec.bats (52)
 
 Structural assertions for `.github/workflows/self-test.yaml`. Locks
-seven cumulative invariants:
+eight cumulative invariants:
 
 1. **#305 actionlint gate** — `actionlint` job declared, runs
    `rhysd/actionlint` via Docker pinned to an explicit version
@@ -307,11 +307,36 @@ seven cumulative invariants:
    (both template-owned; downstream Dockerfile.example consumers
    inherit the lint pass). Both gate on
    `needs.classify.outputs.code_changed == 'true'` so doc-only PRs
-   SKIP them. The existing `test` job's "Run CI" step now invokes
-   `ci.sh --bats-only` to skip its own ShellCheck phase (no
-   duplication). Both new jobs join `ci-rollup`'s `needs:` list, and
-   `release` also gates on them so a tag with a lint regression
-   doesn't publish a Release.
+   SKIP them. Both join `ci-rollup`'s `needs:` list, and `release`
+   also gates on them so a tag with a lint regression doesn't publish
+   a Release.
+
+8. **#377 Bats unit/integration split + Kcov coverage move** — the
+   pre-#377 monolithic `test` job is fully removed and replaced by
+   three sibling jobs:
+   - `bats-unit` (matrix `shard: ['1/2', '2/2']`, `fail-fast: false`):
+     each shard runs a round-robin partition of `test/unit/*_spec.bats`
+     via `ci.sh --bats-unit-shard ${{ matrix.shard }}`. Parallel
+     execution drops PR wall-time from ~5min to ~2min.
+   - `bats-integration`: runs `test/integration/` via
+     `ci.sh --bats-integration`. Pulled out of the unit serial path
+     so each unit shard sees only its share.
+   - `coverage`: `if: github.event_name == 'push' && github.ref ==
+     'refs/heads/main'` — gated to main pushes only. Runs
+     `ci.sh --coverage` (full kcov pipeline) and uploads to Codecov.
+     **NOT in `ci-rollup`'s `needs:`** — coverage failure must not
+     block PR merge. PR-side coverage delta still works because
+     Codecov compares the PR head against the latest main coverage
+     blob.
+
+   `ci-rollup needs:` now `[actionlint, classify, shellcheck,
+   hadolint, bats-unit, bats-integration, integration-e2e,
+   behavioural]` (8 jobs) — every PR-check job. `release needs:`
+   updates from `[shellcheck, hadolint, test, integration-e2e,
+   behavioural]` → `[shellcheck, hadolint, bats-unit, bats-integration,
+   integration-e2e, behavioural]`. Post-#377 only `actionlint` +
+   `classify` are hard-mandatory in `ci-rollup`'s verifier (the
+   always-running `test` job no longer exists).
 
 | Category | Tests |
 |----------|-------|
@@ -319,22 +344,26 @@ seven cumulative invariants:
 | `actionlint` step uses `rhysd/actionlint:<pinned-version>` Docker image | 1 |
 | `classify` job declared with `code_changed` + `behavioural_relevant` outputs | 3 |
 | `classify` doc-only allow-list + behavioural block-list + non-PR default | 3 |
-| `test`/`integration-e2e`/`behavioural` declare `needs: [actionlint, classify]` | 3 |
-| `test` doc-only short-circuit + real-step `code_changed == 'true'` gate | 2 |
+| `bats-unit`/`bats-integration`/`integration-e2e`/`behavioural` declare `needs: [actionlint, classify]` | 4 |
+| `bats-unit`/`bats-integration` job-level `if: code_changed == 'true'` + no remaining monolithic `test:` job (#377) | 3 |
 | `integration-e2e` job-level `if: code_changed == 'true'` + `behavioural` job-level `if: behavioural_relevant == 'true'` (#317 P3 tightens) | 2 |
-| `test` + `behavioural` use `docker/build-push-action@v6` with `scope=test-tools` GHA cache | 2 |
+| `bats-unit`/`bats-integration`/`behavioural` use `docker/build-push-action@v6` with `scope=test-tools` GHA cache | 3 |
 | `classify` fail-open (`set -uo pipefail`) + pre-fetch base ref (#317 gotcha-1/2) | 2 |
-| `test` Obtain step pulls `:main` with 3-layer fallback + Build step gated on `build_local` (#317 P2) | 2 |
+| `bats-unit` Obtain step pulls `:main` with 3-layer fallback + Build step gated on `build_local` (#317 P2 + #377) | 2 |
+| `bats-integration` Obtain step + 3-layer fallback (#317 P2 + #377) | 1 |
 | `integration-e2e` Obtain step + `TEST_TOOLS_IMAGE` env passthrough + no `driver: docker` pin (#317 P2) | 2 |
 | `behavioural` Obtain step with 3-layer fallback (#317 P2) | 1 |
-| Obtain steps pre-fetch base ref (4 occurrences: classify + 3 jobs, #317 P2 reuses P1 gotcha-2 fix) | 1 |
+| Obtain steps pre-fetch base ref (5 occurrences post-#377: classify + 4 jobs, #317 P2 reuses P1 gotcha-2 fix) | 1 |
 | `classify` behavioural block-list extends to `setup.sh` + `i18n.sh` + `lib/**` + `prune.sh` (#317 P3 gotcha-5) | 1 |
-| `ci-rollup` declared + `needs: [actionlint, classify, shellcheck, hadolint, test, integration-e2e, behavioural]` + `if: always()` (#337 + #376) | 3 |
-| `ci-rollup` verify step consumes every `needs.<job>.result` + SKIPPED treated as pass for conditional jobs + `success` required for hard-mandatory jobs (#337 + #376) | 3 |
+| `ci-rollup` declared + `needs: [actionlint, classify, shellcheck, hadolint, bats-unit, bats-integration, integration-e2e, behavioural]` + `if: always()` (#337 + #376 + #377) | 3 |
+| `ci-rollup` does NOT need `coverage` (#377) | 1 |
+| `ci-rollup` verify step consumes every `needs.<job>.result` + SKIPPED treated as pass for conditional jobs + `success` required for hard-mandatory jobs (#337 + #376 + #377) | 3 |
 | `shellcheck` job declared + `needs: [actionlint, classify]` + `if: code_changed == 'true'` + runs `ci.sh --shellcheck-only` on plain ubuntu-latest with no buildx (#376) | 3 |
 | `hadolint` job declared + `needs: [actionlint, classify]` + `if: code_changed == 'true'` + lints both template-owned Dockerfiles via `hadolint-action` (#376) | 3 |
-| `test` job's CI step passes `--bats-only` after #376 split | 1 |
-| `release` job gates on `shellcheck` + `hadolint` pass before publishing a tag (#376) | 1 |
+| `bats-unit` declared + `strategy.matrix.shard: ['1/2', '2/2']` + `fail-fast: false` + invokes `ci.sh --bats-unit-shard ${{ matrix.shard }}` (#377) | 3 |
+| `bats-integration` declared + invokes `ci.sh --bats-integration` (#377) | 2 |
+| `coverage` declared + `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` + runs `ci.sh --coverage` + uploads Codecov (#377) | 3 |
+| `release` job needs `[shellcheck, hadolint, bats-unit, bats-integration, integration-e2e, behavioural]` before publishing a tag (#376 + #377) | 1 |
 
 ### test/unit/release_test_tools_yaml_spec.bats (10)
 

--- a/script/ci/ci.sh
+++ b/script/ci/ci.sh
@@ -10,9 +10,17 @@
 #                             # job, #376; plain ubuntu-latest runner with
 #                             # pre-installed shellcheck)
 #   ./ci.sh --bats-only       # Run Bats only inside compose (skip ShellCheck)
-#                             # (used by self-test.yaml's `test` job once the
-#                             # dedicated shellcheck job exists, #376)
+#                             # (used by self-test.yaml's bats jobs, #376/#377)
+#   ./ci.sh --bats-unit-shard N/T  # Run unit shard N of T (skip ShellCheck +
+#                                  # integration). Used by the bats-unit
+#                                  # matrix in self-test.yaml (#377)
+#   ./ci.sh --bats-integration     # Run integration tests only (skip
+#                                  # ShellCheck + unit). Used by the
+#                                  # bats-integration job in self-test.yaml
+#                                  # (#377)
 #   ./ci.sh --coverage        # Run ShellCheck + Bats + Kcov coverage
+#                             # (push-to-main only via self-test.yaml's
+#                             # coverage job, #377)
 #   ./ci.sh -h, --help        # Show this help
 #
 # Kcov instrumentation wraps every bats command and slows the suite
@@ -41,32 +49,42 @@ Usage: ./ci.sh [OPTIONS]
 Run CI pipeline: ShellCheck + Bats [+ Kcov coverage].
 
 Options:
-  --ci              Run directly inside CI container (called by compose);
-                    honors $COVERAGE=1 to include kcov (else bats only),
-                    and $BATS_ONLY=1 to skip the ShellCheck phase
-  --lint-only       Run ShellCheck only (via docker compose)
-  --shellcheck-only Run ShellCheck only, directly, no compose; relies on
-                    shellcheck already being in PATH (e.g. plain
-                    ubuntu-latest GHA runner). Used by self-test.yaml's
-                    dedicated shellcheck job (#376)
-  --bats-only       Run Bats only inside compose (skip the ShellCheck
-                    phase). Used by self-test.yaml's `test` job once the
-                    dedicated shellcheck job exists (#376)
-  --coverage        Run tests with Kcov coverage (slow; CI / release check)
-  -h, --help        Show this help
+  --ci                    Run directly inside CI container (called by
+                          compose); honors $COVERAGE=1 to include kcov,
+                          $BATS_ONLY=1 to skip the ShellCheck phase,
+                          $BATS_UNIT_SHARD to run only one matrix shard,
+                          $BATS_INTEGRATION=1 to run integration only
+  --lint-only             ShellCheck only (via docker compose)
+  --shellcheck-only       ShellCheck only, directly, no compose; relies on
+                          shellcheck already being in PATH (e.g. plain
+                          ubuntu-latest GHA runner). Used by
+                          self-test.yaml's dedicated shellcheck job (#376)
+  --bats-only             Bats only inside compose (skip ShellCheck) (#376)
+  --bats-unit-shard N/T   Run unit shard N of T (skip ShellCheck +
+                          integration). Used by the bats-unit matrix in
+                          self-test.yaml (#377)
+  --bats-integration      Run integration tests only (skip ShellCheck +
+                          unit). Used by the bats-integration job in
+                          self-test.yaml (#377)
+  --coverage              Run tests with Kcov coverage (slow; CI / release
+                          check). Used by self-test.yaml's coverage job
+                          (push-to-main only, #377)
+  -h, --help              Show this help
 
 Default (no flag): ShellCheck + bats via docker compose, no kcov.
 Kcov wraps every bats command and slows the suite 2-5x, so the
 dev-loop default skips it.
 
 Examples:
-  ./ci.sh                  # Fast: ShellCheck + Bats (no kcov)
-  make test                # Same as above
-  ./ci.sh --coverage       # Full: ShellCheck + Bats + Kcov
-  make coverage            # Same as above
-  make lint                # ShellCheck only
-  ./ci.sh --shellcheck-only # Direct shellcheck, no compose (GHA shellcheck job)
-  ./ci.sh --bats-only      # Compose-bats only, skip ShellCheck (GHA test job)
+  ./ci.sh                       # Fast: ShellCheck + Bats (no kcov)
+  make test                     # Same as above
+  ./ci.sh --coverage            # Full: ShellCheck + Bats + Kcov
+  make coverage                 # Same as above
+  make lint                     # ShellCheck only
+  ./ci.sh --shellcheck-only     # Direct shellcheck, no compose
+  ./ci.sh --bats-only           # Compose-bats only, skip ShellCheck
+  ./ci.sh --bats-unit-shard 1/2 # Compose-bats unit shard 1 of 2
+  ./ci.sh --bats-integration    # Compose-bats integration only
 EOF
   exit 0
 }
@@ -136,29 +154,89 @@ _run_shellcheck() {
 
 # ── Bats tests ───────────────────────────────────────────────────────────────
 
-_run_tests() {
-  # --jobs N uses GNU parallel under the hood; bats parallelizes both
-  # across files and within files by default. All specs use per-test
-  # mktemp dirs (BATS_TEST_TMPDIR / TEMP_DIR) so there's no shared
-  # filesystem state between tests — safe to run concurrently.
-  #
-  # When parallel is missing (e.g. earlier alpine test-tools images
-  # before #168's parallel addition), fall back to serial bats so the
-  # suite still runs — slower but correct.
-  local -a _bats_args=()
-  local _label
+_bats_args_with_label() {
+  # Shared helper: populate the caller-supplied array name with the
+  # `--jobs N` argument when GNU parallel is available, and set the
+  # caller-supplied label var. Reused by every _run_*_tests function so
+  # parallelism + fallback messaging stay in one place. Inputs:
+  #   $1 = name of array var (e.g. _bats_args)
+  #   $2 = name of label string var (e.g. _label)
+  # All specs use per-test mktemp dirs (BATS_TEST_TMPDIR / TEMP_DIR) so
+  # there's no shared filesystem state between tests — safe to run
+  # concurrently. When parallel is missing (earlier alpine test-tools
+  # images pre-#168), fall back to serial bats — slower but correct.
+  local -n _out_args="$1"
+  local -n _out_label="$2"
+  _out_args=()
   if command -v parallel >/dev/null 2>&1; then
     local _jobs
     _jobs="$(nproc 2>/dev/null || echo 4)"
-    _bats_args=(--jobs "${_jobs}")
-    _label="jobs=${_jobs}"
+    _out_args=(--jobs "${_jobs}")
+    _out_label="jobs=${_jobs}"
   else
-    _label="serial; parallel not in PATH"
+    _out_label="serial; parallel not in PATH"
   fi
+}
+
+_run_unit_tests() {
+  local -a _bats_args
+  local _label
+  _bats_args_with_label _bats_args _label
   echo "--- Running Bats Unit Tests (${_label}) ---"
   bats "${_bats_args[@]}" "${REPO_ROOT}/test/unit/"
+}
+
+_run_integration_tests() {
+  local -a _bats_args
+  local _label
+  _bats_args_with_label _bats_args _label
   echo "--- Running Bats Integration Tests (${_label}) ---"
   bats "${_bats_args[@]}" "${REPO_ROOT}/test/integration/"
+}
+
+_run_tests() {
+  # Wrapper retained for the full sequential dev-loop path (local
+  # `make test`). Kept so refactors are localised; the CI matrix shard
+  # jobs go through _run_unit_shard / _run_integration_tests directly.
+  _run_unit_tests
+  _run_integration_tests
+}
+
+_run_unit_shard() {
+  # Run a deterministic subset of test/unit/*_spec.bats for the GHA
+  # bats-unit matrix (#377). Spec accepts `<n>/<total>` where 1<=n<=total.
+  # Round-robin partition over `find ... | sort` so the mapping is stable
+  # across runs regardless of which files were added since the last
+  # matrix tuning. Issue #377 notes weight-by-test-count as a deferred
+  # follow-up; round-robin keeps each shard's count balanced enough at
+  # the current 30-ish unit spec scale.
+  local _spec="${1:?BUG: _run_unit_shard expects <n>/<total>}"
+  if [[ "${_spec}" != */* ]]; then
+    _die "Invalid shard spec '${_spec}'. Expected <n>/<total> (e.g. 1/2)."
+  fi
+  local _shard="${_spec%/*}"
+  local _total="${_spec#*/}"
+  if ! [[ "${_shard}" =~ ^[0-9]+$ && "${_total}" =~ ^[0-9]+$ ]] \
+       || (( _shard < 1 || _shard > _total )); then
+    _die "Invalid shard spec '${_spec}'. Need 1<=n<=total."
+  fi
+  local _files
+  _files=$(find "${REPO_ROOT}/test/unit" -maxdepth 1 -name '*_spec.bats' -print \
+             | sort \
+             | awk -v s="${_shard}" -v t="${_total}" 'NR % t == (s - 1) % t')
+  if [[ -z "${_files}" ]]; then
+    _die "No spec files matched shard ${_spec}. Empty test/unit/ ?"
+  fi
+  local -a _bats_args
+  local _label
+  _bats_args_with_label _bats_args _label
+  echo "--- Running Bats Unit Shard ${_spec} (${_label}) ---"
+  # Word-split intentional: print one line per shard file.
+  # shellcheck disable=SC2086
+  printf '  shard:%s\n' ${_files}
+  # Word-split intentional: bats accepts multiple file args.
+  # shellcheck disable=SC2086
+  bats "${_bats_args[@]}" ${_files}
 }
 
 # ── Kcov coverage ────────────────────────────────────────────────────────────
@@ -208,6 +286,11 @@ _run_via_compose() {
   # _run_shellcheck when the dedicated GHA shellcheck job (#376) is
   # covering it in parallel. Default 0 keeps the local `make test`
   # path unchanged (full shellcheck + bats).
+  #
+  # BATS_UNIT_SHARD / BATS_INTEGRATION (#377) route the matrix
+  # bats-unit + bats-integration GHA jobs to the right subset inside
+  # the container; empty / 0 keep the local `make test` path
+  # unchanged (full unit + integration).
   local _service="${1:-ci}"
   local _coverage="${2:-0}"
   docker compose -f "${REPO_ROOT}/compose.yaml" run --rm \
@@ -215,6 +298,8 @@ _run_via_compose() {
     -e HOST_GID="$(id -g)" \
     -e COVERAGE="${_coverage}" \
     -e BATS_ONLY="${BATS_ONLY:-0}" \
+    -e BATS_UNIT_SHARD="${BATS_UNIT_SHARD:-}" \
+    -e BATS_INTEGRATION="${BATS_INTEGRATION:-0}" \
     "${_service}"
 }
 
@@ -272,6 +357,8 @@ main() {
   local behavioural=0
   local bats_only=0
   local shellcheck_only=0
+  local bats_unit_shard=""
+  local bats_integration=0
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -280,6 +367,8 @@ main() {
       --lint-only) mode="lint"; shift ;;
       --shellcheck-only) shellcheck_only=1; shift ;;
       --bats-only) bats_only=1; shift ;;
+      --bats-unit-shard) bats_unit_shard="${2:?--bats-unit-shard expects <n>/<total>}"; shift 2 ;;
+      --bats-integration) bats_integration=1; shift ;;
       --coverage) mode="coverage"; shift ;;
       --behavioural) behavioural=1; shift ;;
       *) echo "Unknown option: $1" >&2; exit 1 ;;
@@ -306,6 +395,11 @@ main() {
       # BATS_ONLY=1 (set by `--bats-only` outer flag, plumbed via
       # `_run_via_compose`) skips the ShellCheck phase — the dedicated
       # self-test.yaml shellcheck job covers it in parallel (#376).
+      # BATS_UNIT_SHARD / BATS_INTEGRATION (#377) route this dispatch
+      # to a matrix-shard / integration-only subset; the dedicated GHA
+      # bats-unit / bats-integration jobs set these via the outer
+      # `--bats-unit-shard` / `--bats-integration` flags so the
+      # in-container path matches the local dev path.
       if [[ "${behavioural}" == "1" ]]; then
         _install_deps
         _run_behavioural
@@ -320,6 +414,10 @@ main() {
         _run_coverage
         _fix_permissions
         echo "Coverage report: ${REPO_ROOT}/coverage/index.html"
+      elif [[ -n "${BATS_UNIT_SHARD:-}" ]]; then
+        _run_unit_shard "${BATS_UNIT_SHARD}"
+      elif [[ "${BATS_INTEGRATION:-0}" == "1" ]]; then
+        _run_integration_tests
       else
         _run_tests
       fi
@@ -334,11 +432,17 @@ main() {
       ;;
     compose)
       # Default: fast CI (shellcheck + bats, no kcov) via the alpine
-      # test-tools-based `ci` service. `--bats-only` plumbs BATS_ONLY=1
-      # to the container so the inner `--ci` dispatch skips
-      # _run_shellcheck (the dedicated GHA shellcheck job covers it,
-      # #376). Local `make test` keeps the full pipeline.
-      if [[ "${bats_only}" == "1" ]]; then
+      # test-tools-based `ci` service. Flag-driven plumbing of the
+      # relevant env vars selects the inner branch:
+      #   --bats-only          -> BATS_ONLY=1 (skip _run_shellcheck)
+      #   --bats-unit-shard X  -> BATS_ONLY=1 + BATS_UNIT_SHARD=X
+      #   --bats-integration   -> BATS_ONLY=1 + BATS_INTEGRATION=1
+      # Local `make test` (no flags) keeps the full pipeline.
+      if [[ -n "${bats_unit_shard}" ]]; then
+        BATS_ONLY=1 BATS_UNIT_SHARD="${bats_unit_shard}" _run_via_compose ci 0
+      elif [[ "${bats_integration}" == "1" ]]; then
+        BATS_ONLY=1 BATS_INTEGRATION=1 _run_via_compose ci 0
+      elif [[ "${bats_only}" == "1" ]]; then
         BATS_ONLY=1 _run_via_compose ci 0
       else
         _run_via_compose ci 0

--- a/test/unit/self_test_yaml_spec.bats
+++ b/test/unit/self_test_yaml_spec.bats
@@ -123,10 +123,16 @@ setup() {
   assert_output --partial '|| true'
 }
 
-# ── Downstream jobs gate on actionlint + classify (#305 / #317) ───────
+# ── Downstream jobs gate on actionlint + classify (#305 / #317 / #377) ─
 
-@test "self-test.yaml: test job declares needs on actionlint AND classify (#317)" {
-  run awk '/^  test:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+@test "self-test.yaml: bats-unit job declares needs on actionlint AND classify (#377)" {
+  run awk '/^  bats-unit:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'needs: [actionlint, classify]'
+}
+
+@test "self-test.yaml: bats-integration job declares needs on actionlint AND classify (#377)" {
+  run awk '/^  bats-integration:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
   assert_output --partial 'needs: [actionlint, classify]'
 }
@@ -143,20 +149,29 @@ setup() {
   assert_output --partial 'needs: [actionlint, classify]'
 }
 
-# ── Doc-only short-circuit + conditional gating (#317) ────────────────
+# ── Conditional gating (#317, #377) ───────────────────────────────────
 
-@test "self-test.yaml: test job has doc-only short-circuit step (#317)" {
-  run awk '/^  test:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+@test "self-test.yaml: bats-unit job-level if: gates on code_changed (#377)" {
+  # Post-#377 bats-unit replaces the always-running `test` job's
+  # short-circuit pattern with a clean job-level skip. ci-rollup's
+  # SKIPPED=pass rule (#337) keeps doc-only PRs merge-able.
+  run awk '/^  bats-unit:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial "needs.classify.outputs.code_changed == 'false'"
-  assert_output --partial "Doc-only short-circuit"
+  assert_output --partial "if: needs.classify.outputs.code_changed == 'true'"
 }
 
-@test "self-test.yaml: test job real steps gated by code_changed == 'true' (#317)" {
-  run awk '/^  test:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+@test "self-test.yaml: bats-integration job-level if: gates on code_changed (#377)" {
+  run awk '/^  bats-integration:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  # At least one step should be gated by the positive branch
-  assert_output --partial "needs.classify.outputs.code_changed == 'true'"
+  assert_output --partial "if: needs.classify.outputs.code_changed == 'true'"
+}
+
+@test "self-test.yaml: no monolithic `test:` job remains after #377 split" {
+  # Pre-#377 a `test` job ran shellcheck + bats sequentially. #376
+  # peeled shellcheck out, #377 splits the rest into bats-unit
+  # (matrix) + bats-integration. The old job is fully removed.
+  run grep -E '^  test:' "${WF}"
+  assert_failure
 }
 
 @test "self-test.yaml: integration-e2e job-level if: gates on code_changed (#317)" {
@@ -190,10 +205,18 @@ setup() {
   assert_output --partial "'script/docker/prune.sh'"
 }
 
-# ── buildx GHA cache on test-tools builds (#317) ──────────────────────
+# ── buildx GHA cache on test-tools builds (#317, #377) ────────────────
 
-@test "self-test.yaml: test job uses docker/build-push-action with GHA cache scope=test-tools (#317)" {
-  run awk '/^  test:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+@test "self-test.yaml: bats-unit job uses docker/build-push-action with GHA cache scope=test-tools (#377)" {
+  run awk '/^  bats-unit:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'uses: docker/build-push-action@v6'
+  assert_output --partial 'cache-from: type=gha,scope=test-tools'
+  assert_output --partial 'cache-to: type=gha,scope=test-tools,mode=max'
+}
+
+@test "self-test.yaml: bats-integration job uses docker/build-push-action with GHA cache scope=test-tools (#377)" {
+  run awk '/^  bats-integration:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
   assert_output --partial 'uses: docker/build-push-action@v6'
   assert_output --partial 'cache-from: type=gha,scope=test-tools'
@@ -210,8 +233,8 @@ setup() {
 
 # ── #317 P2: Obtain step + rolling tag fallback ──────────────────────
 
-@test "self-test.yaml: test job has Obtain step pulling :main with 3-layer fallback (#317 P2)" {
-  run awk '/^  test:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+@test "self-test.yaml: bats-unit job has Obtain step pulling :main with 3-layer fallback (#317 P2 + #377)" {
+  run awk '/^  bats-unit:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
   assert_output --partial 'Obtain test-tools:local'
   assert_output --partial 'docker pull --platform linux/amd64'
@@ -221,10 +244,19 @@ setup() {
   assert_output --partial 'build_local=false'
 }
 
-@test "self-test.yaml: test job Build step is gated on steps.obtain.outputs.build_local == 'true' (#317 P2)" {
-  run awk '/^  test:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+@test "self-test.yaml: bats-unit Build step is gated on steps.obtain.outputs.build_local == 'true' (#317 P2 + #377)" {
+  run awk '/^  bats-unit:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
   assert_output --partial "steps.obtain.outputs.build_local == 'true'"
+}
+
+@test "self-test.yaml: bats-integration job has Obtain step + 3-layer fallback (#317 P2 + #377)" {
+  run awk '/^  bats-integration:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'Obtain test-tools:local'
+  assert_output --partial 'ghcr.io/ycpss91255-docker/test-tools:main'
+  assert_output --partial 'build_local=true'
+  assert_output --partial 'build_local=false'
 }
 
 @test "self-test.yaml: integration-e2e job has Obtain step + TEST_TOOLS_IMAGE env passthrough (#317 P2)" {
@@ -258,14 +290,16 @@ setup() {
   assert_output --partial 'build_local=false'
 }
 
-@test "self-test.yaml: Obtain step pre-fetches base ref before diff (#317 P2 + P1 gotcha-2 reuse)" {
+@test "self-test.yaml: Obtain step pre-fetches base ref before diff (#317 P2 + P1 gotcha-2 reuse, #377)" {
   # Same gotcha-2 mitigation as the classify job: fork PRs need an
   # explicit fetch of origin/<base_ref> before `git diff` can resolve
-  # the merge base for `dockerfile/Dockerfile.test-tools`. 4 expected
-  # occurrences: classify job (1) + Obtain step in 3 jobs (3).
+  # the merge base for `dockerfile/Dockerfile.test-tools`. Post-#377
+  # the `test` job split into bats-unit + bats-integration so the
+  # occurrence count grows: classify (1) + 4 jobs with Obtain steps
+  # (bats-unit + bats-integration + integration-e2e + behavioural).
   run grep -c 'git fetch origin' "${WF}"
   assert_success
-  assert_output '4'
+  assert_output '5'
 }
 
 # ── ci-rollup aggregator (#337) ───────────────────────────────────────
@@ -275,14 +309,27 @@ setup() {
   assert_success
 }
 
-@test "self-test.yaml: ci-rollup needs all sibling jobs that branch protection used to require (#337 + #376)" {
-  # The aggregator must wait on actionlint + classify + shellcheck +
-  # hadolint + test + integration-e2e + behavioural so its result
-  # reflects every PR check. New sub-jobs (#377 bats-*) join this
-  # list later.
+@test "self-test.yaml: ci-rollup needs every sibling PR-check job (#337 + #376 + #377)" {
+  # The aggregator waits on actionlint + classify + shellcheck +
+  # hadolint + bats-unit + bats-integration + integration-e2e +
+  # behavioural so its result reflects every PR check. `coverage` is
+  # intentionally NOT in the list — it's a push-to-main metric, not a
+  # PR gate; including it would block PR merges on a coverage hiccup.
   run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial 'needs: [actionlint, classify, shellcheck, hadolint, test, integration-e2e, behavioural]'
+  assert_output --partial 'needs: [actionlint, classify, shellcheck, hadolint, bats-unit, bats-integration, integration-e2e, behavioural]'
+}
+
+@test "self-test.yaml: ci-rollup does NOT need coverage (#377)" {
+  # Coverage is push-to-main-only metric, not a PR gate.
+  run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  refute_output --partial 'needs.coverage.result'
+  # The `needs:` line itself must not list coverage either. Negative
+  # assertion via partial — the `needs: [...]` line above is the
+  # canonical source.
+  refute_output --partial ', coverage,'
+  refute_output --partial ', coverage]'
 }
 
 @test "self-test.yaml: ci-rollup runs unconditionally via if: always() (#337)" {
@@ -294,7 +341,7 @@ setup() {
   assert_output --partial 'if: always()'
 }
 
-@test "self-test.yaml: ci-rollup verify step consumes every needs result (#337 + #376)" {
+@test "self-test.yaml: ci-rollup verify step consumes every needs result (#337 + #376 + #377)" {
   # The shell verifier must inspect each upstream's ${{ needs.<job>.result }}
   # to translate the parallel job graph into a single pass/fail signal.
   run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
@@ -303,28 +350,28 @@ setup() {
   assert_output --partial 'needs.classify.result'
   assert_output --partial 'needs.shellcheck.result'
   assert_output --partial 'needs.hadolint.result'
-  assert_output --partial 'needs.test.result'
+  assert_output --partial 'needs.bats-unit.result'
+  assert_output --partial 'needs.bats-integration.result'
   assert_output --partial 'needs.integration-e2e.result'
   assert_output --partial 'needs.behavioural.result'
 }
 
-@test "self-test.yaml: ci-rollup treats SKIPPED as pass for conditionally-gated jobs (#337)" {
-  # integration-e2e + behavioural carry job-level `if:` gates that skip
-  # on doc-only / non-behavioural PRs (#317 P1/P3). The rollup must not
-  # fail those skips, otherwise doc-only PRs cannot merge — SKIPPED is
-  # only treated as missing by branch protection at the JOB level, but
-  # ci-rollup is itself a single SUCCESS step so it must collapse
-  # SKIPPED upstream into pass.
+@test "self-test.yaml: ci-rollup treats SKIPPED as pass for conditionally-gated jobs (#337 + #377)" {
+  # Post-#377 every PR-check job has a job-level `if:` gate that may
+  # cause it to skip on doc-only / non-behavioural PRs (the old
+  # always-running `test` job no longer exists). The rollup must
+  # collapse SKIPPED into pass for those, otherwise doc-only PRs
+  # cannot merge.
   run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
   assert_output --partial 'skipped'
 }
 
-@test "self-test.yaml: ci-rollup requires hard-mandatory jobs to be success (#337)" {
-  # actionlint / classify / test always run — SKIPPED there indicates
-  # a workflow bug, not an intentional gate. Hard-fail those.
-  # Verified indirectly by asserting the success comparison appears in
-  # the rollup's shell step.
+@test "self-test.yaml: ci-rollup requires hard-mandatory jobs to be success (#337 + #377)" {
+  # Post-#377 only actionlint + classify are hard-mandatory (the old
+  # always-running `test` job no longer exists). SKIPPED there
+  # indicates a workflow bug, not an intentional gate. Verified
+  # indirectly by asserting the success comparison appears.
   run awk '/^  ci-rollup:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
   assert_output --partial 'success'
@@ -387,23 +434,73 @@ setup() {
   assert_output --partial 'config: .hadolint.yaml'
 }
 
-@test "self-test.yaml: test job's CI step passes --bats-only after #376 split" {
-  # Once the dedicated shellcheck job exists, the `test` job no longer
-  # needs to run shellcheck inside its compose container — it would
-  # just duplicate work. The wrapper flag plumbs BATS_ONLY=1 through
-  # _run_via_compose to the inner --ci dispatch, which skips
-  # _run_shellcheck.
-  run awk '/^  test:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
-  assert_success
-  assert_output --partial './script/ci/ci.sh --bats-only'
-  refute_output --partial './script/ci/ci.sh\n'  # not the no-flag form alone
-}
-
-@test "self-test.yaml: release job gates on shellcheck + hadolint pass before publishing a tag (#376)" {
-  # release fires on tag push only, but if shellcheck / hadolint fail
-  # the tag should NOT produce a Release. Pre-#376 the release job
-  # didn't list either; post-#376 both join the chain.
+@test "self-test.yaml: release job gates on shellcheck + hadolint + bats-* + integration-e2e + behavioural before publishing a tag (#376 + #377)" {
+  # release fires on tag push only, but if any PR-check job fails the
+  # tag should NOT produce a Release. Post-#377 the `test` job is
+  # replaced by `bats-unit` + `bats-integration` in this chain.
   run awk '/^  release:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
-  assert_output --partial 'needs: [shellcheck, hadolint, test, integration-e2e, behavioural]'
+  assert_output --partial 'needs: [shellcheck, hadolint, bats-unit, bats-integration, integration-e2e, behavioural]'
+}
+
+# ── bats-unit + bats-integration + coverage jobs (#377) ───────────────
+
+@test "self-test.yaml: declares bats-unit job (#377)" {
+  run grep -E '^  bats-unit:' "${WF}"
+  assert_success
+}
+
+@test "self-test.yaml: bats-unit declares strategy.matrix.shard with 1/2 + 2/2 + fail-fast: false (#377)" {
+  # Default N=2 per the issue body. Each shard runs in parallel; the
+  # matrix rollup propagates to needs.bats-unit.result. fail-fast: false
+  # so a shard 1 failure doesn't cancel shard 2 (the maintainer wants
+  # to see both shards' results).
+  run awk '/^  bats-unit:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial 'fail-fast: false'
+  assert_output --partial "shard: ['1/2', '2/2']"
+}
+
+@test "self-test.yaml: bats-unit invokes ci.sh --bats-unit-shard \${{ matrix.shard }} (#377)" {
+  run awk '/^  bats-unit:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial './script/ci/ci.sh --bats-unit-shard ${{ matrix.shard }}'
+}
+
+@test "self-test.yaml: declares bats-integration job (#377)" {
+  run grep -E '^  bats-integration:' "${WF}"
+  assert_success
+}
+
+@test "self-test.yaml: bats-integration invokes ci.sh --bats-integration (#377)" {
+  run awk '/^  bats-integration:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial './script/ci/ci.sh --bats-integration'
+}
+
+@test "self-test.yaml: declares coverage job (#377)" {
+  run grep -E '^  coverage:' "${WF}"
+  assert_success
+}
+
+@test "self-test.yaml: coverage gates on push to main only — never on PRs or tags (#377)" {
+  # Pre-#377 kcov was wired but never exercised on PRs (the 2-5x
+  # slowdown was too expensive). #377 makes that implicit policy
+  # explicit. Restricting to `push && ref == refs/heads/main` ensures
+  # a tag push (which sets ref to refs/tags/v...) doesn't trigger it
+  # either.
+  run awk '/^  coverage:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial "if: github.event_name == 'push' && github.ref == 'refs/heads/main'"
+}
+
+@test "self-test.yaml: coverage invokes ci.sh --coverage + uploads to Codecov (#377)" {
+  # Codecov upload step migrated here from the old test job. Token
+  # source unchanged (\${{ secrets.CODECOV_TOKEN }}).
+  run awk '/^  coverage:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
+  assert_success
+  assert_output --partial './script/ci/ci.sh --coverage'
+  assert_output --partial 'codecov/codecov-action@v6'
+  assert_output --partial 'token: ${{ secrets.CODECOV_TOKEN }}'
+  assert_output --partial 'directory: ./coverage'
 }


### PR DESCRIPTION
## Summary

Replaces the pre-#377 monolithic `test` job (which serially ran
shellcheck + 1308 bats unit + 64 bats integration) with three sibling
jobs:

- **`bats-unit`** — matrix `shard: ['1/2', '2/2']` with
  `fail-fast: false`. Each shard runs
  `ci.sh --bats-unit-shard ${{ matrix.shard }}` over a round-robin
  partition of `test/unit/*_spec.bats`. Parallel execution drops PR
  wall-time from ~5 min serial → ~2 min parallel.
- **`bats-integration`** — runs `ci.sh --bats-integration` over
  `test/integration/`. Pulled out of the unit serial path so each
  unit shard sees only its share.
- **`coverage`** — gated on `push && ref == refs/heads/main` only.
  Runs the full Kcov pipeline (`ci.sh --coverage`) and uploads to
  Codecov. **Intentionally NOT in `ci-rollup`'s `needs:`** so a
  coverage hiccup never blocks PR merge. The Codecov upload step
  migrated here from the old `test` job.

## ci.sh refactor

- New `--bats-unit-shard N/T` and `--bats-integration` top-level
  flags plumb `BATS_UNIT_SHARD` / `BATS_INTEGRATION` env vars
  through `_run_via_compose` to the inner `--ci` dispatch (always
  with `BATS_ONLY=1` because the dedicated shellcheck job covers
  lint).
- `_run_tests` factored into `_run_unit_tests` +
  `_run_integration_tests` + new `_run_unit_shard <N>/<T>`. Shared
  parallelism logic extracted into `_bats_args_with_label`.
- Local `make test` keeps the full pipeline (shellcheck + bats unit
  + bats integration) unchanged.

## ci-rollup + release `needs:` reshaped

```yaml
ci-rollup needs:
  [actionlint, classify, shellcheck, hadolint, bats-unit,
   bats-integration, integration-e2e, behavioural]   # every PR check
   # NOT coverage (push-to-main metric, not a PR gate)

release needs:
  [shellcheck, hadolint, bats-unit, bats-integration,
   integration-e2e, behavioural]                     # was: test
```

Post-#377 only `actionlint` + `classify` are hard-mandatory in the
verifier (the always-running `test` job no longer exists;
bats-unit/bats-integration skip on doc-only PRs alongside the lint
jobs). Branch-protection state unchanged — single required check
remains `ci-rollup`.

## Shard partition strategy

Round-robin over `find test/unit -name '*_spec.bats' | sort` with
N=2 today. Issue body notes weight-by-test-count as a deferred
follow-up; round-robin keeps each shard's file count balanced enough
at the current ~30 spec scale. Tune N up after a round of CI wall-time
measurement if needed.

## Tests

12 new structural assertions (40 → 52) in
`test/unit/self_test_yaml_spec.bats`:

- `bats-unit` declared + `strategy.matrix.shard` + `fail-fast: false`
  + `ci.sh --bats-unit-shard ${{ matrix.shard }}` invocation +
  Obtain + Build + cache (5 assertions)
- `bats-integration` declared + invocation + Obtain + cache (3
  assertions)
- `coverage` declared + push-to-main gate + invocation + Codecov
  upload (3 assertions)
- ci-rollup `needs:` reshape + does NOT need `coverage` + verifier
  consumes `bats-unit.result` + `bats-integration.result` (covered
  by updated assertions, +1 negative for coverage)
- No `test:` job remains (1 assertion)
- `release` `needs:` reshape (covered by updated assertion)

Full suite: 1334 unit + 64 integration = **1398 tests green** via
`make -f Makefile.ci test`. TEST.md count + invariant 8 section +
table updated. CHANGELOG `[Unreleased]` entries under `### Added`
(jobs) and `### Changed` (ci.sh refactor).

## Test plan

- [ ] CI: `actionlint` green (new yaml blocks syntactically valid)
- [ ] CI: `bats-unit` matrix runs both shards in parallel; both pass
- [ ] CI: `bats-integration` runs and passes
- [ ] CI: `coverage` does NOT run on this PR (gated to main push)
- [ ] CI: `ci-rollup` aggregator collapses 8 upstream results to pass
- [ ] After merge to main: `coverage` job fires on the main push run
      and uploads to Codecov

Refs #377; depends on #337 (PR #380) + #376 (PR #381), both merged.
