### PR TITLE
feat(prune.sh): --worktree-orphans surgically removes removed-worktree images

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`./prune.sh --worktree-orphans`** (#388). New opt-in mode that
+  removes tagged images left behind by removed worktrees. Algorithm:
+  for each tagged image matching `<owner>/<name>-<suffix>:<tag>` where
+  `<owner>` equals the current `DOCKER_HUB_USER` (loaded from `.env`
+  or detected via the same chain `setup.sh` uses), check if
+  `<workspace>/worktree/<name>-<suffix>/` exists — if not, the
+  worktree is gone and the tagged image is an orphan. `docker image
+  prune` cannot reach these (not dangling), and `docker system prune
+  -a` is too aggressive (kills every idle tagged image on the
+  daemon). Closes the leak case for the multi-worktree workflow where
+  `git worktree remove` wipes the cwd before the image is cleaned.
+
+  Safety gates: bare-name images (no `<owner>/` prefix) and images
+  owned by a different `<other>/` prefix are **always skipped** —
+  ownership cannot be confirmed, so we refuse to delete. Cleaning
+  those is left to manual `docker rmi`.
+
+  Companion flags:
+  - `--workspace <dir>` to point at the workspace root (defaults to
+    `WS_PATH` from `.env` when run from a repo with one).
+  - `--owner <name>` to override the detected owner (rare; useful
+    when migrating images between machines).
+  - `--repo <name>` (repeatable) to scope the scan to a specific repo
+    basename — only `<owner>/<name>-*` candidates considered.
+  - `-y` / `--dry-run` honored same as the existing prune flags.
+
+  Not included in `--all` (requires workspace + filesystem context
+  that the bulk prune doesn't have). Chain explicitly:
+  `./prune.sh --all --worktree-orphans`.
+
 ### BREAKING
 
 - **`./build.sh` now auto-prunes the displaced predecessor image after

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -588,7 +588,7 @@ down — `docker network prune --filter until=10m` + `docker image prune
 found; usage help mentions `--prune` with the two grace windows; the
 plain `stop.sh --dry-run` path emits no `docker prune` commands).
 
-### test/unit/prune_sh_spec.bats (23)
+### test/unit/prune_sh_spec.bats (36)
 
 Unit tests for the new `script/docker/prune.sh` wrapper (#319) — atomic
 docker garbage cleanup with conservative per-target `--filter until=`
@@ -607,7 +607,19 @@ across all selected targets, **volume confirmation prompt** (`n`
 aborts with exit-1 + i18n "aborted" message; `-y` skips the prompt;
 zh-TW prompt body asserts), `-C` / `--chdir` parity (accepted but
 no-op for daemon-wide prune; value-required + directory guards),
-usage help mentions every flag family.
+usage help mentions every flag family, and **#388 `--worktree-orphans`
+mode** (13 cases): per-test smart docker stub keyed on
+`DOCKER_IMAGES_OUTPUT` / `DOCKER_RMI_LOG` mocks `docker images` + `rmi`;
+fixtures construct real `<workspace>/worktree/<name>/` dirs so the
+existence check has something to consult. Cases cover empty-list
+no-op, owner-match + missing worktree → rmi, owner-match + worktree
+alive → keep, main-checkout pattern (no hyphen) → keep, **two safety
+gates**: bare-name image → skip ("Skipping N bare-name image" log),
+other-owner image → skip ("Skipping N image(s) owned by another user"
+log). Plus `--repo` filter, `--dry-run` plan-only output, `-y` skip
+prompt, missing `--workspace` + empty `.env` → exit 2, `--workspace`
+flag wins over `.env` `WS_PATH`, `--owner` flag wins over `.env`
+`DOCKER_HUB_USER`, and `--help` mentions all four new flags.
 
 Regression guard for **issue #282** — the four user-facing wrappers
 (`build.sh` / `run.sh` / `exec.sh` / `stop.sh`) must resolve `_lib.sh`

--- a/script/docker/prune.sh
+++ b/script/docker/prune.sh
@@ -102,7 +102,9 @@ usage() {
   case "${_LANG}" in
     zh-TW)
       cat >&2 <<'EOF'
-用法: ./prune.sh [-h] [-C|--chdir DIR] [--networks] [--images] [--volumes] [--builder] [--all] [--until DURATION] [-y|--yes] [--dry-run] [--lang LANG]
+用法: ./prune.sh [-h] [-C|--chdir DIR] [--networks] [--images] [--volumes] [--builder] [--all]
+                  [--worktree-orphans [--workspace DIR] [--owner NAME] [--repo NAME]]
+                  [--until DURATION] [-y|--yes] [--dry-run] [--lang LANG]
 
 清理本機 docker 垃圾（unused network / dangling image / buildx cache / volume）。
 不會碰執行中的 container 或 active resource。
@@ -114,9 +116,19 @@ usage() {
   --images          清 dangling images（預設 --filter until=24h）
   --volumes         清未使用的 volumes（**會刪資料**；預設需 -y 確認）
   --builder         清 buildx cache（預設 --filter until=24h）— 釋放大量磁碟
-  --all             = --networks --images --builder（不含 --volumes，避免誤刪資料）
+  --all             = --networks --images --builder（不含 --volumes，亦不含 --worktree-orphans）
+  --worktree-orphans
+                    清理由已移除 worktree 所遺留的 tagged image (#388)。對每個
+                    `<owner>/<name>-<suffix>:<tag>` image 檢查
+                    `<workspace>/worktree/<name>-<suffix>/` 是否存在 — 不存在則
+                    視為 orphan。**安全閘**：只清 `<owner>` 等於當前 DOCKER_HUB_USER
+                    的 image；無 prefix 的裸名與其他 user 的 image 永遠 SKIP。
+  --workspace DIR   覆寫 workspace 目錄（預設讀 .env 的 WS_PATH）
+  --owner NAME      覆寫 owner 比對值（預設讀 .env 的 DOCKER_HUB_USER；
+                    .env 缺則 fallback 偵測 docker info / \$USER / id -un）
+  --repo NAME       縮 scope，只考慮 `<owner>/<name>-*` image。可重複指定多次。
   --until DURATION  覆寫所有 prune 的 --filter until=<dur>（例：1h, 7d）
-  -y, --yes         跳過 --volumes 的互動確認
+  -y, --yes         跳過 --volumes 及 --worktree-orphans 的互動確認
   --dry-run         只印出將執行的 docker 指令，不實際執行
   --lang LANG       設定訊息語言（en|zh-TW|zh-CN|ja；預設: en）
 
@@ -125,11 +137,15 @@ usage() {
   ./prune.sh --all                # 一鍵清網路 + image + builder cache
   ./prune.sh --volumes -y         # 清 volume（跳過確認）
   ./prune.sh --all --until 1h     # 把門檻拉嚴到 1 小時
+  ./prune.sh --worktree-orphans --dry-run   # 看 worktree-orphan 候選
+  ./prune.sh --worktree-orphans -y          # 實清，跳過確認
 EOF
       ;;
     zh-CN)
       cat >&2 <<'EOF'
-用法: ./prune.sh [-h] [-C|--chdir DIR] [--networks] [--images] [--volumes] [--builder] [--all] [--until DURATION] [-y|--yes] [--dry-run] [--lang LANG]
+用法: ./prune.sh [-h] [-C|--chdir DIR] [--networks] [--images] [--volumes] [--builder] [--all]
+                  [--worktree-orphans [--workspace DIR] [--owner NAME] [--repo NAME]]
+                  [--until DURATION] [-y|--yes] [--dry-run] [--lang LANG]
 
 清理本机 docker 垃圾（unused network / dangling image / buildx cache / volume）。
 不会碰运行中的 container 或 active resource。
@@ -141,9 +157,19 @@ EOF
   --images          清 dangling images（默认 --filter until=24h）
   --volumes         清未使用的 volumes（**会删数据**；默认需 -y 确认）
   --builder         清 buildx cache（默认 --filter until=24h）— 释放大量磁盘
-  --all             = --networks --images --builder（不含 --volumes，避免误删数据）
+  --all             = --networks --images --builder（不含 --volumes，也不含 --worktree-orphans）
+  --worktree-orphans
+                    清理由已移除 worktree 遗留的 tagged image (#388)。对每个
+                    `<owner>/<name>-<suffix>:<tag>` image 检查
+                    `<workspace>/worktree/<name>-<suffix>/` 是否存在 — 不存在则
+                    视为 orphan。**安全闸**：只清 `<owner>` 等于当前 DOCKER_HUB_USER
+                    的 image；无 prefix 的裸名与其他 user 的 image 永远 SKIP。
+  --workspace DIR   覆写 workspace 目录（默认读 .env 的 WS_PATH）
+  --owner NAME      覆写 owner 比对值（默认读 .env 的 DOCKER_HUB_USER；
+                    .env 缺则 fallback 检测 docker info / \$USER / id -un）
+  --repo NAME       缩 scope，只考虑 `<owner>/<name>-*` image。可重复指定多次。
   --until DURATION  覆写所有 prune 的 --filter until=<dur>（例：1h, 7d）
-  -y, --yes         跳过 --volumes 的交互确认
+  -y, --yes         跳过 --volumes 及 --worktree-orphans 的交互确认
   --dry-run         只打印将执行的 docker 命令，不实际执行
   --lang LANG       设置消息语言（en|zh-TW|zh-CN|ja；默认: en）
 
@@ -152,11 +178,15 @@ EOF
   ./prune.sh --all                # 一键清网络 + image + builder cache
   ./prune.sh --volumes -y         # 清 volume（跳过确认）
   ./prune.sh --all --until 1h     # 把门槛拉严到 1 小时
+  ./prune.sh --worktree-orphans --dry-run   # 看 worktree-orphan 候选
+  ./prune.sh --worktree-orphans -y          # 实清，跳过确认
 EOF
       ;;
     ja)
       cat >&2 <<'EOF'
-使用法: ./prune.sh [-h] [-C|--chdir DIR] [--networks] [--images] [--volumes] [--builder] [--all] [--until DURATION] [-y|--yes] [--dry-run] [--lang LANG]
+使用法: ./prune.sh [-h] [-C|--chdir DIR] [--networks] [--images] [--volumes] [--builder] [--all]
+                   [--worktree-orphans [--workspace DIR] [--owner NAME] [--repo NAME]]
+                   [--until DURATION] [-y|--yes] [--dry-run] [--lang LANG]
 
 ローカルの docker ガベージ（未使用 network / dangling image / buildx cache / volume）を整理します。
 実行中のコンテナや active なリソースには手を出しません。
@@ -168,9 +198,20 @@ EOF
   --images          dangling image を整理（デフォルト --filter until=24h）
   --volumes         未使用 volume を整理（**データ削除**；デフォルト -y 確認必要）
   --builder         buildx cache を整理（デフォルト --filter until=24h）— ディスク大量解放
-  --all             = --networks --images --builder（--volumes は含まない、データ誤削除回避）
+  --all             = --networks --images --builder（--volumes / --worktree-orphans は含まない）
+  --worktree-orphans
+                    削除済み worktree が残した tagged image を整理 (#388)。各
+                    `<owner>/<name>-<suffix>:<tag>` image について
+                    `<workspace>/worktree/<name>-<suffix>/` の存在を確認 —
+                    存在しなければ orphan とみなす。**安全ガード**: `<owner>`
+                    が現在の DOCKER_HUB_USER と一致する image のみを対象とし、
+                    prefix のない裸名・他ユーザの image は常にスキップ。
+  --workspace DIR   workspace ディレクトリを上書き（デフォルトは .env の WS_PATH）
+  --owner NAME      owner 比較値を上書き（デフォルトは .env の DOCKER_HUB_USER；
+                    .env 不在時は docker info / \$USER / id -un フォールバック）
+  --repo NAME       scope を絞り、`<owner>/<name>-*` のみ候補化。複数指定可。
   --until DURATION  全 prune の --filter until=<dur> を上書き（例: 1h, 7d）
-  -y, --yes         --volumes の確認プロンプトをスキップ
+  -y, --yes         --volumes 及び --worktree-orphans の確認プロンプトをスキップ
   --dry-run         実行される docker コマンドを表示するのみ（実行はしない）
   --lang LANG       メッセージ言語を設定（en|zh-TW|zh-CN|ja；デフォルト: en）
 
@@ -179,11 +220,15 @@ EOF
   ./prune.sh --all                # network + image + builder cache 一括整理
   ./prune.sh --volumes -y         # volume 整理（確認スキップ）
   ./prune.sh --all --until 1h     # しきい値を 1 時間に厳しく
+  ./prune.sh --worktree-orphans --dry-run   # worktree-orphan 候補を確認
+  ./prune.sh --worktree-orphans -y          # 実削除（確認スキップ）
 EOF
       ;;
     *)
       cat >&2 <<'EOF'
-Usage: ./prune.sh [-h] [-C|--chdir DIR] [--networks] [--images] [--volumes] [--builder] [--all] [--until DURATION] [-y|--yes] [--dry-run] [--lang LANG]
+Usage: ./prune.sh [-h] [-C|--chdir DIR] [--networks] [--images] [--volumes] [--builder] [--all]
+                  [--worktree-orphans [--workspace DIR] [--owner NAME] [--repo NAME]]
+                  [--until DURATION] [-y|--yes] [--dry-run] [--lang LANG]
 
 Clean up local docker garbage (unused networks / dangling images / buildx cache / volumes).
 Does NOT touch running containers or active resources.
@@ -202,10 +247,25 @@ Options:
   --builder         Prune buildx cache (default --filter until=24h). Significant
                     disk reclaim.
   --all             = --networks --images --builder. Does NOT include --volumes
-                    to avoid accidental data loss.
+                    or --worktree-orphans (those require explicit opt-in).
+  --worktree-orphans
+                    Remove tagged images left behind by removed worktrees (#388).
+                    For each image `<owner>/<name>-<suffix>:<tag>`, check if
+                    `<workspace>/worktree/<name>-<suffix>/` still exists — if
+                    not, the worktree is gone and the image is an orphan.
+                    **Safety gates**: only acts on images whose `<owner>/`
+                    prefix matches the current DOCKER_HUB_USER; bare-name
+                    images (no prefix) and other-user images are ALWAYS
+                    skipped. Refuses without explicit opt-in.
+  --workspace DIR   Override workspace dir (default: WS_PATH from .env).
+  --owner NAME      Override the owner match value (default: DOCKER_HUB_USER
+                    from .env; falls back to docker info Username / \$USER /
+                    id -un when .env is absent).
+  --repo NAME       Narrow scope: only consider `<owner>/<name>-*` images.
+                    Repeatable.
   --until DURATION  Override the per-target default --filter until=<dur>
                     (e.g. 1h, 7d). Applies to whichever targets are selected.
-  -y, --yes         Skip the --volumes confirmation prompt.
+  -y, --yes         Skip the --volumes and --worktree-orphans prompts.
   --dry-run         Print the docker commands that would run, but do not execute.
   --lang LANG       Set message language (en|zh-TW|zh-CN|ja; default: en).
 
@@ -214,6 +274,8 @@ Examples:
   ./prune.sh --all                 # One-shot networks + images + builder cache
   ./prune.sh --volumes -y          # Prune volumes, skip confirmation
   ./prune.sh --all --until 1h      # Tighten threshold to 1 hour
+  ./prune.sh --worktree-orphans --dry-run   # Preview worktree-orphan candidates
+  ./prune.sh --worktree-orphans -y          # Actually clean, skip prompt
 EOF
       ;;
   esac
@@ -241,6 +303,190 @@ _run_prune() {
   fi
 }
 
+# ── #388 worktree-orphans prune ───────────────────────────────────────────
+
+# _ensure_env_loaded sources .env once per invocation if it exists. Used by
+# both _resolve_workspace and _resolve_owner so they share the same loaded
+# state. No-op when .env is absent (e.g. fresh sandbox); callers handle the
+# missing-value fallback themselves.
+_ensure_env_loaded() {
+  if [[ "${_PRUNE_ENV_LOADED:-0}" == "1" ]]; then
+    return 0
+  fi
+  _PRUNE_ENV_LOADED=1
+  if [[ -f "${FILE_PATH}/.env" ]]; then
+    _load_env "${FILE_PATH}/.env"
+  fi
+}
+
+# _resolve_workspace sets _RESOLVED_WORKSPACE from (in order):
+#   --workspace flag override, then $WS_PATH from .env (if .env exists).
+# Exits 2 with a hint when neither resolves. Always loads .env so the
+# subsequent _resolve_owner call inherits DOCKER_HUB_USER even when
+# --workspace bypassed the WS_PATH lookup.
+_resolve_workspace() {
+  _ensure_env_loaded
+  if [[ -n "${WORKSPACE_OVERRIDE:-}" ]]; then
+    _RESOLVED_WORKSPACE="${WORKSPACE_OVERRIDE}"
+    return 0
+  fi
+  if [[ -n "${WS_PATH:-}" ]]; then
+    _RESOLVED_WORKSPACE="${WS_PATH}"
+    return 0
+  fi
+  _log_err prune "cannot resolve workspace; pass --workspace <dir> or run from a repo with .env (no WS_PATH found)"
+  exit 2
+}
+
+# _resolve_owner sets _RESOLVED_OWNER for the safety gate. Order:
+#   --owner flag override → $DOCKER_HUB_USER from .env → inline detect
+#   (mirrors setup.sh's detect_docker_hub_user: `docker info`
+#   Username → $USER → `id -un`). Never empty — at minimum $USER /
+#   id -un produce a value, so this function does not exit.
+_resolve_owner() {
+  _ensure_env_loaded
+  if [[ -n "${OWNER_OVERRIDE:-}" ]]; then
+    _RESOLVED_OWNER="${OWNER_OVERRIDE}"
+    return 0
+  fi
+  if [[ -n "${DOCKER_HUB_USER:-}" ]]; then
+    _RESOLVED_OWNER="${DOCKER_HUB_USER}"
+    return 0
+  fi
+  local _name
+  _name="$(docker info 2>/dev/null \
+    | awk '/^[[:space:]]*Username:/{print $2}')" || true
+  _RESOLVED_OWNER="${_name:-${USER:-$(id -un)}}"
+}
+
+# _matches_repo_filter checks <name> against the REPO_FILTERS array.
+# Exit 0 when filters empty (no filter == all match) or any filter
+# matches as either exact equality or a `<filter>-` prefix.
+_matches_repo_filter() {
+  local _name="${1:?_matches_repo_filter requires name}"
+  if (( ${#REPO_FILTERS[@]} == 0 )); then
+    return 0
+  fi
+  local _f
+  for _f in "${REPO_FILTERS[@]}"; do
+    if [[ "${_name}" == "${_f}" || "${_name}" == "${_f}-"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# _run_worktree_orphans_prune enumerates tagged docker images and removes
+# the ones whose source worktree dir is gone. Safety gates: only acts on
+# images whose `<owner>/` prefix matches the resolved owner; bare-name
+# and other-user images are skipped. See plan #388 for the algorithm.
+_run_worktree_orphans_prune() {
+  local _RESOLVED_WORKSPACE _RESOLVED_OWNER
+  _resolve_workspace
+  _resolve_owner
+  local _worktree_root="${_RESOLVED_WORKSPACE%/}/worktree"
+
+  _log_info prune "Scanning worktree-orphan images (owner=${_RESOLVED_OWNER}, workspace=${_RESOLVED_WORKSPACE})..."
+
+  # IFS read into array — `docker images` output is one tag per line.
+  local -a _all_images=()
+  local _line
+  while IFS= read -r _line; do
+    [[ -z "${_line}" ]] && continue
+    _all_images+=("${_line}")
+  done < <(docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null \
+    | grep -v ':<none>$' || true)
+
+  local -a _candidates=()
+  local -a _skipped_other_owner=()
+  local -a _skipped_bare=()
+  local _full _repo_part _tag _user _name
+  for _full in "${_all_images[@]}"; do
+    _tag="${_full##*:}"
+    _repo_part="${_full%:*}"
+
+    # Safety gate #1: bare names (no '/') — cannot prove ownership.
+    if [[ "${_repo_part}" != */* ]]; then
+      _name="${_repo_part}"
+      # Only collect for the summary if it looks worktree-shaped
+      # (contains a hyphen). Otherwise it is plainly a main checkout.
+      if [[ "${_name}" == *-* ]]; then
+        _skipped_bare+=("${_full}")
+      fi
+      continue
+    fi
+
+    _user="${_repo_part%%/*}"
+    _name="${_repo_part#*/}"
+
+    # Safety gate #2: owner mismatch — refuse to touch other-user images.
+    if [[ "${_user}" != "${_RESOLVED_OWNER}" ]]; then
+      if [[ "${_name}" == *-* ]]; then
+        _skipped_other_owner+=("${_full}")
+      fi
+      continue
+    fi
+
+    # Main-checkout pattern (no worktree suffix marker) — never a candidate.
+    if [[ "${_name}" != *-* ]]; then
+      continue
+    fi
+
+    # --repo filter narrows by basename prefix or exact match.
+    if ! _matches_repo_filter "${_name}"; then
+      continue
+    fi
+
+    # Worktree directory still on disk → repo still alive, keep image.
+    if [[ -d "${_worktree_root}/${_name}" ]]; then
+      continue
+    fi
+
+    _candidates+=("${_full}")
+  done
+
+  # Always emit the safety summary so the user knows we deliberately
+  # left other-user / bare-name images alone.
+  if (( ${#_skipped_other_owner[@]} > 0 )); then
+    _log_info prune "Skipping ${#_skipped_other_owner[@]} image(s) owned by another user (safety):"
+    printf '  %s\n' "${_skipped_other_owner[@]}" >&2
+  fi
+  if (( ${#_skipped_bare[@]} > 0 )); then
+    _log_info prune "Skipping ${#_skipped_bare[@]} bare-name image(s) — ownership unknown:"
+    printf '  %s\n' "${_skipped_bare[@]}" >&2
+  fi
+
+  if (( ${#_candidates[@]} == 0 )); then
+    _log_info prune "No worktree orphans found."
+    return 0
+  fi
+
+  _log_info prune "Worktree-orphan candidates (${#_candidates[@]}):"
+  printf '  %s\n' "${_candidates[@]}" >&2
+
+  if [[ "${ASSUME_YES}" != true && "${DRY_RUN}" != true ]]; then
+    printf '[prune] remove %d image(s)? [y/N] ' "${#_candidates[@]}" >&2
+    local _reply
+    read -r _reply
+    case "${_reply}" in
+      y|Y|yes|YES) ;;
+      *)
+        _log_info prune "aborted by user."
+        return 1
+        ;;
+    esac
+  fi
+
+  local _img
+  for _img in "${_candidates[@]}"; do
+    if [[ "${DRY_RUN}" == true ]]; then
+      printf '[dry-run] docker rmi %q\n' "${_img}"
+    else
+      docker rmi "${_img}" || true
+    fi
+  done
+}
+
 main() {
   # Pre-pass for --lang so usage() runs in requested locale even when
   # --help is first. See build.sh for full rationale (#222).
@@ -258,6 +504,10 @@ main() {
   local DO_IMAGES=false
   local DO_VOLUMES=false
   local DO_BUILDER=false
+  local DO_WORKTREE_ORPHANS=false
+  local WORKSPACE_OVERRIDE=""
+  local OWNER_OVERRIDE=""
+  local -a REPO_FILTERS=()
   local UNTIL_OVERRIDE=""
   local ASSUME_YES=false
   DRY_RUN=false
@@ -289,10 +539,33 @@ main() {
         ;;
       --all)
         # Excludes --volumes intentionally (see usage / issue #319).
+        # Also excludes --worktree-orphans intentionally — that mode
+        # requires workspace + filesystem context the daemon-wide
+        # bulk prune does not have. Chain explicitly when needed:
+        #   ./prune.sh --all --worktree-orphans
         DO_NETWORKS=true
         DO_IMAGES=true
         DO_BUILDER=true
         shift
+        ;;
+      --worktree-orphans)
+        # #388: surgically remove tagged images whose source worktree
+        # dir is gone. Always opt-in; safety-gated to the current
+        # DOCKER_HUB_USER's images only.
+        DO_WORKTREE_ORPHANS=true
+        shift
+        ;;
+      --workspace)
+        WORKSPACE_OVERRIDE="${2:?"--workspace requires a value"}"
+        shift 2
+        ;;
+      --owner)
+        OWNER_OVERRIDE="${2:?"--owner requires a value"}"
+        shift 2
+        ;;
+      --repo)
+        REPO_FILTERS+=("${2:?"--repo requires a value"}")
+        shift 2
         ;;
       --until)
         UNTIL_OVERRIDE="${2:?"--until requires a value (e.g. 1h, 7d)"}"
@@ -322,7 +595,8 @@ main() {
   # No target selected → print help-y error and exit 2 (not 0; caller likely
   # invoked us by mistake — avoid silent no-op).
   if [[ "${DO_NETWORKS}" != true && "${DO_IMAGES}" != true \
-        && "${DO_VOLUMES}" != true && "${DO_BUILDER}" != true ]]; then
+        && "${DO_VOLUMES}" != true && "${DO_BUILDER}" != true \
+        && "${DO_WORKTREE_ORPHANS}" != true ]]; then
     _log_err prune "$(_msg info nothing_selected)"
     exit 2
   fi
@@ -364,6 +638,10 @@ main() {
     fi
     _log_info prune "Pruning volumes (until=${_vol_until:-<none>})..."
     _run_prune volume "${_vol_until}"
+  fi
+
+  if [[ "${DO_WORKTREE_ORPHANS}" == true ]]; then
+    _run_worktree_orphans_prune
   fi
 }
 

--- a/test/unit/prune_sh_spec.bats
+++ b/test/unit/prune_sh_spec.bats
@@ -224,3 +224,206 @@ teardown() {
   assert_output --partial "--dry-run"
   assert_output --partial "-y"
 }
+
+# ── #388 --worktree-orphans: surgical removal of removed-worktree images ──
+#
+# Strategy mirrors build_sh_prune_spec.bats: a per-test docker stub keyed
+# on env vars overrides the default arg-echo stub. The orphan flow uses
+# 3 docker verbs:
+#   docker images --format '...'  → emit DOCKER_IMAGES_OUTPUT (newline list)
+#   docker rmi <tag>              → append <tag> to DOCKER_RMI_LOG
+#   anything else                 → silent exit 0
+# Per-test setup also configures DOCKER_HUB_USER + WS_PATH in .env and
+# constructs `<workspace>/worktree/<name>/` directories so the worktree-
+# existence check has something real to consult.
+
+# _orphans_setup_stub installs a docker stub honouring DOCKER_IMAGES_OUTPUT
+# and DOCKER_RMI_LOG, and primes .env with WS_PATH=$1, DOCKER_HUB_USER=$2.
+_orphans_setup_stub() {
+  local _ws="${1:-/nonexistent}"
+  local _owner="${2:-tester}"
+  DOCKER_RMI_LOG="${TEMP_DIR}/rmi.log"
+  export DOCKER_RMI_LOG
+  : > "${DOCKER_RMI_LOG}"
+  cat > "${BIN_DIR}/docker" <<'EOS'
+#!/usr/bin/env bash
+set -uo pipefail
+if [[ "${1:-}" == "images" ]]; then
+  if [[ -n "${DOCKER_IMAGES_OUTPUT:-}" ]]; then
+    printf '%s\n' "${DOCKER_IMAGES_OUTPUT}"
+  fi
+  exit 0
+fi
+if [[ "${1:-}" == "rmi" ]]; then
+  shift
+  printf '%s\n' "$*" >> "${DOCKER_RMI_LOG}"
+  exit 0
+fi
+exit 0
+EOS
+  chmod +x "${BIN_DIR}/docker"
+  {
+    printf 'WS_PATH=%s\n' "${_ws}"
+    printf 'DOCKER_HUB_USER=%s\n' "${_owner}"
+  } > "${SANDBOX}/.env"
+}
+
+@test "prune.sh --worktree-orphans on empty image list → no rmi" {
+  local _ws="${TEMP_DIR}/ws"
+  mkdir -p "${_ws}/worktree"
+  _orphans_setup_stub "${_ws}" tester
+  unset DOCKER_IMAGES_OUTPUT
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans -y
+  assert_success
+  assert_output --partial "No worktree orphans found."
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "prune.sh --worktree-orphans: owner match + missing worktree → rmi" {
+  local _ws="${TEMP_DIR}/ws"
+  mkdir -p "${_ws}/worktree"
+  _orphans_setup_stub "${_ws}" tester
+  export DOCKER_IMAGES_OUTPUT="tester/repo-99:devel"
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans -y
+  assert_success
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output --partial "tester/repo-99:devel"
+}
+
+@test "prune.sh --worktree-orphans: owner match + worktree exists → keep" {
+  local _ws="${TEMP_DIR}/ws"
+  mkdir -p "${_ws}/worktree/repo-99"
+  _orphans_setup_stub "${_ws}" tester
+  export DOCKER_IMAGES_OUTPUT="tester/repo-99:devel"
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans -y
+  assert_success
+  assert_output --partial "No worktree orphans found."
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "prune.sh --worktree-orphans: main-checkout pattern (no hyphen) → keep" {
+  local _ws="${TEMP_DIR}/ws"
+  mkdir -p "${_ws}/worktree"
+  _orphans_setup_stub "${_ws}" tester
+  export DOCKER_IMAGES_OUTPUT="tester/ros1_bridge:devel"
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans -y
+  assert_success
+  assert_output --partial "No worktree orphans found."
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "prune.sh --worktree-orphans: bare-name image (no owner prefix) → SAFETY skip" {
+  # Safety gate #1: cannot prove ownership, refuse to delete.
+  local _ws="${TEMP_DIR}/ws"
+  mkdir -p "${_ws}/worktree"
+  _orphans_setup_stub "${_ws}" tester
+  export DOCKER_IMAGES_OUTPUT="repo-99:runtime"
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans -y
+  assert_success
+  assert_output --partial "Skipping 1 bare-name image"
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "prune.sh --worktree-orphans: other-owner image → SAFETY skip" {
+  # Safety gate #2: other user's image, not ours to delete.
+  local _ws="${TEMP_DIR}/ws"
+  mkdir -p "${_ws}/worktree"
+  _orphans_setup_stub "${_ws}" bob
+  export DOCKER_IMAGES_OUTPUT="alice/repo-99:devel"
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans -y
+  assert_success
+  assert_output --partial "Skipping 1 image(s) owned by another user"
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "prune.sh --worktree-orphans --repo <name> filter" {
+  # Only ros1_bridge-* should be considered; foo-99 is ignored even though
+  # its worktree is missing.
+  local _ws="${TEMP_DIR}/ws"
+  mkdir -p "${_ws}/worktree"
+  _orphans_setup_stub "${_ws}" tester
+  export DOCKER_IMAGES_OUTPUT="tester/ros1_bridge-59:test
+tester/foo-99:devel"
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans --repo ros1_bridge -y
+  assert_success
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output --partial "tester/ros1_bridge-59:test"
+  refute_output --partial "tester/foo-99:devel"
+}
+
+@test "prune.sh --worktree-orphans --dry-run prints plan, no real rmi" {
+  local _ws="${TEMP_DIR}/ws"
+  mkdir -p "${_ws}/worktree"
+  _orphans_setup_stub "${_ws}" tester
+  export DOCKER_IMAGES_OUTPUT="tester/repo-99:devel"
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans --dry-run
+  assert_success
+  assert_output --partial "[dry-run] docker rmi"
+  assert_output --partial "tester/repo-99:devel"
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output ""
+}
+
+@test "prune.sh --worktree-orphans -y skips confirmation" {
+  local _ws="${TEMP_DIR}/ws"
+  mkdir -p "${_ws}/worktree"
+  _orphans_setup_stub "${_ws}" tester
+  export DOCKER_IMAGES_OUTPUT="tester/repo-99:devel"
+  # No stdin piping needed — -y bypasses the prompt and rmi fires.
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans -y
+  assert_success
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output --partial "tester/repo-99:devel"
+}
+
+@test "prune.sh --worktree-orphans without --workspace + empty .env → exit 2" {
+  # No WS_PATH in .env, no --workspace flag → must error out.
+  : > "${SANDBOX}/.env"
+  cat > "${BIN_DIR}/docker" <<'EOS'
+#!/usr/bin/env bash
+exit 0
+EOS
+  chmod +x "${BIN_DIR}/docker"
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans -y
+  assert_failure
+  [ "$status" -eq 2 ]
+  assert_output --partial "cannot resolve workspace"
+}
+
+@test "prune.sh --worktree-orphans --workspace <flag> wins over .env WS_PATH" {
+  local _env_ws="${TEMP_DIR}/env_ws"
+  local _flag_ws="${TEMP_DIR}/flag_ws"
+  mkdir -p "${_env_ws}/worktree/repo-99"   # would KEEP if env-ws used
+  mkdir -p "${_flag_ws}/worktree"          # MISSING repo-99 → orphan if flag-ws used
+  _orphans_setup_stub "${_env_ws}" tester
+  export DOCKER_IMAGES_OUTPUT="tester/repo-99:devel"
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans --workspace "${_flag_ws}" -y
+  assert_success
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output --partial "tester/repo-99:devel"
+}
+
+@test "prune.sh --worktree-orphans --owner <flag> wins over .env DOCKER_HUB_USER" {
+  local _ws="${TEMP_DIR}/ws"
+  mkdir -p "${_ws}/worktree"
+  _orphans_setup_stub "${_ws}" bob          # .env says bob
+  export DOCKER_IMAGES_OUTPUT="alice/repo-99:devel"
+  run bash "${SANDBOX}/prune.sh" --worktree-orphans --owner alice -y
+  assert_success
+  run cat "${DOCKER_RMI_LOG}"
+  assert_output --partial "alice/repo-99:devel"
+}
+
+@test "prune.sh --help mentions --worktree-orphans (#388)" {
+  run bash "${SANDBOX}/prune.sh" --help
+  assert_success
+  assert_output --partial "--worktree-orphans"
+  assert_output --partial "--workspace"
+  assert_output --partial "--owner"
+  assert_output --partial "--repo"
+}


### PR DESCRIPTION
Closes #388.

## Summary

New opt-in `./prune.sh --worktree-orphans` mode that surgically removes tagged docker images whose source worktree was deleted via `git worktree remove`. These images cannot be cleaned by the existing `--images` flag (not dangling) and would otherwise require either manual `docker rmi` per-tag or the daemon-wide `docker system prune -a` (which also kills every other repo's idle tagged image — too aggressive).

Algorithm: for each tagged image `<owner>/<name>-<suffix>:<tag>`, check whether `<workspace>/worktree/<name>-<suffix>/` still exists. If the worktree dir is gone, the image is an orphan. Direct 1:1 match because `setup.conf`'s default `[image_name] rules = @basename` makes the image-name equal to the worktree dir basename — no repo derivation needed.

## Safety gates (closing the user's review concern)

Three skip rules, **always applied**:

| Image shape | Owner | Decision |
|---|---|---|
| `<owner>/<name>-<sfx>:<tag>` (`<owner>` == DOCKER_HUB_USER) | mine | **DELETE** if worktree gone |
| `<other>/<name>-<sfx>:<tag>` | someone else | **SKIP** ("not mine; refuse to touch") |
| `<name>-<sfx>:<tag>` (no `<owner>/` prefix) | unknown | **SKIP** ("ownership unprovable") |
| Any image where `<name>` has no hyphen | (main checkout pattern) | **SKIP** (no worktree suffix) |

The two safety-gate skips emit explicit log lines so the user can see *why* certain images were left alone:

```
[prune] INFO: Skipping 2 image(s) owned by another user (safety):
  alice/repo-99:devel
  alice/repo-99:runtime
[prune] INFO: Skipping 1 bare-name image(s) — ownership unknown:
  repo-99:runtime
```

## Companion flags

- **`--workspace <dir>`** — override workspace root. Default: `WS_PATH` from `.env` when run from a downstream repo with one.
- **`--owner <name>`** — override the owner match value. Default: `DOCKER_HUB_USER` from `.env`; falls back to `docker info` Username → `$USER` → `id -un` (same chain `setup.sh`'s `detect_docker_hub_user` uses).
- **`--repo <name>`** — narrow scope to `<owner>/<name>-*` images only. Repeatable.
- **`-y` / `--dry-run`** — same semantics as existing prune flags.

**Not folded into `--all`** (per issue body's open Q4): `--all` is daemon-wide bulk cleanup with no workspace context. Chain explicitly: `./prune.sh --all --worktree-orphans`.

## Why

Real example from #388 body: `ros1_bridge` accumulated 14 orphan tagged images (~24 GB) — `yunchien/ros1_bridge-59:test`, `yunchien/ros1_bridge-readme-align:test`, etc. — from worktrees that were since removed. Pre-#388 these required manual `docker rmi` per-tag with visual scanning (easy to miss, easy to delete the wrong one). Post-#388: one command, safety-gated, dry-run preview, owner-strict.

Acceptance criteria from #388 issue body — all four open questions resolved:

- [x] **Q1 workspace location**: `--workspace <dir>` flag (default: `WS_PATH` from `.env`). Walk-up rejected as brittle.
- [x] **Q2 repo derivation**: not needed. image-name directly matches worktree dir basename (consequence of `@basename` rule). Optional `--repo <name>` filter narrows scope.
- [x] **Q3 cover no-`<user>/` prefix**: **NO** — explicitly skipped per user review (multi-user safety). Same for other-user prefix.
- [x] **Q4 fold into `--all`**: NO. Opt-in only.

## Test plan

- [x] `make -f Makefile.ci test` — 1440 ok / 0 fail (1427 pre-PR + 13 new prune_sh_spec.bats cases)
- [x] ShellCheck via test stage — clean
- [ ] Manual smoke after merge: real workspace, `./prune.sh --worktree-orphans --dry-run` — confirm candidate list matches actual worktree-gone images, no other-user / bare-name images listed
- [ ] Manual smoke: `./prune.sh --worktree-orphans -y` — confirm orphans removed; `docker images` shows main-repo `:devel` / `:runtime` images intact
- [ ] Multi-user box smoke: create an `alice/test-1:devel` image with `docker tag`, run as `bob` → confirm it's listed under "Skipping ... owned by another user" and not deleted

## Downstream impact

- This is a **Y (minor) bump** under v0.X.Y semantics — adds a flag, no default behavior change (opt-in only). Cut as next minor (e.g. v0.33.0) alongside any other `[Unreleased]` entries.
- Downstream consumers pull via `make -f Makefile.ci upgrade VERSION=vX.Y.0`. The new flag is opt-in; existing `./prune.sh --networks` / `--all` / etc. invocations are unchanged.

## Out of scope (per #388 issue body's "Alternatives considered")

- Auto-trigger via `git worktree remove` hook → git has no such hook point; deferred.
- Change `setup.conf` `[image_name]` default rule to avoid `@basename` fallback → broad impact; existing orphans still need cleanup → orthogonal.
- Buildx cache cleanup → `prune.sh --builder` already covers.
