### PR TITLE
ci(build-worker): split buildx GHA cache into 4 per-target scopes (#378 b1)

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -298,19 +298,35 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Compute cache scope
-        # #272 — derive a per-(repo, variant, arch) cache scope key.
-        # ${image_name}[-${cache_variant}]-${matrix.hardware}-cache.
+        # #272 — derive a per-(repo, variant, arch) cache scope base.
+        # ${image_name}[-${cache_variant}]-${matrix.hardware}.
         # See `cache_variant` input description for naming rationale.
         # `matrix.hardware` (x86_64 / aarch64) is preferred over
         # `matrix.platform` (linux/amd64) because some buildx cache
         # backends balk on `/` in scope keys.
+        #
+        # #378 b1 — per-target suffix (`-devel-test-cache`, `-devel-cache`,
+        # `-runtime-test-cache`, `-runtime-cache`) is appended at the use
+        # site (each docker/build-push-action call). Pre-#378 all 4 build
+        # steps shared one `<base>-cache` scope under `mode=max`, so a
+        # late-stage COPY change in devel cascaded the manifest pointer
+        # in the shared scope and invalidated runtime / runtime-test
+        # caches on the next PR (refs the audit in
+        # https://github.com/ycpss91255-docker/base/issues/378). Splitting
+        # by target isolates each chain's manifest history.
+        #
+        # Shape migration cost: every existing scope key is orphaned by
+        # this change — first PR per active downstream pays a 4-way
+        # cold-restart (sequentially, the 4 build steps within one job
+        # share layers in the buildx local store so it's not 4x time).
+        # After that, every PR enjoys isolated per-target caches.
         id: cache
         run: |
           base="${{ inputs.image_name }}"
           if [ -n "${{ inputs.cache_variant }}" ]; then
             base="${base}-${{ inputs.cache_variant }}"
           fi
-          echo "key=${base}-${{ matrix.hardware }}-cache" >> "${GITHUB_OUTPUT}"
+          echo "key=${base}-${{ matrix.hardware }}" >> "${GITHUB_OUTPUT}"
 
       - name: Generate .env
         run: |
@@ -357,8 +373,8 @@ jobs:
           target: devel-test
           platforms: ${{ matrix.platform }}
           push: false
-          cache-from: type=gha,scope=${{ steps.cache.outputs.key }}
-          cache-to: type=gha,scope=${{ steps.cache.outputs.key }},mode=max
+          cache-from: type=gha,scope=${{ steps.cache.outputs.key }}-devel-test-cache
+          cache-to: type=gha,scope=${{ steps.cache.outputs.key }}-devel-test-cache,mode=max
           build-args: |
             USER_NAME=ci
             USER_GROUP=ci
@@ -377,8 +393,8 @@ jobs:
           target: devel
           platforms: ${{ matrix.platform }}
           push: false
-          cache-from: type=gha,scope=${{ steps.cache.outputs.key }}
-          cache-to: type=gha,scope=${{ steps.cache.outputs.key }},mode=max
+          cache-from: type=gha,scope=${{ steps.cache.outputs.key }}-devel-cache
+          cache-to: type=gha,scope=${{ steps.cache.outputs.key }}-devel-cache,mode=max
           build-args: |
             USER_NAME=ci
             USER_GROUP=ci
@@ -411,8 +427,8 @@ jobs:
           target: runtime-test
           platforms: ${{ matrix.platform }}
           push: false
-          cache-from: type=gha,scope=${{ steps.cache.outputs.key }}
-          cache-to: type=gha,scope=${{ steps.cache.outputs.key }},mode=max
+          cache-from: type=gha,scope=${{ steps.cache.outputs.key }}-runtime-test-cache
+          cache-to: type=gha,scope=${{ steps.cache.outputs.key }}-runtime-test-cache,mode=max
           build-args: |
             USER_NAME=ci
             USER_GROUP=ci
@@ -430,8 +446,8 @@ jobs:
           target: runtime
           platforms: ${{ matrix.platform }}
           push: false
-          cache-from: type=gha,scope=${{ steps.cache.outputs.key }}
-          cache-to: type=gha,scope=${{ steps.cache.outputs.key }},mode=max
+          cache-from: type=gha,scope=${{ steps.cache.outputs.key }}-runtime-cache
+          cache-to: type=gha,scope=${{ steps.cache.outputs.key }}-runtime-cache,mode=max
           build-args: |
             USER_NAME=ci
             USER_GROUP=ci

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`build-worker.yaml` buildx GHA cache split into 4 per-target
+  scopes** (#378 b1 mitigation). Pre-#378 all 4 build steps
+  (`devel-test` / `devel` / `runtime-test` / `runtime`) shared one
+  `<image_name>[-<variant>]-<hardware>-cache` scope under `mode=max`,
+  so a late-stage `COPY .base/...` change in `devel` cascaded the
+  shared scope's manifest pointer and invalidated `runtime` /
+  `runtime-test` caches on the next PR. Each target now writes to its
+  own scope: `<base>-devel-test-cache`, `<base>-devel-cache`,
+  `<base>-runtime-test-cache`, `<base>-runtime-cache`. **Migration
+  cost**: every existing GHA cache entry is orphaned by the shape
+  change; first PR per active downstream pays a 4-way cold restart
+  (sequentially within the same build job — the 4 build steps share
+  layers via the buildx local store, so the wall-time hit is
+  meaningfully less than 4×). After that, every PR enjoys
+  per-target-isolated caches. Caller contract (workflow `inputs:`)
+  unchanged. Refs the b1 mitigation direction in the #378 audit
+  comment.
+
 ### Fixed
 
 - **`exec.sh` one-shot commands no longer leak terminal escape

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1415 tests** total (1351 unit + 64 integration).
+Template self-tests: **1416 tests** total (1352 unit + 64 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -187,17 +187,18 @@ target areas the issue body called out.
 | Menu restructure #221 (i18n keys for main.runtime/mounts/features × 4 langs; `_render_runtime_menu` / `_render_mounts_menu` / `_render_features_menu` function existence; main-menu dispatch for image/build/runtime/mounts/features + bare network/deploy/gui/volumes/environment no longer dispatch from main; Runtime sub-menu dispatch for network/deploy/gui/environment + __back/Cancel; Mounts sub-menu dispatch for volumes/devices/tmpfs + __back/Cancel; Features sub-menu __back, per_stage enabled enters editor, per_stage hidden shows msgbox without entering editor; Advanced sub-menu image/build/devices/tmpfs entries removed, security still dispatches) | 31 |
 | #328 logging menu dispatch (Runtime menu's `logging` entry calls `_edit_section_logging`; `_edit_section_logging`'s top-level menu routes `global` to `_edit_logging_keys logging` and `devel` / `test` / `runtime` to `_edit_logging_keys logging.<svc>`) | 5 |
 
-### test/unit/build_worker_yaml_spec.bats (32)
+### test/unit/build_worker_yaml_spec.bats (33)
 
 Structural assertions for `.github/workflows/build-worker.yaml` (#195
-+ #243 + #272 + #273). Reusable workflows are not exec'd by these tests; instead
-grep patterns lock the YAML invariants — `context_path` /
-`dockerfile_path` inputs declared with the right defaults, all 4
-`docker/build-push-action` steps (devel-test / devel / runtime-test /
-runtime after #243) forwarding those inputs, no leftover
-`context: .` / `file: ./Dockerfile` literals, the GHA-cache
-plumbing (#272: `cache_variant` input, `Compute cache scope` step,
-`cache-from` / `cache-to` on all 4 build steps), and the #273
++ #243 + #272 + #273 + #378 b1). Reusable workflows are not exec'd by
+these tests; instead grep patterns lock the YAML invariants —
+`context_path` / `dockerfile_path` inputs declared with the right
+defaults, all 4 `docker/build-push-action` steps (devel-test / devel /
+runtime-test / runtime after #243) forwarding those inputs, no
+leftover `context: .` / `file: ./Dockerfile` literals, the GHA-cache
+plumbing (#272: `cache_variant` input, `Compute cache scope` step;
+#378 b1: per-target scope suffix so a late-stage COPY change in one
+target no longer cascades into siblings' manifests), and the #273
 doc-only PR fast-pass (`path-filter` job; Phase 2 classifier is pure
 shell via `git diff --name-only base...head` + `case` glob, no
 `dorny/paths-filter` dependency; 6-path allowlist; compute-matrix +
@@ -216,7 +217,7 @@ on doc-only PRs).
 | User build-args use long form matching Dockerfile.example sys stage (#198: USER_NAME / USER_GROUP / USER_UID / USER_GID across 4 build steps + no short-form regression) | 5 |
 | `build_contexts` input forwards to docker/build-push-action `build-contexts:` (#207: input declared with empty default, 4 build steps forward, default preserves zero-diff) | 3 |
 | #243 stage rename + runtime-test smoke: `target: devel-test` (renamed from `test`), no leftover `target: test`, `target: runtime-test` exists, runtime-test gated on `inputs.build_runtime` (>=2 occurrences shared with runtime gate) | 4 |
-| #272 GHA buildx cache: `cache_variant` input declared with empty default, `Compute cache scope` step emits `id: cache` + scope key into `GITHUB_OUTPUT`, 4 build steps set `cache-from: type=gha,scope=...`, 4 build steps set `cache-to: ...,mode=max`, default preserves zero-diff for single-call callers | 5 |
+| #272 + #378 b1 GHA buildx cache: `cache_variant` input declared with empty default, `Compute cache scope` step emits `id: cache` + base key (no `-cache` suffix; per-target suffix appended at use site), 4 build steps use per-target `<base>-<target>-cache` scopes (cache-from + cache-to per target), no legacy shared-scope leftover (negative regression), 4 build steps preserve `mode=max`, default preserves zero-diff for single-call callers | 6 |
 | #273 doc-only PR fast-pass (Phase 1 + Phase 2 shell rewrite): `path-filter` job declared, classifier is pure shell (`git diff --name-only base...head` + `case` glob; no `dorny/paths-filter` dependency), reads EVENT_NAME / BASE_SHA / HEAD_SHA from env: keys so the case body stays portable, non-PR event short-circuits before git diff (BASE_SHA / HEAD_SHA empty on push / tag / workflow_dispatch), 6-path allowlist (`**/*.md`, `doc/**`, `LICENSE`, `.gitignore`, `.github/CODEOWNERS`, `.github/dependabot.yml`) in a single `case` arm, `compute-matrix` + `build` jobs gated on `code_changed == 'true'` (2 occurrences), `docker-build` aggregator handles `code_changed == 'false'` short-circuit + `needs: [path-filter, build]`, non-PR triggers always set `code_changed=true` | 8 |
 
 ### test/unit/self_test_yaml_spec.bats (52)

--- a/test/unit/build_worker_yaml_spec.bats
+++ b/test/unit/build_worker_yaml_spec.bats
@@ -208,31 +208,48 @@ setup() {
   assert_output --partial 'default: ""'
 }
 
-@test "build-worker.yaml: Compute cache scope step emits id: cache with scope key in GITHUB_OUTPUT (#272)" {
-  # The step computes `${image_name}[-${cache_variant}]-${hardware}-cache`
-  # once at the top of the build job; all 4 build steps reference the
-  # output. Asserts presence + id so downstream `steps.cache.outputs.key`
-  # references resolve.
+@test "build-worker.yaml: Compute cache scope step emits id: cache with base key in GITHUB_OUTPUT (#272 + #378)" {
+  # The step computes the per-(repo, variant, arch) base
+  # `${image_name}[-${cache_variant}]-${hardware}` once; per-target
+  # suffix (`-devel-test-cache`, `-devel-cache`, `-runtime-test-cache`,
+  # `-runtime-cache`) is appended at the use site. See the b1 mitigation
+  # of #378 for why the shape changed from a single shared `<base>-cache`
+  # scope to 4 per-target scopes.
   run grep -E '^        id: cache$' "${WF}"
   assert_success
-  run grep -E '^          echo "key=\$\{base\}-\$\{\{ matrix\.hardware \}\}-cache" >> "\$\{GITHUB_OUTPUT\}"$' "${WF}"
+  run grep -E '^          echo "key=\$\{base\}-\$\{\{ matrix\.hardware \}\}" >> "\$\{GITHUB_OUTPUT\}"$' "${WF}"
   assert_success
 }
 
-@test "build-worker.yaml: 4 build steps all set cache-from=type=gha (#272)" {
-  # Every docker/build-push-action call must read from the same GHA
-  # scope so feature-branch builds reuse the base branch's cache and
-  # subsequent steps within the same shard share intermediate layers.
-  run grep -c '^          cache-from: type=gha,scope=\${{ steps\.cache\.outputs\.key }}$' "${WF}"
-  assert_success
-  assert_output "4"
+@test "build-worker.yaml: 4 build steps use per-target cache scopes (#378 b1)" {
+  # Pre-#378 all 4 build steps shared `${steps.cache.outputs.key}` so a
+  # late-stage COPY in devel cascaded the manifest pointer in the
+  # shared scope, invalidating runtime / runtime-test caches on the
+  # next PR. Post-#378 each target has its own scope; one scope's
+  # manifest update no longer affects the others.
+  for _target in devel-test devel runtime-test runtime; do
+    run grep -F "cache-from: type=gha,scope=\${{ steps.cache.outputs.key }}-${_target}-cache" "${WF}"
+    assert_success
+    run grep -F "cache-to: type=gha,scope=\${{ steps.cache.outputs.key }}-${_target}-cache,mode=max" "${WF}"
+    assert_success
+  done
 }
 
-@test "build-worker.yaml: 4 build steps all set cache-to=type=gha,...,mode=max (#272)" {
+@test "build-worker.yaml: 4 distinct cache scopes exist, no shared scope leftover (#378 b1)" {
+  # Negative regression: ensure no legacy `cache-from:`/`cache-to:` line
+  # still references the bare base key (which would mean a build step
+  # was missed in the per-target migration).
+  run grep -cE '^          cache-(from|to): type=gha,scope=\$\{\{ steps\.cache\.outputs\.key \}\}(,|$)' "${WF}"
+  [ "${status}" -ne 0 ] || [ "${output}" = "0" ]
+}
+
+@test "build-worker.yaml: 4 build steps all set mode=max on cache-to (#272 preserved)" {
   # mode=max exports all intermediate stage layers (including the heavy
   # builder / source-build stages). The 10 GB GHA quota tradeoff is
-  # accepted; LRU eviction is expected to keep hot paths cached.
-  run grep -c '^          cache-to: type=gha,scope=\${{ steps\.cache\.outputs\.key }},mode=max$' "${WF}"
+  # accepted; LRU eviction is expected to keep hot paths cached. With
+  # per-target scopes (#378 b1) the total storage roughly 4x grows; LRU
+  # still keeps hot paths.
+  run grep -cE '^          cache-to: type=gha,scope=\${{ steps\.cache\.outputs\.key }}-(devel-test|devel|runtime-test|runtime)-cache,mode=max$' "${WF}"
   assert_success
   assert_output "4"
 }
@@ -240,8 +257,8 @@ setup() {
 @test "build-worker.yaml: cache_variant default preserves zero-diff for single-call callers (#272)" {
   # Single-distro repos (agent/* + ros1_bridge-${distro} pattern) leave
   # cache_variant unset; the scope key reduces to
-  # ${image_name}-${hardware}-cache, which is already per-(repo, arch)
-  # and matches the existing matrix shape.
+  # ${image_name}-${hardware}-<target>-cache (#378 b1), which is still
+  # per-(repo, arch) and now also per-target.
   local _cv
   _cv="$(grep -A 3 '^      cache_variant:' "${WF}" | grep 'default:' | head -1)"
   [[ "${_cv}" == *'""'* ]]


### PR DESCRIPTION
## Summary

First mitigation PR for #378 — implements **b1** (per-target cache
scopes) from the audit comment
([#issuecomment-4485134478](https://github.com/ycpss91255-docker/base/issues/378#issuecomment-4485134478)).

Pre-#378 all 4 build steps in `build-worker.yaml` (`devel-test` /
`devel` / `runtime-test` / `runtime`) shared one cache scope
`<image_name>[-<variant>]-<hardware>-cache` under `mode=max`. Each
step re-exported its full layer set into the shared scope, so the
manifest pointer flipped between the targets. A late-stage
`COPY .base/...` change in `devel` reused the shared scope, leaving
the next PR's `runtime` / `runtime-test` `cache-from` with the wrong
manifest and forcing an avoidable cold rebuild. That's p1 in the
audit.

This PR splits the scope by target:

```
<base>-devel-test-cache     <base>-devel-cache
<base>-runtime-test-cache   <base>-runtime-cache
```

`Compute cache scope` step now emits the bare base (drops the legacy
`-cache` suffix); each `docker/build-push-action` step appends its
own `-<target>-cache` suffix at the use site so target / scope
alignment is co-located.

## Migration cost

Every existing GHA cache entry is orphaned by the shape change. First
PR per active downstream pays a **4-way cold restart**, but:

- The 4 build steps run sequentially in the same job and share layers
  via the buildx local content store, so wall-time is meaningfully
  less than 4× a single cold build.
- After the first PR per repo, every subsequent PR enjoys
  per-target-isolated caches — a late COPY change in one target
  invalidates only that target's scope, not its siblings'.

Same one-time cost shape as the #339 dispatcher migration; the
ros1_bridge audit measurements showed that case settled within a
single PR.

## Caller contract

Workflow `inputs:` shape unchanged (`image_name`, `cache_variant`,
etc. — same signature). Every existing caller continues to invoke
`build-worker.yaml` exactly as before; the internal scope-key
construction is the only thing that moves.

## Tests

`test/unit/build_worker_yaml_spec.bats` cache row rewritten
(32 → 33 tests, +1 net):

- Compute step assertion updated to expect the base key without the
  legacy `-cache` suffix
- New: 4 build steps use per-target `<base>-<target>-cache` scopes
  (loops over the 4 targets asserting `cache-from` + `cache-to` per
  target)
- New (negative regression): no leftover `cache.outputs.key` literal
  without a target suffix anywhere in `cache-from` / `cache-to` —
  guards against missing a build step in a future per-target
  migration
- `mode=max` assertion preserved with updated regex
- `cache_variant` default-empty assertion preserved

Full suite green: 1352 unit + 64 integration = **1416 tests** via
`make -f Makefile.ci test`. TEST.md count + per-spec entry updated.
CHANGELOG `[Unreleased] ### Changed` entry calls out the migration
cost.

## Test plan

- [ ] CI: `actionlint` green (yaml syntax)
- [ ] CI: `ci-rollup` aggregator green
- [ ] After merge: first batch-template-upgrade fanout per active
      downstream is expected to be cold for all 4 buildx targets;
      subsequent PRs should warm
- [ ] After 2-3 PRs on a downstream that exercises `runtime` (e.g.
      `app/ros1_bridge`), confirm runtime-stage build wall-time
      stays warm after a `devel`-side COPY change

## Out of scope (per audit)

- **b2** (drop volatile inputs from cache key) — still on the table,
  lower priority; cross-repo cache sharing gain is marginal at the
  current scope profile.
- **b3** (pre-built sub-image for the ros1_bridge catkin builder
  stage, ~13 min warm-cache wall time) — separate PR on
  `app/ros1_bridge` itself; b3's complexity (new
  `builder-image-worker.yaml` reusable + GHCR pin management) is
  contained and only affects the opt-in repo.

Refs #378.
