### PR TITLE
fix(upgrade.sh): anchor #399 idempotency regex to prevent /lint/script/ false-positive (closes #403)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `upgrade.sh` #399 idempotency regex false-positive: `COPY script/*.sh /lint/script/` was matching the already-patched check because `/lint/` is a prefix of `/lint/script/`. Anchored the regex with `$` so only the exact `/lint/` destination triggers the skip. Closes #403.
+
 ## [v0.34.1] - 2026-05-25
 
 Patch release: single feature from #399 / PR #400.

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1416 tests** total (1352 unit + 64 integration).
+Template self-tests: **1447 tests** total (1379 unit + 68 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -1193,7 +1193,7 @@ invocation — `build.sh --dry-run`).
 | `fresh clone with stale absolute mount_1: build.sh auto-migrates + generates local .env` | Stale-path auto-migrate |
 | `fresh clone with portable ${WS_PATH} mount_1: no warning, .env gets local path` | Happy path round-trip |
 
-### test/integration/upgrade_spec.bats (15)
+### test/integration/upgrade_spec.bats (16)
 
 End-to-end verification for `upgrade.sh` driving a real subtree update
 against a fake template remote (bare repo with `v0.9.5` / `v0.9.7` tags
@@ -1212,6 +1212,10 @@ lint-stage auto-patch that heals downstream Dockerfiles missing the
 | `upgrade.sh is idempotent on Dockerfile already containing the lib COPY line (#348)` | Already-patched Dockerfile is unchanged on re-run |
 | `upgrade.sh warns + skips Dockerfile patch when stock shellcheck anchor is missing (#348)` | Custom Dockerfile shape opts out of auto-heal |
 | `upgrade.sh continues cleanly when no Dockerfile at repo root (#348)` | Subtree-only repos (no consumer Dockerfile) skip silently |
+| `upgrade.sh patches Dockerfile COPY *.sh /lint/ → script/*.sh /lint/ (#399)` | Auto-patch stale root COPY post-#330 |
+| `upgrade.sh is idempotent when Dockerfile already has COPY script/*.sh /lint/ (#399)` | Already-patched COPY skipped |
+| `upgrade.sh skips #399 patch when Dockerfile has no COPY *.sh /lint/ line` | No stale line to patch |
+| `upgrade.sh patches stale COPY *.sh /lint/ even when COPY script/*.sh /lint/script/ exists (#403)` | Regression: /lint/script/ must not false-positive |
 | `upgrade.sh v0.9.7 is idempotent on a second run` | Re-run is no-op |
 | `upgrade.sh --check reports update available from v0.9.5 → v0.9.7` | --check flag |
 | `make upgrade-check (downstream Makefile): exit 0 when update available (#175)` | Regression #175: make wraps exit 1 |

--- a/test/integration/upgrade_spec.bats
+++ b/test/integration/upgrade_spec.bats
@@ -228,6 +228,28 @@ EOF
   [ "$(grep -c 'COPY script/\*\.sh /lint/' Dockerfile)" = "1" ]
 }
 
+@test "upgrade.sh patches stale COPY *.sh /lint/ even when COPY script/*.sh /lint/script/ exists (#403)" {
+  cd "${DOWN_DIR}"
+  mkdir -p script
+  ln -sf ../.base/script/docker/build.sh script/build.sh
+  cat > Dockerfile <<'EOF'
+FROM busybox AS lint
+COPY *.sh /lint/
+COPY script/*.sh /lint/script/
+COPY .base/script/docker/lib /lint/lib
+RUN shellcheck -S warning /lint/*.sh /lint/script/*.sh /lint/lib/*.sh
+EOF
+  git add Dockerfile script/
+  git commit -q -m "add Dockerfile (stale root + script/ subdest)"
+
+  run env TEMPLATE_REMOTE="file://${TMPL_BARE}" ./.base/upgrade.sh v0.9.7
+  assert_success
+  assert_output --partial "Dockerfile patched: COPY *.sh /lint/ -> COPY script/*.sh /lint/ (#399)"
+
+  grep -qE '^COPY script/\*\.sh /lint/$' Dockerfile
+  grep -q 'COPY script/\*\.sh /lint/script/' Dockerfile
+}
+
 @test "upgrade.sh skips #399 patch when Dockerfile has no COPY *.sh /lint/ line" {
   cd "${DOWN_DIR}"
   cat > Dockerfile <<'EOF'

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -331,7 +331,7 @@ _upgrade() {
   # Modelled on the Step 5 / #348 precedent above.
   if [[ ! -f "${_dockerfile}" ]]; then
     _log "  no Dockerfile at repo root — skip (#399 wrapper-copy patch)"
-  elif grep -qE '^[[:space:]]*COPY[[:space:]]+script/\*\.sh[[:space:]]+/lint/' "${_dockerfile}"; then
+  elif grep -qE '^[[:space:]]*COPY[[:space:]]+script/\*\.sh[[:space:]]+/lint/?[[:space:]]*$' "${_dockerfile}"; then
     _log "  Dockerfile already uses COPY script/*.sh /lint/ — skip (#399 idempotent)"
   elif grep -qE '^[[:space:]]*COPY[[:space:]]+\*\.sh[[:space:]]+/lint/' "${_dockerfile}"; then
     sed -i -E 's|^([[:space:]]*)COPY[[:space:]]+\*\.sh[[:space:]]+/lint/|\1COPY script/*.sh /lint/|' "${_dockerfile}"


### PR DESCRIPTION
## Summary

- Fix `upgrade.sh` #399 idempotency regex false-positive when downstream Dockerfile has `COPY script/*.sh /lint/script/` (closes #403)
- Add regression test in `upgrade_spec.bats`
- TEST.md count synced (1379 unit + 68 integration = 1447)

## Detail

The grep pattern on line 334 matched `COPY script/*.sh /lint/script/` because `/lint/` is a prefix of `/lint/script/`. Repos with both the stale `COPY *.sh /lint/` and a separate `COPY script/*.sh /lint/script/` (for repo-specific helpers used by in-image tests) triggered a false-positive skip.

Fix: append `/?[[:space:]]*$` to the regex anchor.

Observed on `ycpss91255-docker/isaac` PR #27 — workaround applied there (manual dual-COPY).

## Test plan

- [x] `make -f Makefile.ci test` all green (1447 tests)
- [x] New test `upgrade.sh patches stale COPY *.sh /lint/ even when COPY script/*.sh /lint/script/ exists (#403)` passes
- [x] Existing #399 idempotency test still passes (no regression)