### PR TITLE
fix(exec.sh): TTY auto-detect + -T/-i flags to stop escape leak (#382)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,8 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`exec.sh` one-shot commands no longer leak terminal escape
+  sequences** (#382). Pre-fix, `docker compose exec` defaulted to
+  `-it` so a one-shot like `./exec.sh bash -c 'ls /foo'` inherited
+  the host terminal's focus-in / bracketed-paste sequences (e.g.
+  `^[[I^[[I`) into stdout, polluting downstream pipelines.
+
 ### Added
 
+- **`exec.sh` gained `-T` / `--no-tty`, `-i` / `--tty`, plus auto-
+  detect for `bash|sh|dash|zsh|ash|ksh -c '...'`** (#382, Option 1+2).
+  Three-tier resolution with last-wins between the explicit flags:
+  - Explicit `-T` / `--no-tty` → no TTY (`docker compose exec -T`).
+    Use for one-shots the auto-detect heuristic misses (`whoami`,
+    `ls /foo`, `env BAR=1 bash -c '...'`).
+  - Explicit `-i` / `--tty` → TTY. Use to override the auto-detect
+    when a `bash -c '...'` invocation genuinely wants a TTY (e.g.
+    `-i bash -c 'tput cols'`).
+  - Auto-detect: first positional `bash|sh|dash|zsh|ash|ksh` plus
+    a following `-c` → no TTY (covers the 90% one-shot wrapping
+    pattern).
+  - Otherwise: keep `-it` (preserves `./exec.sh` and
+    `./exec.sh htop` muscle memory).
+
+  Usage text + examples updated in all 4 languages (en / zh-TW /
+  zh-CN / ja).
 - **Bats matrix shards + dedicated coverage job in `self-test.yaml`**
   (#377). Three new sibling jobs replace the pre-#377 monolithic
   `test` job:

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1398 tests** total (1334 unit + 64 integration).
+Template self-tests: **1415 tests** total (1351 unit + 64 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -501,7 +501,7 @@ value-required and directory guards, usage help mention), and **`-v`
 / `--verbose` / `-vv` / `--very-verbose` flag** (#311: same export +
 trace pattern as build.sh, parity across wrappers).
 
-### test/unit/exec_sh_spec.bats (36)
+### test/unit/exec_sh_spec.bats (53)
 
 Unit tests for `exec.sh` argument parsing, the container-running
 precheck, and i18n. Sandbox tree mirrors build_sh_spec.bats;
@@ -519,13 +519,21 @@ standalone `--` consumed before CMD flows through to `docker compose
 exec`, lets a dash-leading CMD pass through, works after `-t TARGET`
 for run.sh parity, no-`--` positional path stays backward-compatible,
 `-h` usage mentions `--`), fallback `_detect_lang` branches when
-`template/` is absent, and **`-C` / `--chdir` flag**
+`template/` is absent, **`-C` / `--chdir` flag**
 (docker_harness#53: redirect FILE_PATH so .env / project name come
 from the alt repo, short + long form, value-required and directory
-guards, usage help mention), and **`-v` / `--verbose` / `-vv` /
+guards, usage help mention), **`-v` / `--verbose` / `-vv` /
 `--very-verbose` flag** (#311: symmetry-only for exec since
 `docker exec` itself does not build, but flag is accepted and `-vv`
-enables wrapper trace).
+enables wrapper trace), and **`-T` / `--no-tty` + `-i` / `--tty`
+TTY-mode flags + auto-detect of `bash|sh|dash|zsh|ash|ksh -c '...'`**
+(#382 Option 1+2: 17 assertions covering the no-CMD default (TTY),
+interactive binary default (TTY), 4 shell flavours with `-c` auto-add
+`-T`, `bash hello.sh` (no `-c`) keeps TTY, explicit `-T`/`--no-tty`
+forces no-TTY, explicit `-i`/`--tty` overrides heuristic, last-wins
+precedence between `-T` and `-i` in both orders, `-T` + `-t TARGET`
+attaches to the right service, `-T` + `--` separator round-trip,
+`--help` mentions both flag pairs).
 
 ### test/unit/stop_sh_spec.bats (34)
 

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -95,7 +95,7 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG] [--] [CMD...]
+用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [-T|--no-tty] [-i|--tty] [--lang LANG] [--] [CMD...]
 
 選項:
   -h, --help        顯示此說明
@@ -109,6 +109,14 @@ usage() {
                     本身不會 build，但保持 flag 一致便於肌肉記憶）。
   -vv, --very-verbose
                     -v 再加 wrapper 本身的 bash trace（set -x）。
+  -T, --no-tty      強制不分配 TTY（傳 -T 給 docker compose exec）。用於 one-shot
+                    指令，避免終端 escape sequence 洩漏到 output。對於
+                    `bash|sh|dash|zsh|ash|ksh -c '...'` 已自動偵測；此 flag
+                    用來涵蓋 heuristic 漏網的 case，如 `whoami`、`ls /foo`、
+                    `env BAR=1 bash -c '...'`。
+  -i, --tty         強制分配 TTY（覆蓋 auto-detect）。用於少數需要 TTY 但走
+                    `bash -c '...'` 的 case（例：`-i bash -c 'tput cols'`）。
+                    與 -T 為 last-wins。
   --                明確分隔 exec.sh 選項與 CMD（與 run.sh 對齊），讓 CMD 可以
                     用 dash 開頭（例：./exec.sh -- my-tool --version）
 
@@ -120,12 +128,14 @@ usage() {
   ./exec.sh htop               # 在 devel 容器中執行 htop
   ./exec.sh ls -la /home       # 在 devel 容器中執行 ls
   ./exec.sh -t runtime bash    # 進入 runtime 容器
+  ./exec.sh bash -c 'ls'       # 自動偵測 → -T，無 escape 洩漏
+  ./exec.sh -T whoami          # 強制 -T 涵蓋 heuristic 漏網 case
   ./exec.sh -- my-tool --version  # 用 -- 把 dash-開頭 CMD 傳進容器
 EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG] [--] [CMD...]
+用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [-T|--no-tty] [-i|--tty] [--lang LANG] [--] [CMD...]
 
 选项:
   -h, --help        显示此说明
@@ -139,6 +149,14 @@ EOF
                     本身不会 build，但保持 flag 一致便于肌肉记忆）。
   -vv, --very-verbose
                     -v 再加 wrapper 本身的 bash trace（set -x）。
+  -T, --no-tty      强制不分配 TTY（传 -T 给 docker compose exec）。用于 one-shot
+                    命令，避免终端 escape sequence 泄漏到 output。对于
+                    `bash|sh|dash|zsh|ash|ksh -c '...'` 已自动检测；此 flag
+                    用来覆盖 heuristic 漏网的 case，如 `whoami`、`ls /foo`、
+                    `env BAR=1 bash -c '...'`。
+  -i, --tty         强制分配 TTY（覆盖 auto-detect）。用于少数需要 TTY 但走
+                    `bash -c '...'` 的 case（例：`-i bash -c 'tput cols'`）。
+                    与 -T 为 last-wins。
   --                明确分隔 exec.sh 选项与 CMD（与 run.sh 对齐），让 CMD 可以
                     以 dash 开头（例：./exec.sh -- my-tool --version）
 
@@ -150,12 +168,14 @@ EOF
   ./exec.sh htop               # 在 devel 容器中运行 htop
   ./exec.sh ls -la /home       # 在 devel 容器中运行 ls
   ./exec.sh -t runtime bash    # 进入 runtime 容器
+  ./exec.sh bash -c 'ls'       # 自动检测 → -T，无 escape 泄漏
+  ./exec.sh -T whoami          # 强制 -T 覆盖 heuristic 漏网 case
   ./exec.sh -- my-tool --version  # 用 -- 把 dash-开头 CMD 传入容器
 EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG] [--] [CMD...]
+使用法: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [-T|--no-tty] [-i|--tty] [--lang LANG] [--] [CMD...]
 
 オプション:
   -h, --help        このヘルプを表示
@@ -169,6 +189,15 @@ EOF
                     docker exec 自体は build しないが、フラグの一貫性のため）。
   -vv, --very-verbose
                     -v に加え wrapper 自体の bash trace（set -x）。
+  -T, --no-tty      TTY 割り当てを抑止（docker compose exec に -T を渡す）。
+                    one-shot コマンドで端末の escape sequence が output に
+                    漏れるのを防ぐ。`bash|sh|dash|zsh|ash|ksh -c '...'` は
+                    自動検出される；本フラグは `whoami`、`ls /foo`、
+                    `env BAR=1 bash -c '...'` など heuristic から外れた
+                    case 用。
+  -i, --tty         TTY 割り当てを強制（auto-detect を上書き）。`bash -c '...'`
+                    だが TTY が必要な稀な case 用（例：`-i bash -c 'tput cols'`）。
+                    -T とは last-wins。
   --                exec.sh のオプションと CMD を明示的に区切る（run.sh と整合）。
                     dash で始まる CMD を渡す場合に使う（例: ./exec.sh -- my-tool --version）
 
@@ -180,12 +209,14 @@ EOF
   ./exec.sh htop               # devel コンテナで htop を実行
   ./exec.sh ls -la /home       # devel コンテナで ls を実行
   ./exec.sh -t runtime bash    # runtime コンテナに接続
+  ./exec.sh bash -c 'ls'       # 自動検出 → -T、escape 漏れなし
+  ./exec.sh -T whoami          # 強制 -T で heuristic 漏れの case をカバー
   ./exec.sh -- my-tool --version  # -- で dash 始まりの CMD を渡す
 EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang LANG] [--] [CMD...]
+Usage: ./exec.sh [-h] [-C|--chdir DIR] [-t TARGET] [--instance NAME] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [-T|--no-tty] [-i|--tty] [--lang LANG] [--] [CMD...]
 
 Options:
   -h, --help        Show this help
@@ -201,6 +232,15 @@ Options:
                     knob to reach for.
   -vv, --very-verbose
                     -v plus bash trace (set -x) on the wrapper itself.
+  -T, --no-tty      Force no-TTY (pass -T to docker compose exec). Use for
+                    one-shot commands so terminal escape sequences (focus-in,
+                    bracketed-paste, …) do not leak into output. The forms
+                    `bash|sh|dash|zsh|ash|ksh -c '...'` are auto-detected;
+                    this flag covers the heuristic-misses case (`whoami`,
+                    `ls /foo`, `env BAR=1 bash -c '...'`).
+  -i, --tty         Force TTY (override auto-detect). Use for the rare case
+                    where a `bash -c '...'` invocation genuinely wants a TTY
+                    (e.g. `-i bash -c 'tput cols'`). Last-wins with -T.
   --                Explicit flag/CMD separator, mirroring run.sh. Lets the CMD
                     start with a dash (e.g. ./exec.sh -- my-tool --version).
 
@@ -212,6 +252,8 @@ Examples:
   ./exec.sh htop               # Run htop in devel container
   ./exec.sh ls -la /home       # Run ls in devel container
   ./exec.sh -t runtime bash    # Enter runtime container
+  ./exec.sh bash -c 'ls'       # Auto-detect → -T, no escape leak
+  ./exec.sh -T whoami          # Force -T to cover heuristic-misses case
   ./exec.sh -- my-tool --version  # Use -- to pass a dash-leading CMD
 EOF
       ;;
@@ -236,6 +278,10 @@ main() {
   local TARGET="devel"
   local INSTANCE=""
   DRY_RUN=false
+  # TTY mode resolution (#382): tracks the user's explicit choice with
+  # last-wins precedence between -T (force no-tty) and -i (force tty).
+  # Empty means no explicit choice; auto-detect runs below.
+  local _tty_mode=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -273,6 +319,21 @@ main() {
         set -x
         shift
         ;;
+      -T|--no-tty)
+        # Force no-TTY (#382). Use for one-shot CMDs the auto-detect
+        # heuristic doesn't recognise (`whoami`, `ls /foo`,
+        # `env BAR=1 bash -c '...'`) so terminal escape sequences
+        # (focus-in, bracketed-paste, …) don't echo into output.
+        _tty_mode="no-tty"
+        shift
+        ;;
+      -i|--tty)
+        # Force TTY (#382). Use to override the auto-detect heuristic
+        # when a `bash -c '...'` invocation actually wants a TTY (rare;
+        # e.g. `bash -c 'tput cols'`).
+        _tty_mode="tty"
+        shift
+        ;;
       --lang)
         _LANG="${2:?"--lang requires a value (en|zh-TW|zh-CN|ja)"}"
         _sanitize_lang _LANG "exec"
@@ -296,6 +357,27 @@ main() {
   # arguments containing whitespace, unlike the previous `${CMD}` splitting.
   if [[ $# -eq 0 ]]; then
     set -- bash
+  fi
+
+  # TTY mode resolution (#382, Option 1+2):
+  # - explicit -T/-i (last-wins via _tty_mode set above) takes priority
+  # - else auto-detect: positional CMD `bash|sh|dash|zsh|ash|ksh -c …`
+  #   implies one-shot → no-TTY. Covers the 90% case where users wrap
+  #   their command in `bash -c '…'`. Edge cases (`whoami`, prefixed
+  #   `env BAR=1 bash -c …`) need explicit -T.
+  # - else default: keep TTY (preserves `./exec.sh` / `./exec.sh htop`
+  #   muscle memory).
+  local _exec_extra_args=()
+  if [[ "${_tty_mode}" == "no-tty" ]]; then
+    _exec_extra_args+=(-T)
+  elif [[ "${_tty_mode}" != "tty" ]]; then
+    case "${1:-}" in
+      bash|sh|dash|zsh|ash|ksh)
+        if [[ "${2:-}" == "-c" ]]; then
+          _exec_extra_args+=(-T)
+        fi
+        ;;
+    esac
   fi
 
   # Load .env, derive PROJECT_NAME (sets/exports INSTANCE_SUFFIX too).
@@ -335,7 +417,7 @@ ${_hint}"
     exit 1
   fi
 
-  _compose_project exec "${TARGET}" "$@"
+  _compose_project exec "${_exec_extra_args[@]}" "${TARGET}" "$@"
 }
 
 main "$@"

--- a/test/unit/exec_sh_spec.bats
+++ b/test/unit/exec_sh_spec.bats
@@ -372,3 +372,152 @@ teardown() {
   assert_success
   [[ "${stderr}" == *"+ "* ]]
 }
+
+# ── TTY auto-detect + explicit -T / -i (#382, Option 1+2) ──────────────
+#
+# `docker compose exec` defaults to -it; running a one-shot CMD inherits
+# that TTY so container-side bash echoes terminal escape sequences
+# (focus-in `^[[I`, bracketed-paste, etc.) into stdout. Fix shape:
+#   - auto-detect: positional CMD `bash|sh|dash|zsh|ash|ksh -c ...`
+#     implies no-TTY (the 90% case)
+#   - explicit `-T / --no-tty` forces no-TTY (escape hatch for the
+#     heuristic-misses case, e.g. `whoami`, `env BAR=1 bash -c '...'`)
+#   - explicit `-i / --tty` forces TTY (override for the rare case
+#     where a `bash -c` actually wants a TTY, e.g. `bash -c 'tput cols'`)
+#   - last-wins between -T and -i (standard CLI convention)
+#
+# Verification is via --dry-run path: _compose prints all argv via
+# `printf '%q'` so we can grep for the literal `-T` between `exec` and
+# the target name.
+
+@test "exec.sh --dry-run with no CMD: no -T (default interactive bash entry, #382)" {
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run
+  assert_success
+  assert_output --partial "exec devel"
+  refute_output --partial "exec -T"
+}
+
+@test "exec.sh --dry-run with interactive binary (htop): no -T (auto-detect doesn't fire, #382)" {
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run htop
+  assert_success
+  refute_output --partial "exec -T"
+}
+
+@test "exec.sh --dry-run bash -c '...': auto-detect adds -T (#382 Option 2)" {
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run bash -c 'echo hi'
+  assert_success
+  assert_output --partial "exec -T devel"
+}
+
+@test "exec.sh --dry-run sh -c '...': auto-detect adds -T (#382 Option 2)" {
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run sh -c 'echo hi'
+  assert_success
+  assert_output --partial "exec -T devel"
+}
+
+@test "exec.sh --dry-run dash -c '...': auto-detect adds -T (#382 Option 2)" {
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run dash -c 'echo hi'
+  assert_success
+  assert_output --partial "exec -T devel"
+}
+
+@test "exec.sh --dry-run zsh -c '...': auto-detect adds -T (#382 Option 2)" {
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run zsh -c 'echo hi'
+  assert_success
+  assert_output --partial "exec -T devel"
+}
+
+@test "exec.sh --dry-run bash hello.sh: no -T (no -c → not a one-shot, #382)" {
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run bash hello.sh
+  assert_success
+  refute_output --partial "exec -T"
+}
+
+@test "exec.sh --dry-run -T whoami: explicit -T forces no-TTY (#382 Option 1)" {
+  # Heuristic doesn't fire (whoami isn't bash/sh + -c); explicit -T
+  # covers this leaked-output case.
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run -T whoami
+  assert_success
+  assert_output --partial "exec -T devel"
+}
+
+@test "exec.sh --dry-run --no-tty long form forces no-TTY (#382)" {
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run --no-tty whoami
+  assert_success
+  assert_output --partial "exec -T devel"
+}
+
+@test "exec.sh --dry-run -T env BAR=1 bash -c '...': covers auto-detect's heuristic gap (#382)" {
+  # `env` is the first positional so the bash + -c heuristic misses;
+  # explicit -T is the escape hatch for this case.
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run -T env BAR=1 bash -c 'echo $BAR'
+  assert_success
+  assert_output --partial "exec -T devel"
+}
+
+@test "exec.sh --dry-run -i bash -c '...': explicit -i overrides heuristic (#382 Option 1)" {
+  # User wants TTY for `bash -c 'tput cols'`-style commands; -i wins
+  # over the auto-detect -T.
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run -i bash -c 'tput cols'
+  assert_success
+  refute_output --partial "exec -T"
+}
+
+@test "exec.sh --dry-run --tty long form overrides heuristic (#382)" {
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run --tty bash -c 'tput cols'
+  assert_success
+  refute_output --partial "exec -T"
+}
+
+@test "exec.sh --dry-run -T -i: last-wins gives TTY (#382)" {
+  # Standard CLI last-wins precedence. -T then -i → -i (TTY).
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run -T -i bash -c 'echo hi'
+  assert_success
+  refute_output --partial "exec -T"
+}
+
+@test "exec.sh --dry-run -i -T: last-wins gives no-TTY (#382)" {
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run -i -T bash -c 'echo hi'
+  assert_success
+  assert_output --partial "exec -T devel"
+}
+
+@test "exec.sh --dry-run -T after -t TARGET still attaches to the right service (#382)" {
+  echo "tester-mockimg-headless" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run -t headless -T whoami
+  assert_success
+  assert_output --partial "exec -T headless"
+}
+
+@test "exec.sh --dry-run -- separator: -T propagates, CMD flows through (#382 + #289)" {
+  # The -- separator stops exec.sh option parsing. -T must be BEFORE --.
+  echo "tester-mockimg" > "${DOCKER_PS_FILE}"
+  run bash "${SANDBOX}/exec.sh" --dry-run -T -- my-tool --version
+  assert_success
+  assert_output --partial "exec -T devel"
+  assert_output --partial "my-tool"
+  assert_output --partial "--version"
+}
+
+@test "exec.sh --help mentions -T / --no-tty and -i / --tty flags (#382)" {
+  run bash "${SANDBOX}/exec.sh" --help
+  assert_success
+  assert_output --partial "-T"
+  assert_output --partial "--no-tty"
+  assert_output --partial "-i"
+  assert_output --partial "--tty"
+}


### PR DESCRIPTION
## Summary

Closes #382.

`docker compose exec` defaults to `-it`, so any one-shot CMD inherits
the host terminal's focus-in / bracketed-paste escape sequences (e.g.
`^[[I^[[I`) into stdout. This breaks downstream consumers (grep,
command substitution, log capture).

Picked **Option 1+2** from the issue body: auto-detect the 90% case +
add explicit `-T` / `-i` flags for the edges. Last-wins between the
two explicit flags.

## Three-tier TTY resolution

| Tier | Trigger | Result |
|---|---|---|
| 1. Explicit `-T` / `--no-tty` | flag set last among `-T`/`-i` | `docker compose exec -T` (no TTY) |
| 2. Explicit `-i` / `--tty` | flag set last among `-T`/`-i` | `-it` (TTY, override auto-detect) |
| 3. Auto-detect | first positional ∈ `{bash, sh, dash, zsh, ash, ksh}` AND `$2 == "-c"` | no TTY |
| 4. Default | none of the above | `-it` (preserves `./exec.sh` / `./exec.sh htop` muscle memory) |

## Behaviour matrix

```
./exec.sh                       # tier 4: -it (interactive bash)
./exec.sh htop                  # tier 4: -it (htop wants TTY)
./exec.sh bash -c 'ls /foo'     # tier 3: -T  (auto-detect)
./exec.sh sh -c 'whoami'        # tier 3: -T
./exec.sh whoami                # tier 4: -it  ← still leaks; needs -T
./exec.sh -T whoami             # tier 1: -T  (escape hatch)
./exec.sh -T env BAR=1 bash -c 'echo $BAR'   # tier 1: -T (heuristic-miss)
./exec.sh -i bash -c 'tput cols' # tier 2: -it (override auto-detect)
./exec.sh -T -i bash -c '...'   # tier 2: -it (last-wins → -i)
./exec.sh -i -T bash -c '...'   # tier 1: -T  (last-wins → -T)
```

## Files touched

- `script/docker/exec.sh` — parse `-T`/`--no-tty` and `-i`/`--tty`
  flags into `_tty_mode` (last-wins), then resolve `_exec_extra_args`
  before threading into `_compose_project exec ${_exec_extra_args[@]}
  ${TARGET} "$@"`. 4-language `usage()` blocks updated.
- `test/unit/exec_sh_spec.bats` — 17 new assertions (36 → 53):
  - default no-CMD (TTY)
  - interactive binary `htop` (TTY)
  - 4 shell flavours × `-c` auto-add `-T` (bash / sh / dash / zsh)
  - `bash hello.sh` (no `-c`) keeps TTY
  - explicit `-T`/`--no-tty` forces no-TTY (3 cases: short, long,
    heuristic-miss `env BAR=1 bash -c ...`)
  - explicit `-i`/`--tty` overrides heuristic (short + long)
  - last-wins precedence in both orders
  - `-T` after `-t TARGET` attaches to the right service
  - `-T` round-trip via `--` separator
  - `--help` mentions all four flag spellings
- `doc/test/TEST.md` — exec_sh count 36 → 53 + per-spec description
  extended; total 1398 → 1415.
- `doc/changelog/CHANGELOG.md` — `[Unreleased]` `### Fixed` (the bug)
  + `### Added` (the flags + auto-detect).

## Acceptance vs issue body

- [x] Reproducer / regression coverage — 17 bats unit assertions
      exercising every branch
- [x] Usage / `--help` text updated in all 4 languages
- [x] CHANGELOG `[Unreleased]` entry (non-breaking — Option 1+2 keeps
      `./exec.sh` / `./exec.sh htop` defaults unchanged)
- N/A (Option 3 not chosen) — no downstream README sweep needed

## Test plan

- [ ] `make -f Makefile.ci test` green (1415 tests)
- [ ] CI `ci-rollup` aggregator green
- [ ] Manual smoke: in a running container, run
      `./exec.sh bash -c 'echo hi'` and confirm output is clean
      (no `^[[I` leak)
- [ ] Manual smoke: `./exec.sh htop` still gives an interactive TTY
- [ ] Manual smoke: `./exec.sh -i bash -c 'tput cols'` prints a
      non-zero column count

Refs #382.
