### PR TITLE
feat(build.sh): auto-prune predecessor image after successful build

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### BREAKING
 
+- **`./build.sh` now auto-prunes the displaced predecessor image after
+  a successful build** (#387). Pre-#387: every rebuild that moved the
+  same tag (e.g. `mockuser/mockimg:devel`) left the old image ID
+  dangling as `<none>:<none>` on the daemon; one dev box accumulated
+  281 images / 357 GB / 200+ dangling before anyone noticed. Post-#387:
+  build.sh snapshots the tag's image ID before invoking
+  `_compose_project build`, and on success runs `docker rmi <old-id>`
+  iff (a) the ID actually moved AND (b) no other tag still references
+  the old ID. Surgical scope — only the image we just displaced; never
+  touches the buildx cache (use `prune.sh --builder` for that), other
+  repos' tagged images, or volumes. Pass **`--no-prune`** to opt out
+  (keep the previous version around for rollback / debug-diff).
+  First-build, cache-hit no-op, multi-tag, and build-failure paths are
+  all guarded — no rmi attempted in those cases. Under `--dry-run` a
+  `[dry-run] docker rmi <old-id-of <tag> if displaced>` line surfaces
+  for visibility without touching the daemon.
+
 - **`./run.sh` foreground exit now auto-tears-down the compose
   project by default** (#386). Pre-#386: leaving an interactive
   `./run.sh` session (or any one-shot `-t test` / `-t runtime`

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -479,6 +479,30 @@ mention), and **`-v` / `--verbose` / `-vv` / `--very-verbose` flag**
 step output is visible; `-vv` adds `set -x` on the wrapper itself;
 usage help mentions all four spellings).
 
+### test/unit/build_sh_prune_spec.bats (7)
+
+Unit tests for `build.sh`'s #387 post-build prune-predecessor logic.
+Separate spec so the docker stub can be tailored to image-inspect /
+images-filter / rmi semantics without bloating the default
+build_sh_spec stub (which only logs argv). Smart docker stub branches
+on `image inspect` (returns `DOCKER_INSPECT_PRE_ID` on the first call,
+`DOCKER_INSPECT_POST_ID` on the second — defaults to PRE_ID for the
+cache-hit case), `images --filter reference=<id>` (emits the
+`<none>:<none>` self-entry plus `DOCKER_IMAGES_OUTPUT` lines so the
+multi-tag-still-references case can be simulated), and `rmi` (appends
+the id to `DOCKER_RMI_LOG` so tests assert presence/absence).
+
+Covers: first-build path (`docker image inspect` exits 1 → no
+`_pre_build_id` → prune skipped, no rmi), cache-hit rebuild
+(`pre == post` → cache-hit guard returns early), successful displaced
+rebuild (`pre != post`, old id has no other tag → `docker rmi
+<old-id>` fires), multi-tag guard (old id still referenced elsewhere
+→ "skip prune: predecessor still tagged" log + no rmi), `--no-prune`
+opt-out (no inspect calls + no rmi even when ids would have moved),
+`--dry-run` (planned-action line `[dry-run] docker rmi <old-id-of ...
+if displaced>` visible + zero real rmi), and `--help` mentions the
+`--no-prune` flag.
+
 ### test/unit/run_sh_spec.bats (54)
 
 Unit tests for `run.sh`. Mirrors the build_sh_spec.bats harness;

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -121,7 +121,7 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
+用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--no-prune] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
 
 選項:
   -h, --help     顯示此說明
@@ -135,6 +135,11 @@ usage() {
                  + .env.bak；需確認，可用 -y 跳過）。之後會自動重跑 setup。
   -y, --yes      略過 --reset-conf 的互動確認
   --no-cache     強制不使用 cache 重建
+  --no-prune     關閉成功 build 後自動清掉被取代的舊 image (#387)。預設行為:
+                 若新 build 更新了同名 tag 且舊 ID 沒被其他 tag 引用,會 docker
+                 rmi 它，避免 dangling <none>:<none> 累積。--no-prune 保留舊
+                 image 供 rollback / debug。Buildx cache 不受影響（要清用
+                 prune.sh --builder）。
   --clean-tools  build 結束後移除 test-tools:local image（預設保留以加速下次 build）
   --dry-run      只印出將執行的 docker 指令，不實際執行
   -v, --verbose  詳細 docker 輸出（BUILDKIT_PROGRESS=plain）。build 卡住時用 —
@@ -155,7 +160,7 @@ EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
+用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--no-prune] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
 
 选项:
   -h, --help     显示此说明
@@ -169,6 +174,11 @@ EOF
                  + .env.bak；需确认，可用 -y 跳过）。之后会自动重跑 setup。
   -y, --yes      跳过 --reset-conf 的交互确认
   --no-cache     强制不使用 cache 重建
+  --no-prune     关闭成功 build 后自动清掉被取代的旧 image (#387)。默认行为:
+                 若新 build 更新了同名 tag 且旧 ID 没被其他 tag 引用,会 docker
+                 rmi 它，避免 dangling <none>:<none> 累积。--no-prune 保留旧
+                 image 供 rollback / debug。Buildx cache 不受影响（要清用
+                 prune.sh --builder）。
   --clean-tools  build 结束后移除 test-tools:local image（默认保留以加速下次 build）
   --dry-run      只打印将执行的 docker 命令，不实际执行
   -v, --verbose  详细 docker 输出（BUILDKIT_PROGRESS=plain）。build 卡住时用 —
@@ -189,7 +199,7 @@ EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
+使用法: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--no-prune] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
 
 オプション:
   -h, --help     このヘルプを表示
@@ -205,6 +215,12 @@ EOF
                  その後 setup を再実行。
   -y, --yes      --reset-conf の確認プロンプトをスキップ
   --no-cache     キャッシュを使わず強制リビルド
+  --no-prune     ビルド成功後の自動 prune-predecessor を無効化 (#387)。デフォル
+                 ト動作: 新しいビルドが同一タグの ID を更新し、旧 ID を他のタグ
+                 が参照していない場合に `docker rmi` で削除 — dangling
+                 `<none>:<none>` の累積を防ぎます。--no-prune は旧 image を残
+                 し、ロールバック / 比較デバッグに使えます。Buildx cache は触れ
+                 ません（`prune.sh --builder` を使用）。
   --clean-tools  build 終了後に test-tools:local image を削除（デフォルトは保持）
   --dry-run      実行される docker コマンドを表示するのみ（実行はしない）
   -v, --verbose  docker の詳細出力（BUILDKIT_PROGRESS=plain）。build がハング
@@ -226,7 +242,7 @@ EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
+Usage: ./build.sh [-h] [-C|--chdir DIR] [-s|--setup] [--reset-conf] [-y|--yes] [--no-cache] [--no-prune] [--clean-tools] [--dry-run] [-v|--verbose] [-vv|--very-verbose] [--lang <en|zh-TW|zh-CN|ja>] [-t|--target TARGET] [TARGET]
 
 Options:
   -h, --help     Show this help
@@ -245,6 +261,14 @@ Options:
                  the fresh conf.
   -y, --yes      Skip the --reset-conf confirmation prompt
   --no-cache     Force rebuild without cache
+  --no-prune     Disable post-build auto-prune of the displaced predecessor
+                 image (#387). By default, if a successful build moves the
+                 tag's image ID and the old ID is no longer referenced by
+                 any other tag, build.sh runs `docker rmi <old-id>` so
+                 dangling <none>:<none> images do not accumulate. Pass
+                 --no-prune to keep the previous image for rollback /
+                 diff-debug. Buildx cache is never touched (use
+                 `prune.sh --builder` for that).
   --clean-tools  Remove test-tools:local image after build (default: keep for faster next build)
   --dry-run      Print the docker commands that would run, but do not execute
   -v, --verbose  Verbose docker output (BUILDKIT_PROGRESS=plain). Use when a
@@ -292,6 +316,7 @@ main() {
   local RESET_CONF=false
   local ASSUME_YES=false
   local NO_CACHE=false
+  local NO_PRUNE=false
   local -a SETUP_FORWARD_ARGS=()
   local CLEAN_TOOLS=false
   local TARGET="devel"
@@ -343,6 +368,14 @@ main() {
         ;;
       --no-cache)
         NO_CACHE=true
+        shift
+        ;;
+      --no-prune)
+        # #387: opt out of post-build auto-prune of the displaced
+        # predecessor image. Default ON; this flag keeps the previous
+        # image around for rollback / debug diffing. Never touches the
+        # buildx cache (see prune.sh --builder for that).
+        NO_PRUNE=true
         shift
         ;;
       --clean-tools)
@@ -549,7 +582,72 @@ main() {
   local _compose_args=()
   [[ "${NO_CACHE}" == true ]] && _compose_args+=(--no-cache)
 
+  # #387: snapshot the existing tag's image ID before the build, so a
+  # successful rebuild that displaces the tag (`old_id != new_id`) can
+  # surgically `docker rmi` the displaced layer set. The check is
+  # guarded by:
+  #   - first build (tag absent) → `old_id` is empty → skip
+  #   - cache-hit no-op (`old_id == new_id`) → skip
+  #   - `old_id` still tagged by another reference → `docker rmi` would
+  #     refuse without `-f`; we detect this and skip
+  #   - build failure → `set -e` aborts main before the prune block runs
+  #   - `--dry-run` / `--no-prune` → print or skip
+  # The buildx cache is intentionally untouched (use `prune.sh --builder`
+  # for that). Tag shape mirrors run.sh's `_full_tag` (#322).
+  local _full_tag="${DOCKER_HUB_USER:-local}/${IMAGE_NAME}:${TARGET}"
+  local _pre_build_id=""
+  if [[ "${NO_PRUNE}" != true && "${DRY_RUN}" != true ]]; then
+    _pre_build_id="$(docker image inspect --format '{{.Id}}' \
+      "${_full_tag}" 2>/dev/null || true)"
+  fi
+
   _compose_project build "${_compose_args[@]}" "${TARGET}"
+
+  if [[ "${NO_PRUNE}" != true && "${DRY_RUN}" != true \
+      && -n "${_pre_build_id}" ]]; then
+    _prune_predecessor "${_full_tag}" "${_pre_build_id}"
+  elif [[ "${NO_PRUNE}" != true && "${DRY_RUN}" == true ]]; then
+    # Surface the planned action under --dry-run so the user can see
+    # the prune step would have fired. Tag-only message (no real IDs
+    # available without a daemon round-trip).
+    printf '[dry-run] docker rmi <old-id-of %s if displaced>\n' "${_full_tag}"
+  fi
+}
+
+# _prune_predecessor removes the displaced predecessor image after a
+# successful build, IFF (a) the tag's ID actually moved AND (b) no other
+# tag still references the old ID. Wrapped in `|| true` so a transient
+# daemon error never bubbles up after a successful build.
+#
+# Args:
+#   $1 _full_tag      the rebuilt tag (e.g. user/image:devel)
+#   $2 _pre_build_id  the image ID this tag pointed at before the build
+_prune_predecessor() {
+  local _full_tag="${1:?_prune_predecessor requires _full_tag}"
+  local _pre_build_id="${2:?_prune_predecessor requires _pre_build_id}"
+  local _post_build_id
+  _post_build_id="$(docker image inspect --format '{{.Id}}' \
+    "${_full_tag}" 2>/dev/null || true)"
+  # Build produced no image (compose `build` is a no-op when the
+  # service has no Dockerfile, etc.) → nothing to compare against.
+  [[ -z "${_post_build_id}" ]] && return 0
+  # Cache-hit / no-op rebuild → same ID, nothing to prune.
+  [[ "${_pre_build_id}" == "${_post_build_id}" ]] && return 0
+  # If the pre-build ID still has any other tag pointing to it, leave
+  # it alone — `docker rmi <id>` would refuse without -f, and a force
+  # delete would unexpectedly untag the alias. Filter excludes the
+  # `<none>:<none>` self-entry produced by docker images when the ID
+  # has no tags besides ours.
+  local _other_tags
+  _other_tags="$(docker images --format '{{.Repository}}:{{.Tag}}' \
+    --filter "reference=${_pre_build_id}" 2>/dev/null \
+    | grep -v '^<none>:<none>$' || true)"
+  if [[ -n "${_other_tags}" ]]; then
+    _log_info build "skip prune: predecessor still tagged (${_other_tags})"
+    return 0
+  fi
+  _log_info build "pruning displaced predecessor ${_pre_build_id:7:12}"
+  docker rmi "${_pre_build_id}" >/dev/null 2>&1 || true
 }
 
 main "$@"

--- a/test/unit/build_sh_prune_spec.bats
+++ b/test/unit/build_sh_prune_spec.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+#
+# Unit tests for build.sh's #387 post-build prune-predecessor logic.
+# Separate spec so the docker stub can be tailored to image-inspect /
+# images-filter / rmi semantics without bloating build_sh_spec.bats's
+# default stub (which only logs args).
+#
+# Stub control env vars (read per-invocation by the smart docker stub):
+#   DOCKER_INSPECT_PRE_ID    image ID returned by `docker image inspect`
+#                            BEFORE the build (empty → exit 1, simulating
+#                            "no prior image")
+#   DOCKER_INSPECT_POST_ID   image ID returned AFTER `_compose_project
+#                            build` finishes. Defaults to DOCKER_INSPECT_PRE_ID
+#                            if unset (cache-hit no-op).
+#   DOCKER_IMAGES_OUTPUT     newline-delimited tag list returned by
+#                            `docker images --filter reference=<id>`.
+#                            `<none>:<none>` is the self-entry the stub
+#                            always emits; populate with extra lines to
+#                            simulate "other tag still references old ID".
+#   DOCKER_RMI_LOG           file that captures every `docker rmi <id>`
+#                            call so tests can assert the rmi did (or
+#                            did not) fire.
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+
+  # shellcheck disable=SC2154
+  TEMP_DIR="$(mktemp -d)"
+  export TEMP_DIR
+
+  SANDBOX="${TEMP_DIR}/repo"
+  mkdir -p "${SANDBOX}/.base/script/docker/lib" \
+           "${SANDBOX}/config/docker"
+
+  cp /source/script/docker/_lib.sh  "${SANDBOX}/.base/script/docker/_lib.sh"
+  cp /source/script/docker/i18n.sh  "${SANDBOX}/.base/script/docker/i18n.sh"
+  cp /source/script/docker/lib/*.sh "${SANDBOX}/.base/script/docker/lib/"
+  ln -s /source/script/docker/build.sh "${SANDBOX}/build.sh"
+
+  MOCK_SETUP_LOG="${TEMP_DIR}/setup.log"
+  export MOCK_SETUP_LOG
+
+  # Mock setup.sh — seeds .env so _load_env succeeds and DOCKER_HUB_USER
+  # / IMAGE_NAME are present for the _full_tag computation in build.sh.
+  cat > "${SANDBOX}/.base/script/docker/setup.sh" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+_subcmd="apply"
+case "${1:-}" in
+  check-drift) _subcmd="check-drift"; shift ;;
+  apply)       shift ;;
+esac
+_base=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-path) _base="$2"; shift 2 ;;
+    --lang)      shift 2 ;;
+    *)           shift ;;
+  esac
+done
+case "${_subcmd}" in
+  check-drift) exit 0 ;;
+  apply)
+    printf 'setup.sh invoked --base-path %s\n' "${_base}" >> "${MOCK_SETUP_LOG}"
+    {
+      echo "USER_NAME=tester"
+      echo "IMAGE_NAME=mockimg"
+      echo "DOCKER_HUB_USER=mockuser"
+    } > "${_base}/.env"
+    echo "# mock compose" > "${_base}/compose.yaml"
+    ;;
+esac
+EOS
+  chmod +x "${SANDBOX}/.base/script/docker/setup.sh"
+
+  BIN_DIR="${TEMP_DIR}/bin"
+  mkdir -p "${BIN_DIR}"
+  DOCKER_RMI_LOG="${TEMP_DIR}/rmi.log"
+  export DOCKER_RMI_LOG
+  : > "${DOCKER_RMI_LOG}"
+  INSPECT_CALL_COUNTER="${TEMP_DIR}/inspect_calls"
+  export INSPECT_CALL_COUNTER
+  : > "${INSPECT_CALL_COUNTER}"
+
+  # Smart docker stub. Branches:
+  #   image inspect → first call returns DOCKER_INSPECT_PRE_ID, second
+  #     returns DOCKER_INSPECT_POST_ID (defaults to PRE_ID for
+  #     cache-hit). Empty PRE_ID → exit 1 (tag absent).
+  #   images --filter reference=<id> → emit DOCKER_IMAGES_OUTPUT (one
+  #     tag per line) prefixed with the self-entry `<none>:<none>` line
+  #     that the build.sh grep filter strips out.
+  #   rmi → append the id to DOCKER_RMI_LOG.
+  #   any other verb (compose build / build / ...) → no-op exit 0.
+  cat > "${BIN_DIR}/docker" <<'EOS'
+#!/usr/bin/env bash
+set -uo pipefail
+if [[ "${1:-}" == "image" && "${2:-}" == "inspect" ]]; then
+  # Count which inspect call this is (pre vs post build).
+  _n="$(($(wc -l < "${INSPECT_CALL_COUNTER}") + 1))"
+  printf '%s\n' "${_n}" >> "${INSPECT_CALL_COUNTER}"
+  if [[ "${_n}" == "1" ]]; then
+    _id="${DOCKER_INSPECT_PRE_ID:-}"
+  else
+    _id="${DOCKER_INSPECT_POST_ID:-${DOCKER_INSPECT_PRE_ID:-}}"
+  fi
+  [[ -z "${_id}" ]] && exit 1
+  printf '%s\n' "${_id}"
+  exit 0
+fi
+if [[ "${1:-}" == "images" ]]; then
+  printf '<none>:<none>\n'
+  if [[ -n "${DOCKER_IMAGES_OUTPUT:-}" ]]; then
+    printf '%s\n' "${DOCKER_IMAGES_OUTPUT}"
+  fi
+  exit 0
+fi
+if [[ "${1:-}" == "rmi" ]]; then
+  shift
+  printf '%s\n' "$*" >> "${DOCKER_RMI_LOG}"
+  exit 0
+fi
+# compose / build / anything else: silent success.
+exit 0
+EOS
+  chmod +x "${BIN_DIR}/docker"
+
+  export PATH="${BIN_DIR}:${PATH}"
+}
+
+teardown() {
+  rm -rf "${TEMP_DIR}"
+}
+
+# ── #387 prune-predecessor cases ──────────────────────────────────────────
+
+@test "build.sh first build (no prior image) skips prune" {
+  # Pre-build inspect returns exit 1 (tag absent) → _pre_build_id empty
+  # → prune branch never enters _prune_predecessor.
+  unset DOCKER_INSPECT_PRE_ID DOCKER_INSPECT_POST_ID DOCKER_IMAGES_OUTPUT
+  run bash "${SANDBOX}/build.sh"
+  assert_success
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "build.sh cache-hit rebuild (same id) skips prune" {
+  # Pre and post inspect return the SAME id → _prune_predecessor early
+  # returns at the cache-hit guard.
+  export DOCKER_INSPECT_PRE_ID="sha256:aaaa000000000000000000000000000000000000000000000000000000000000"
+  # POST defaults to PRE when unset
+  run bash "${SANDBOX}/build.sh"
+  assert_success
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "build.sh successful rebuild with displaced id rmi's old id" {
+  # Pre = old id, post = new id, no other tag points at old → rmi fires.
+  export DOCKER_INSPECT_PRE_ID="sha256:aaaa000000000000000000000000000000000000000000000000000000000000"
+  export DOCKER_INSPECT_POST_ID="sha256:bbbb000000000000000000000000000000000000000000000000000000000000"
+  export DOCKER_IMAGES_OUTPUT=""  # only the <none>:<none> self-entry
+  run bash "${SANDBOX}/build.sh"
+  assert_success
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output --partial "sha256:aaaa"
+}
+
+@test "build.sh skips prune when old id still tagged by another reference" {
+  # Pre = old id, post = new id, BUT docker images shows another tag
+  # also pointing at old id (multi-tag scenario) → no rmi.
+  export DOCKER_INSPECT_PRE_ID="sha256:aaaa000000000000000000000000000000000000000000000000000000000000"
+  export DOCKER_INSPECT_POST_ID="sha256:bbbb000000000000000000000000000000000000000000000000000000000000"
+  export DOCKER_IMAGES_OUTPUT="mockuser/mockimg:legacy"
+  run bash "${SANDBOX}/build.sh"
+  assert_success
+  assert_output --partial "skip prune: predecessor still tagged"
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "build.sh --no-prune skips prune even when id displaced" {
+  # Same scenario as the rmi-fires case, but --no-prune short-circuits
+  # before either inspect call runs.
+  export DOCKER_INSPECT_PRE_ID="sha256:aaaa000000000000000000000000000000000000000000000000000000000000"
+  export DOCKER_INSPECT_POST_ID="sha256:bbbb000000000000000000000000000000000000000000000000000000000000"
+  run bash "${SANDBOX}/build.sh" --no-prune
+  assert_success
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "build.sh --dry-run prints planned prune step + does not rmi" {
+  # Dry-run surfaces the planned prune line for visibility but does
+  # not invoke docker rmi.
+  export DOCKER_INSPECT_PRE_ID="sha256:aaaa000000000000000000000000000000000000000000000000000000000000"
+  export DOCKER_INSPECT_POST_ID="sha256:bbbb000000000000000000000000000000000000000000000000000000000000"
+  run bash "${SANDBOX}/build.sh" --dry-run
+  assert_success
+  assert_output --partial "[dry-run] docker rmi <old-id-of"
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "build.sh --help mentions --no-prune (#387)" {
+  run bash "${SANDBOX}/build.sh" --help
+  assert_success
+  assert_output --partial "--no-prune"
+}


### PR DESCRIPTION
Closes #387.

## Summary

`./build.sh` now auto-prunes the displaced predecessor image after every successful build, closing the dangling `<none>:<none>` accumulation that frequent dev iteration (multi-stage builds + repeated rebuilds of the same tag) produces. One dev box hit 281 images / 357 GB / 200+ dangling before the leak was visible.

- **Snapshot + compare**: `docker image inspect --format '{{.Id}}' "${DOCKER_HUB_USER:-local}/${IMAGE_NAME}:${TARGET}"` before `_compose_project build`, again after. Rmi only fires if the IDs differ AND the old ID is not referenced by any other tag.
- **Surgical scope**: never touches the buildx cache (use `prune.sh --builder`), other repos' tagged images, volumes, or anything besides the one image we just displaced.
- **Five guarded short-circuit paths**:
  - first build (tag absent → `_pre_build_id` empty) → no rmi
  - cache-hit no-op (`pre == post`) → no rmi
  - multi-tag (`docker images --filter reference=<old-id>` has another tag) → log `skip prune: predecessor still tagged` + no rmi
  - build failure → `set -e` aborts main before the prune block runs
  - `--no-prune` flag → skip the snapshot + the rmi entirely
- **`--no-prune` escape hatch**: keep the previous image around for rollback / diff-debug.
- **`--dry-run`** prints one `[dry-run] docker rmi <old-id-of <tag> if displaced>` planned-action line for visibility, no real rmi.

## Why

Issue #387 reproducer: rebuild the same tag N times → N-1 dangling images. `docker image prune` reclaims them but is manual, daemon-wide (can touch other repos' artifacts), and only runs when the user remembers. `build.sh` is the only point that knows exactly which image just got displaced, so it does the most surgical possible cleanup with zero impact on anything else on the daemon.

Acceptance criteria from #387:

- [x] After a second build, the previous image is removed and disk reclaimed
- [x] First build (no prior image) → no error, build completes normally
- [x] Build failure → no prune attempted (fail-fast)
- [x] No-op rebuild (cache hit 100%) → no prune
- [x] `old_id` referenced by another tag → no prune
- [x] `./build.sh --no-prune` matches pre-#387 keep-dangling behavior
- [x] Buildx cache untouched
- [x] bats unit tests cover all six cases (+ `--help` flag mention as a seventh)
- [x] `usage` / `--help` updated in 4 languages
- [x] CHANGELOG `[Unreleased]` BREAKING entry + `--no-prune` documented

## Test plan

- [x] `make -f Makefile.ci test` — 1427 ok / 0 fail (1420 pre-PR + 7 new build_sh_prune_spec.bats)
- [x] ShellCheck (via test stage) — clean
- [ ] Manual smoke after merge: `./build.sh devel` twice with a touched Dockerfile between → confirm `docker images -f dangling=true` does NOT grow
- [ ] Manual smoke: `./build.sh --no-prune devel` twice → confirm the displaced image stays (`docker images | grep <none>` increases by one)
- [ ] Manual smoke: tag the existing image with a second name (`docker tag user/img:devel user/img:legacy`), then rebuild → confirm the multi-tag guard logs `skip prune: predecessor still tagged` and no rmi runs

## Downstream impact

- This is a **Y (minor) bump** alongside #386 in the same `[Unreleased]` window. Cut as the next minor (e.g. v0.33.0) after this merges.
- Downstream consumers receive the change via `make -f Makefile.ci upgrade VERSION=vX.Y.0`. No migration required; `--no-prune` is opt-in.
- The Dockerfile + compose.yaml shape is unchanged — this is a wrapper-side behavioral addition only.

## Out of scope (per #387 issue body)

- Buildx cache cleanup (use `prune.sh --builder`)
- Historical dangling images (already accumulated before this lands) — run `./prune.sh --images` once to clean
- Dockerfile LABEL marking to broaden "historical dangling-of-ours" detection
- `./run.sh` exit auto-down — landed separately in #386 / PR #389
- worktree-orphan tagged image cleanup → tracked in #388
