### PR TITLE
feat(setup.sh): prune stale [logging] gitignore entries (#390)

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ file, in addition to the docker daemon's json-file log:
 
 ```ini
 [logging]
-local_path = ./logs/   # repo-relative; or /abs/, or ~/dir/
+local_path = ./log/   # repo-relative; or /abs/, or ~/dir/
 ```
 
 Re-run any wrapper to regenerate `compose.yaml`. Host file lands at

--- a/config/docker/setup.conf
+++ b/config/docker/setup.conf
@@ -139,7 +139,7 @@ mount_1 =
 # The helper is a no-op when LOG_FILE_PATH is unset, so the source
 # line is safe to add unconditionally. Path semantics for the
 # local_path value:
-#   ./logs/     relative to repo root
+#   ./log/      relative to repo root
 #   /abs/path/  absolute, used verbatim
 #   ~/dir/      ~ expanded to $HOME
 #   (empty)     feature disabled (default, back-compat)

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -126,6 +126,17 @@ Closes the multi-worktree-workflow lifecycle leaks (orphan `<projname>_default` 
 
 ### Added
 
+- **`setup.sh apply` prunes stale `[logging] local_path` entries
+  from the managed `.gitignore` block** (#390). Pre-#390 the helper
+  `_sync_logging_local_paths_gitignore` only appended; when a
+  downstream rewrote its `local_path` value (e.g. `./logs/` →
+  `./log/` to match the project's singular directory convention),
+  the prior `/logs/` entry persisted forever inside the managed
+  marker block. Post-#390 each apply rewrites the block to exactly
+  the current candidate set: stale entries drop out, new ones
+  appear, and when the resulting block is empty the marker comment
+  itself is removed so a feature-off repo carries no trace. Lines
+  outside the managed block stay user-owned and untouched.
 - **`exec.sh` gained `-T` / `--no-tty`, `-i` / `--tty`, plus auto-
   detect for `bash|sh|dash|zsh|ash|ksh -c '...'`** (#382, Option 1+2).
   Three-tier resolution with last-wins between the explicit flags:

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -347,7 +347,7 @@ template ファイルが repo にコピーされ、検出された workspace が
 
 ```ini
 [logging]
-local_path = ./logs/   # repo 相対、または /abs/、~/dir/ も可
+local_path = ./log/   # repo 相対、または /abs/、~/dir/ も可
 ```
 
 任意の wrapper を再実行すると `compose.yaml` が再生成されます。

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -332,7 +332,7 @@ template；没写的 section 则吃 template 默认。
 
 ```ini
 [logging]
-local_path = ./logs/   # 相对 repo 根；或 /abs/、~/dir/ 也可
+local_path = ./log/   # 相对 repo 根；或 /abs/、~/dir/ 也可
 ```
 
 跑任何 wrapper 重新生成 `compose.yaml`。host 文件会落在

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -332,7 +332,7 @@ template；沒寫的 section 則吃 template 預設。
 
 ```ini
 [logging]
-local_path = ./logs/   # 相對 repo 根；或 /abs/、~/dir/ 也可
+local_path = ./log/   # 相對 repo 根；或 /abs/、~/dir/ 也可
 ```
 
 跑任何 wrapper 重新產 `compose.yaml`。host 檔案會落在

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -693,7 +693,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 | `environment env_N supports multiple cross-references in one value (refs #236)` | multi-ref |
 | `environment env_N transitive cross-reference resolves through chain (refs #236)` | transitive |
 
-### test/unit/compose_logging_spec.bats (29)
+### test/unit/compose_logging_spec.bats (32)
 
 Covers `[logging]` + `[logging.<svc>]` support in
 `generate_compose_yaml` (#310). Tests the global emission on every
@@ -729,6 +729,9 @@ behaviour, and the two new setup.sh helpers `_parse_logging_svc_sections`
 | `_sync_logging_local_paths_gitignore is idempotent (#328)` | Re-run no-op |
 | `_sync_logging_local_paths_gitignore collects from both global + per-svc (#328)` | Multi-source |
 | `_sync_logging_local_paths_gitignore is no-op when no local_path keys (#328)` | Empty no-op |
+| `_sync_logging_local_paths_gitignore prunes stale managed entries on value change (#390)` | Rename prune |
+| `_sync_logging_local_paths_gitignore drops marker + entries when candidates become empty (#390)` | Feature-off cleanup |
+| `_sync_logging_local_paths_gitignore preserves user entries outside managed block (#390)` | User-owned untouched |
 | `setup.conf [logging] comment block references in-image helper path (/usr/local/lib/base/, #368)` | Documented adoption path matches in-image COPY |
 | `generate_compose_yaml emits per-stage LOG_FILE_PATH on extends:devel stage when [logging] local_path is set (#367)` | Per-svc LOG_FILE_PATH on auto-emitted extends-only stage |
 | `generate_compose_yaml emits per-stage volume mount on extends:devel stage when [logging] local_path is set (#367)` | Per-svc volume mount on auto-emitted extends-only stage |

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -1325,13 +1325,24 @@ _parse_logging_svc_sections() {
 # emit, ensure the per-repo .gitignore covers each relative
 # local_path so users don't accidentally commit container logs.
 # Absolute paths and `~/...` are skipped — gitignore patterns apply
-# only inside the repo. Entries are added under a stable marker
-# comment so re-syncs don't churn the file.
+# only inside the repo.
+#
+# Entries live inside a managed block introduced by a stable marker
+# comment. The block scope is the marker line plus any immediately-
+# following lines that look like a gitignore dir entry (`/<path>/`);
+# the first non-matching line (blank line, comment, non-anchored
+# entry, etc.) ends the block. On each apply we rewrite the block to
+# exactly the current desired entries, which prunes stale entries
+# left over from prior `local_path` values (#390). The marker
+# comment itself is dropped when the block ends up empty so an
+# `apply` with no logging local_path leaves no trace. Lines outside
+# the managed block are user-owned and never touched.
 _sync_logging_local_paths_gitignore() {
   local _base="${1:?}"
   local _global="${2:-}"
   local _per_svc="${3:-}"
   local _gitignore="${_base%/}/.gitignore"
+  local _marker='# managed by template: [logging] local_path (do not remove)'
 
   local -a _candidates=()
   local _line _k _v
@@ -1353,7 +1364,6 @@ _sync_logging_local_paths_gitignore() {
       [[ "${_k}" == "local_path" && -n "${_v}" ]] && _candidates+=("${_v}")
     done <<< "${_per_svc}"
   fi
-  (( ${#_candidates[@]} == 0 )) && return 0
 
   # Filter: keep only relative paths; strip leading `./`, trailing `/`.
   local -a _entries=()
@@ -1373,33 +1383,71 @@ _sync_logging_local_paths_gitignore() {
     # marks it as a directory so it matches the dir + its contents.
     _entries+=("/${_p}/")
   done
-  (( ${#_entries[@]} == 0 )) && return 0
 
-  # Dedup + missing-only append.
+  # Dedup.
   local -A _seen=()
-  local -a _missing=()
+  local -a _desired=()
   for _p in "${_entries[@]}"; do
     [[ -n "${_seen[${_p}]:-}" ]] && continue
     _seen[${_p}]=1
-    if [[ ! -f "${_gitignore}" ]] || ! grep -qxF "${_p}" "${_gitignore}"; then
-      _missing+=("${_p}")
-    fi
+    _desired+=("${_p}")
   done
-  (( ${#_missing[@]} == 0 )) && return 0
 
+  # If file doesn't exist and nothing desired, leave it absent.
   if [[ ! -f "${_gitignore}" ]]; then
+    (( ${#_desired[@]} == 0 )) && return 0
     : > "${_gitignore}"
   fi
-  # Ensure trailing newline before append.
-  if [[ -s "${_gitignore}" ]]; then
-    local _last
-    _last="$(tail -c 1 -- "${_gitignore}")"
-    [[ "${_last}" != $'\n' ]] && printf '\n' >> "${_gitignore}"
+
+  # Split existing content into pre-marker / post-marker, dropping
+  # the marker block itself (re-emitted below from _desired). When
+  # no marker exists, every line lands in _pre and the block is
+  # appended at the end if anything is desired.
+  local -a _pre=() _post=()
+  local _in_block=0 _seen_marker=0
+  while IFS= read -r _line || [[ -n "${_line}" ]]; do
+    if [[ "${_seen_marker}" -eq 0 && "${_line}" == "${_marker}" ]]; then
+      _seen_marker=1
+      _in_block=1
+      continue
+    fi
+    if [[ "${_in_block}" -eq 1 ]]; then
+      # Consume only gitignore dir-entry shape; anything else ends
+      # the managed block and is preserved as post-block content.
+      if [[ "${_line}" =~ ^/.+/$ ]]; then
+        continue
+      fi
+      _in_block=0
+      _post+=("${_line}")
+      continue
+    fi
+    if [[ "${_seen_marker}" -eq 1 ]]; then
+      _post+=("${_line}")
+    else
+      _pre+=("${_line}")
+    fi
+  done < "${_gitignore}"
+
+  # Compose output: pre / marker+desired (if any) / post. When there
+  # is nothing desired and no prior marker existed, return early to
+  # keep the file byte-identical to the input (preserves idempotency
+  # and avoids touching unrelated files).
+  if (( ${#_desired[@]} == 0 && _seen_marker == 0 )); then
+    return 0
   fi
-  if ! grep -q '^# managed by template: \[logging\] local_path' "${_gitignore}"; then
-    printf '# managed by template: [logging] local_path (do not remove)\n' >> "${_gitignore}"
-  fi
-  printf '%s\n' "${_missing[@]}" >> "${_gitignore}"
+
+  {
+    if (( ${#_pre[@]} > 0 )); then
+      printf '%s\n' "${_pre[@]}"
+    fi
+    if (( ${#_desired[@]} > 0 )); then
+      printf '%s\n' "${_marker}"
+      printf '%s\n' "${_desired[@]}"
+    fi
+    if (( ${#_post[@]} > 0 )); then
+      printf '%s\n' "${_post[@]}"
+    fi
+  } > "${_gitignore}"
 }
 
 _collect_logging() {

--- a/test/unit/compose_logging_spec.bats
+++ b/test/unit/compose_logging_spec.bats
@@ -381,6 +381,61 @@ CONF
 }
 
 # ════════════════════════════════════════════════════════════════════
+# _sync_logging_local_paths_gitignore prune behavior (#390)
+# ════════════════════════════════════════════════════════════════════
+#
+# When local_path values change (e.g. a rename), stale entries inside
+# the managed block must be removed so downstream .gitignore stays
+# consistent without manual intervention. Entries outside the managed
+# block are user-owned and must never be touched.
+
+@test "_sync_logging_local_paths_gitignore prunes stale managed entries on value change (#390)" {
+  local _gitignore="${TEMP_DIR}/.gitignore"
+  : > "${_gitignore}"
+  _sync_logging_local_paths_gitignore "${TEMP_DIR}" "local_path=./logs/" ""
+  run grep -xF "/logs/" "${_gitignore}"
+  assert_success
+  # Second apply with renamed value: /logs/ pruned, /log/ added.
+  _sync_logging_local_paths_gitignore "${TEMP_DIR}" "local_path=./log/" ""
+  run grep -xF "/logs/" "${_gitignore}"
+  assert_failure
+  run grep -xF "/log/" "${_gitignore}"
+  assert_success
+}
+
+@test "_sync_logging_local_paths_gitignore drops marker + entries when candidates become empty (#390)" {
+  local _gitignore="${TEMP_DIR}/.gitignore"
+  : > "${_gitignore}"
+  _sync_logging_local_paths_gitignore "${TEMP_DIR}" "local_path=./logs/" ""
+  run grep -xF "/logs/" "${_gitignore}"
+  assert_success
+  # Feature turned off: marker + entries removed.
+  _sync_logging_local_paths_gitignore "${TEMP_DIR}" "" ""
+  run grep -xF "/logs/" "${_gitignore}"
+  assert_failure
+  run grep -xF "# managed by template: [logging] local_path (do not remove)" "${_gitignore}"
+  assert_failure
+}
+
+@test "_sync_logging_local_paths_gitignore preserves user entries outside managed block (#390)" {
+  local _gitignore="${TEMP_DIR}/.gitignore"
+  # User-owned /logs/ above the managed block (e.g. legacy entry kept
+  # for the host directory after the rename migration).
+  printf '%s\n' "# user ignores" "/logs/" "" > "${_gitignore}"
+  _sync_logging_local_paths_gitignore "${TEMP_DIR}" "local_path=./log/" ""
+  run grep -xF "/logs/" "${_gitignore}"
+  assert_success
+  run grep -xF "/log/" "${_gitignore}"
+  assert_success
+  # Turning the feature off prunes managed /log/ but leaves user /logs/.
+  _sync_logging_local_paths_gitignore "${TEMP_DIR}" "" ""
+  run grep -xF "/logs/" "${_gitignore}"
+  assert_success
+  run grep -xF "/log/" "${_gitignore}"
+  assert_failure
+}
+
+# ════════════════════════════════════════════════════════════════════
 # setup.conf [logging] section: in-image helper path reference (#368)
 # ════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary

Closes #390 (base scope). Refactors `_sync_logging_local_paths_gitignore`
to rewrite the managed marker block on every apply: stale entries left
behind by a prior `local_path` value (e.g. `./logs/` → `./log/`) drop
out automatically, and when the resulting block is empty the marker
comment is removed too so a feature-off repo carries no trace. Lines
outside the managed block remain user-owned and untouched.

Also flips the documented `[logging] local_path` example from plural
`./logs/` to singular `./log/` in `setup.conf:142` and the four README
translations. The actual default value stays empty — opt-in semantics
are unchanged.

## Context

- The base default for `local_path` is empty (opt-in). The `logs/`
  outlier only exists in `ros1_bridge` because that repo follows the
  docs example and overrides the setting in its own `setup.conf`.
- The other twelve downstream repos have empty `local_path`, so this
  PR is a no-op for them after merge.
- The corresponding `ros1_bridge` override flip lives in a follow-up
  PR scheduled after this PR merges and base releases the new tag.

## Implementation

- `_sync_logging_local_paths_gitignore` refactor:
  - Parse `.gitignore` into three buckets: pre-marker / managed-block
    / post-marker.
  - Managed-block scope = the marker line plus any immediately-
    following `/<path>/` dir-entry lines; the first non-matching line
    (blank / comment / non-anchored entry) ends the block.
  - Rewrite the block with the current desired entries; when desired
    is empty, drop the marker comment as well.
  - Pre / post buckets are written back verbatim.
- `compose_logging_spec.bats` gains three new tests:
  - Rename case (`./logs/` → `./log/`): the stale entry disappears.
  - Feature-off case: marker + entries all gone.
  - User-owned lines outside the managed block stay put (test seeds
    `# user ignores\n/logs/\n\n` before the first sync).
- `doc/test/TEST.md` updated (29 → 32).
- Example in `config/docker/setup.conf:142` plus four README
  translations flips `./logs/` → `./log/`.
- CHANGELOG `[Unreleased]` Added entry covers the prune behavior.

## Test plan

- [x] `make -f Makefile.ci test` (Docker) green; new tests 187 / 188 /
  189 pass.
- [x] Six existing `_sync_logging_local_paths_gitignore` tests (#328)
  still pass.
- [x] Existing idempotency test holds (re-running with the same input
  produces byte-identical output).
- [ ] CI green (Y bump; awaiting `ci-rollup` aggregator =
  `bats-unit` / `bats-integration` / `lint` / `hadolint`).

## Follow-up (out of scope)

- New base tag (Y bump) cut after merge; user decides the exact
  `v0.X.Y` and timing.
- `ros1_bridge` `config/docker/setup.conf` override flip
  (`./logs/` → `./log/`) once the new base tag is consumed via
  `make upgrade VERSION=…` in that repo.
