### PR TITLE
feat(run.sh): auto compose-down on foreground exit (--rm-like)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### BREAKING
+
+- **`./run.sh` foreground exit now auto-tears-down the compose
+  project by default** (#386). Pre-#386: leaving an interactive
+  `./run.sh` session (or any one-shot `-t test` / `-t runtime`
+  invocation) left the container and the compose project's default
+  network on the daemon; users had to run `./stop.sh` separately, and
+  worktree workflows accumulated orphan `<projname>_default` networks
+  when `git worktree remove` deleted the cwd before `./stop.sh` could
+  resolve. Post-#386: a `trap _compose_cleanup EXIT` is installed for
+  every foreground invocation (devel + non-devel) and runs
+  `COMPOSE_PROFILES='*' docker compose ... down --remove-orphans -t 0`
+  — same teardown stop.sh performs — on normal exit, Ctrl-C, and
+  signal. Pass **`--no-rm`** to restore the pre-#386 keep-alive
+  behavior (re-attach later via `./exec.sh`, inspect post-mortem
+  logs). `-d` / `--detach` is unchanged (background lifecycle is
+  already user-managed; the trap is suppressed automatically).
+
 ### Changed
 
 - **`build-worker.yaml` buildx GHA cache split into 4 per-target

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -479,7 +479,7 @@ mention), and **`-v` / `--verbose` / `-vv` / `--very-verbose` flag**
 step output is visible; `-vv` adds `set -x` on the wrapper itself;
 usage help mentions all four spellings).
 
-### test/unit/run_sh_spec.bats (50)
+### test/unit/run_sh_spec.bats (54)
 
 Unit tests for `run.sh`. Mirrors the build_sh_spec.bats harness;
 `docker ps` reads from a controllable stub file so tests can simulate
@@ -500,7 +500,11 @@ before compose up, `--build` after check-drift), and **`-C` / `--chdir`
 flag** (docker_harness#53: redirect FILE_PATH, short + long form,
 value-required and directory guards, usage help mention), and **`-v`
 / `--verbose` / `-vv` / `--very-verbose` flag** (#311: same export +
-trace pattern as build.sh, parity across wrappers).
+trace pattern as build.sh, parity across wrappers), and **#386
+foreground exit auto compose-down** (default-on for devel + one-shot
+non-devel targets, `--no-rm` opts out, `-d` suppresses the trap; the
+trap fires `down --remove-orphans` to mirror stop.sh and close the
+worktree-removed-before-stop network leak).
 
 ### test/unit/exec_sh_spec.bats (53)
 

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -143,8 +143,8 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
-              [-v|--verbose] [-vv|--very-verbose]
+用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [--no-rm] [-s|--setup]
+              [--build] [--dry-run] [-v|--verbose] [-vv|--very-verbose]
               [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
               [-t|--target TARGET] [CMD...]
 
@@ -154,6 +154,11 @@ usage() {
                     若 CMD 中需要字面 -C，可用 -- 分隔。類似 git -C / make -C。
   -t, --target T    Compose service 名稱（預設: devel；例: runtime）
   -d, --detach      背景執行（docker compose up -d，不接受 CMD）
+  --no-rm           關閉 foreground 結束時的自動 compose down (#386)。預設前景
+                    執行結束（含 Ctrl-C / signal）會自動清掉 container + project
+                    default network；--no-rm 保留現有 container/network 供之後
+                    ./exec.sh 重連或檢查 log。-d 本來就由使用者管理 lifecycle，
+                    本旗標對 -d 無作用。
   -s, --setup       強制重跑 setup.sh（互動式 TTY 開 TUI，否則非互動式 apply）。
                     預設（無此旗標）：當 setup.conf / Dockerfile stages / GPU /
                     GUI / USER_UID 漂移時，.env + compose.yaml 自動重新生成 (#88)。
@@ -175,8 +180,8 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
-              [-v|--verbose] [-vv|--very-verbose]
+用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [--no-rm] [-s|--setup]
+              [--build] [--dry-run] [-v|--verbose] [-vv|--very-verbose]
               [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
               [-t|--target TARGET] [CMD...]
 
@@ -186,6 +191,11 @@ EOF
                     若 CMD 中需要字面 -C，可用 -- 分隔。类似 git -C / make -C。
   -t, --target T    Compose service 名称（默认: devel；例: runtime）
   -d, --detach      后台运行（docker compose up -d，不接受 CMD）
+  --no-rm           关闭 foreground 结束时的自动 compose down (#386)。默认前台
+                    执行结束（含 Ctrl-C / signal）会自动清掉 container + project
+                    default network；--no-rm 保留现有 container/network 供之后
+                    ./exec.sh 重连或检查 log。-d 本来就由使用者管理 lifecycle，
+                    本旗标对 -d 无作用。
   -s, --setup       强制重跑 setup.sh（交互式 TTY 开 TUI，否则非交互式 apply）。
                     默认（无此旗标）：当 setup.conf / Dockerfile stages / GPU /
                     GUI / USER_UID 漂移时，.env + compose.yaml 自动重新生成 (#88)。
@@ -207,8 +217,8 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
-               [-v|--verbose] [-vv|--very-verbose]
+使用法: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [--no-rm] [-s|--setup]
+               [--build] [--dry-run] [-v|--verbose] [-vv|--very-verbose]
                [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
                [-t|--target TARGET] [CMD...]
 
@@ -219,6 +229,13 @@ EOF
                     git -C / make -C と同様。
   -t, --target T    Compose サービス名（デフォルト: devel；例: runtime）
   -d, --detach      バックグラウンド実行（docker compose up -d、CMD は受け付けない）
+  --no-rm           foreground 終了時の自動 compose down を無効化 (#386)。
+                    デフォルトでは foreground 実行終了時（Ctrl-C / signal 含む）
+                    に container + project default network を自動で削除します。
+                    --no-rm は現状の container/network を残し、後で ./exec.sh
+                    で再接続したりログを確認できるようにします。-d は本来
+                    ユーザがライフサイクル管理する想定なので、この旗標は -d に
+                    は影響しません。
   -s, --setup       setup.sh を強制実行（インタラクティブ TTY なら TUI、それ以外
                     は非インタラクティブ apply）。デフォルト（フラグ無し）：setup.conf
                     / Dockerfile stages / GPU / GUI / USER_UID が drift した時、
@@ -243,8 +260,8 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [-s|--setup] [--build] [--dry-run]
-               [-v|--verbose] [-vv|--very-verbose]
+Usage: ./run.sh [-h] [-C|--chdir DIR] [-d|--detach] [--no-rm] [-s|--setup]
+               [--build] [--dry-run] [-v|--verbose] [-vv|--very-verbose]
                [--instance NAME] [--lang <en|zh-TW|zh-CN|ja>]
                [-t|--target TARGET] [CMD...]
 
@@ -255,6 +272,13 @@ Options:
                     need a literal -C inside CMD. Mirrors git -C / make -C.
   -t, --target T    Compose service name (default: devel; e.g. runtime)
   -d, --detach      Run in background (docker compose up -d; no CMD accepted)
+  --no-rm           Disable auto compose-down on foreground exit (#386).
+                    By default, exiting a foreground run (including Ctrl-C
+                    or signal) tears down the container + project default
+                    network. Pass --no-rm to keep them around for later
+                    ./exec.sh reattach or log inspection. -d already
+                    leaves lifecycle to the user, so this flag is a no-op
+                    in detached mode.
   -s, --setup       Force rerun setup.sh (opens the TUI on an interactive TTY,
                     otherwise non-interactive apply). Default (no flag):
                     auto-regenerate .env + compose.yaml when setup.conf /
@@ -281,14 +305,35 @@ EOF
   exit 0
 }
 
-# _devel_cleanup tears down the project on shell exit so the container does
-# not outlive the foreground `./run.sh` session.
+# _compose_cleanup tears down the project on shell exit so the container
+# and its compose-project default network do not outlive the foreground
+# `./run.sh` session. Installed via `trap ... EXIT` in foreground mode by
+# default (#386); covers normal exit, Ctrl-C, and signal termination.
 #
-# `down -t 0` skips the default 10s SIGTERM grace period: the user already
-# exited the interactive bash, so there is nothing to drain gracefully —
+# Mirrors stop.sh's _down_one teardown: `COMPOSE_PROFILES='*'` activates
+# every profile-gated service (#341) and `--remove-orphans` catches the
+# default network plus containers from prior compose.yaml shapes. The
+# leak this prevents: worktree workflows where `git worktree remove`
+# wipes the cwd before `./stop.sh` ever runs, leaving the
+# `<projname>_default` network on the daemon forever (#386).
+#
+# `down -t 0` skips the default 10s SIGTERM grace: the user already
+# exited the interactive shell, so there is nothing to drain gracefully —
 # without -t 0 the script appears to hang for ~10s after `exit`.
-_devel_cleanup() {
-  _compose_project down -t 0 >/dev/null 2>&1 || true
+#
+# stdout/stderr are silenced in real mode so the trap stays invisible
+# after a clean foreground exit (compose down's "[+] Removing ..." chatter
+# is noise once the user has already left the shell). Under DRY_RUN the
+# redirect is dropped so the planned `[dry-run] docker compose ... down
+# --remove-orphans` line is actually visible — same convention as the
+# rest of `_compose` callers.
+_compose_cleanup() {
+  if [[ "${DRY_RUN:-false}" == true ]]; then
+    COMPOSE_PROFILES='*' _compose_project down --remove-orphans -t 0 || true
+  else
+    COMPOSE_PROFILES='*' _compose_project down --remove-orphans -t 0 \
+      >/dev/null 2>&1 || true
+  fi
 }
 
 main() {
@@ -307,6 +352,7 @@ main() {
 
   local RUN_SETUP=false
   local DETACH=false
+  local NO_RM=false
   local PRE_BUILD=false
   local TARGET="devel"
   local INSTANCE=""
@@ -356,6 +402,15 @@ main() {
         # skips the test stage entirely). Use this flag to get full
         # local CI parity on a fresh clone.
         PRE_BUILD=true
+        shift
+        ;;
+      --no-rm)
+        # #386: opt out of the auto compose-down on foreground exit.
+        # Default ON; this flag restores the pre-#386 "container/network
+        # stays alive after exit" behavior — useful for re-attaching
+        # via ./exec.sh later or inspecting logs post-mortem. -d already
+        # implies no auto-down (background lifecycle is user-managed).
+        NO_RM=true
         shift
         ;;
       --dry-run)
@@ -555,16 +610,28 @@ ${_parallel}"
     fi
   fi
 
+  # #386: foreground exit auto-down. Default ON for every foreground
+  # target (devel + one-shot stages); opt out via --no-rm. The trap
+  # tears the project down on shell exit, Ctrl-C, or signal — covers
+  # the worktree-removed-before-stop leak case where the cwd that
+  # `./stop.sh` would resolve from no longer exists. -d skips the trap
+  # because background lifecycle is the user's responsibility. The
+  # trap fires under --dry-run too so the "[dry-run] docker compose
+  # ... down --remove-orphans" line is visible in the planned-action
+  # output (no real teardown happens — _compose honors DRY_RUN).
+  if [[ "${DETACH}" != true && "${NO_RM}" != true ]]; then
+    trap _compose_cleanup EXIT
+  fi
+
   if [[ "${DETACH}" == true ]]; then
     _compose_project down 2>/dev/null || true
     _compose_project up -d "${TARGET}"
   elif [[ "${TARGET}" == "devel" ]]; then
     # Foreground devel: `up -d` + `exec` so a second terminal can join via
-    # `./exec.sh`. Trap auto-`down` on exit to preserve the
-    # "exit shell = container gone" semantic of the previous `compose run`.
-    # CMD_ARGS passthrough: empty → `bash` (matches Dockerfile CMD for devel);
-    # non-empty → override (e.g. `./run.sh ls /tmp`).
-    trap _devel_cleanup EXIT
+    # `./exec.sh`. CMD_ARGS passthrough: empty → `bash` (matches
+    # Dockerfile CMD for devel); non-empty → override
+    # (e.g. `./run.sh ls /tmp`). Exit cleanup handled by the
+    # centrally-installed `trap _compose_cleanup EXIT` above (#386).
     _compose_project up -d "${TARGET}"
     if (( ${#CMD_ARGS[@]} > 0 )); then
       _compose_project exec "${TARGET}" "${CMD_ARGS[@]}"

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -305,6 +305,46 @@ EOS
   assert_output --partial "bash"
 }
 
+# ── #386: foreground exit auto compose-down ────────────────────────────────
+# trap _compose_cleanup EXIT is installed for any foreground invocation
+# (devel + one-shot stages). It fires on normal exit, Ctrl-C, and signal.
+# Under --dry-run the trap still fires but _compose only prints, never
+# touches docker, which is what these tests assert against.
+
+@test "run.sh default foreground (devel) installs auto-down trap" {
+  run bash "${SANDBOX}/run.sh" --dry-run
+  assert_success
+  # The trap-fired teardown is distinguishable from the -d branch's
+  # pre-up bare `down` by the --remove-orphans flag mirrored from stop.sh.
+  assert_output --partial "down --remove-orphans"
+}
+
+@test "run.sh foreground non-devel target also installs auto-down trap" {
+  # The pre-#386 trap only covered devel; one-shot stages (runtime / test)
+  # leaked the project default network because `compose run --rm` removes
+  # the container but leaves the network. The central install now covers
+  # both paths.
+  run bash "${SANDBOX}/run.sh" --dry-run -t test
+  assert_success
+  assert_output --partial "down --remove-orphans"
+}
+
+@test "run.sh --no-rm disables auto-down trap" {
+  run bash "${SANDBOX}/run.sh" --dry-run --no-rm
+  assert_success
+  # exec/up still appear; only the trap-fired down is suppressed.
+  refute_output --partial "down --remove-orphans"
+}
+
+@test "run.sh -d does not install auto-down trap" {
+  # Detached mode leaves lifecycle to the user. The pre-up explicit
+  # `down` (bare, no --remove-orphans) still runs to clear any stale
+  # instance, but the trap path must not fire.
+  run bash "${SANDBOX}/run.sh" --dry-run -d
+  assert_success
+  refute_output --partial "down --remove-orphans"
+}
+
 @test "run.sh -d combined with CMD is rejected with exit 2" {
   run bash "${SANDBOX}/run.sh" --dry-run -d ls /tmp
   assert_failure

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -298,21 +298,23 @@ setup() {
   assert_success
 }
 
-@test "run.sh devel branch installs trap to auto-down on exit" {
-  # Refactored: trap calls _devel_cleanup which runs compose down.
-  run grep -E 'trap _devel_cleanup EXIT' /source/script/docker/run.sh
+@test "run.sh foreground installs trap to auto-down on exit" {
+  # #386: trap calls _compose_cleanup which runs compose down. Trap is
+  # installed centrally before the dispatch block so both devel and
+  # non-devel foreground paths get the cleanup; -d / --no-rm opt out.
+  run grep -E 'trap _compose_cleanup EXIT' /source/script/docker/run.sh
   assert_success
-  run grep -E '_devel_cleanup\(\)' /source/script/docker/run.sh
+  run grep -E '_compose_cleanup\(\)' /source/script/docker/run.sh
   assert_success
 }
 
-@test "run.sh _devel_cleanup uses short timeout to avoid 10s grace period" {
-  # Regression: compose down's default 10s SIGTERM grace makes ./run.sh
-  # appear to hang for ~10s after the user exits the bash shell. Interactive
-  # devel doesn't need graceful shutdown — the user already exited.
-  run grep -E '_devel_cleanup\(\)' /source/script/docker/run.sh
+@test "run.sh _compose_cleanup uses --remove-orphans + short timeout" {
+  # #386: aligned with stop.sh's _down_one so worktree-removed-before-stop
+  # network leaks get caught. -t 0 skips the default 10s SIGTERM grace
+  # period (user already exited the foreground shell — nothing to drain).
+  run grep -E '_compose_cleanup\(\)' /source/script/docker/run.sh
   assert_success
-  run grep -E 'down -t 0|down --timeout 0' /source/script/docker/run.sh
+  run grep -E 'down --remove-orphans -t 0|down -t 0 --remove-orphans' /source/script/docker/run.sh
   assert_success
 }
 


### PR DESCRIPTION
Closes #386.

## Summary

Foreground `./run.sh` exit now auto-tears-down the compose project by default — same teardown `./stop.sh` performs. Closes the worktree-removed-before-stop leak (every worktree-keyed `<projname>_default` network accumulated on the daemon because `git worktree remove` wipes the cwd before `./stop.sh` can resolve project name from it).

- **Trap install**: centrally before the dispatch block, gated on `DETACH != true && NO_RM != true`. Covers devel (was already partial pre-#386) AND non-devel one-shot stages (was uncovered — `compose run --rm` removes the container but leaves the network).
- **Cleanup body**: `COMPOSE_PROFILES='*' docker compose ... down --remove-orphans -t 0` — mirrors `stop.sh`'s `_down_one`. `--remove-orphans` is what closes the network leak; `COMPOSE_PROFILES='*'` activates profile-gated services so they get torn down too (#341 parity).
- **`--no-rm` escape hatch**: keep the pre-#386 keep-alive behavior for the re-attach / log-inspect use case.
- **`-d` / `--detach`** unchanged: background lifecycle is already user-managed, trap suppressed.

## Why

Issue #386 reproducer: every `git worktree add ... feat/foo` directory runs `./run.sh` once during development. If the worktree is later removed via `git worktree remove`, the cwd that `./stop.sh` would resolve from no longer exists, and the main checkout's `./stop.sh` computes a different project name so it can't reach the orphan. Networks accumulate. One dev box hit 3-4 leaked `<projname>_default` networks before noticing.

Acceptance criteria from #386:

- [x] `./run.sh` foreground exit auto-runs compose down (container + network cleaned)
- [x] `./run.sh -d` unchanged
- [x] `./run.sh --no-rm` matches pre-#386 keep-alive behavior
- [x] Ctrl-C / signal also triggers auto-down (trap on EXIT covers all paths)
- [x] bats tests cover the 4 cases above
- [x] `usage` / `--help` updated in 4 languages (en / zh-TW / zh-CN / ja)
- [x] CHANGELOG `[Unreleased]` BREAKING entry + `--no-rm` documented

## Test plan

- [x] `make -f Makefile.ci test` — 1420 ok / 0 fail (was 1356 pre-PR; +4 new run_sh_spec cases + the renamed template_spec.bats pair migrates from `_devel_cleanup` → `_compose_cleanup`)
- [x] ShellCheck (via test stage) — clean
- [ ] Manual smoke after merge: `./run.sh` in worktree, `exit`, confirm `docker network ls` does not show `<projname>_default`
- [ ] Manual smoke: `./run.sh --no-rm`, `exit`, confirm container + network survive; then `./stop.sh` cleans
- [ ] Manual smoke: `./run.sh -t test`, completes, confirm network cleaned

## Downstream impact

- This is a **Y (minor) bump** under the v0.X.Y scheme (user-visible default change). Cut after merge alongside any other [Unreleased] entries.
- Downstream consumers pull the bump via `make -f Makefile.ci upgrade VERSION=vX.Y.0` — no manual migration on their side; the `--no-rm` flag is opt-in.
- Existing `./stop.sh` continues to work; the change only adds an automatic call when the user previously had to invoke it manually.

## Out of scope (per #386 issue body)

- `stop.sh --gc` daemon-wide orphan sweep
- `build.sh` post-build image cleanup (separate issue #387)
- `run.sh -d` auto-cleanup
- buildx cache / named volume cleanup
