### PR TITLE
feat(setup.conf): add [network] pid for PID namespace mode (closes #412)

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Allowlist (v1 — keys that can be overridden per-stage):
 |---|---|
 | `[deploy]` | `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime` |
 | `[gui]` | `mode` |
-| `[network]` | `mode`, `ipc`, `network_name`, `port_<N>`, `port_inherit` |
+| `[network]` | `mode`, `ipc`, `pid`, `network_name`, `port_<N>`, `port_inherit` |
 | `[security]` | `privileged` |
 | `[volumes]` | `mount_<N>`, `mount_inherit` |
 | `[environment]` | `env_<N>`, `env_inherit` |
@@ -348,7 +348,7 @@ two derived artifacts.
 [build]    apt_mirror_ubuntu, apt_mirror_debian            # Dockerfile build args
 [deploy]   gpu_mode (auto|force|off), gpu_count, gpu_capabilities
 [gui]      mode (auto|force|off)
-[network]  mode (host|bridge|none), ipc, privileged
+[network]  mode (host|bridge|none), ipc, pid (host|private), privileged
 [volumes]  mount_1 (workspace, auto-populated on first run)
            mount_2..mount_N (extra host mounts; devices via /dev path)
 [logging]  driver (json-file default), max_size, max_file, compress

--- a/config/docker/setup.conf
+++ b/config/docker/setup.conf
@@ -75,6 +75,7 @@ mode = auto
 [network]
 mode = host
 ipc = host
+pid = private
 network_name =
 
 # ═════════════════════════════════════════════════════════════════════

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`[network] pid` setting** for PID namespace mode (`host` / `private`). Default `private` (Docker default). Set `pid = host` when running multiple GPU-rendering containers on the same GPU to avoid NVIDIA driver pthread robust mutex failures (`ESRCH`). Follows the `[network] ipc` precedent: setup.conf -> `.env` `PID_MODE` -> compose.yaml `pid:`. Per-stage override and TUI selection (4 languages) included. Closes #412.
+
 ### Fixed
 - **Makefile forwarding: absolute container paths** — `make exec -- /root/demo/test.sh` failed with `No rule to make target` because GNU Make's built-in implicit rules stat every goal on the host filesystem. Added `--no-builtin-rules` + `.SUFFIXES:` so the `%:` catch-all fires correctly for arbitrary absolute paths. Closes #414 (case 2).
 - **Makefile forwarding: VAR=VALUE args silently lost** — `make setup set build.arg_4 ROS2_DISTRO=jazzy` dropped the `ROS2_DISTRO=jazzy` token because Make treats any `KEY=VALUE` CLI token as a variable override, not a goal. Added a `MAKEOVERRIDES` guard that detects swallowed args and aborts with a clear error message pointing users to the underlying script. Closes #414 (case 1).

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -249,7 +249,7 @@ Override 可能な key (v1)：
 |---|---|
 | `[deploy]` | `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime` |
 | `[gui]` | `mode` |
-| `[network]` | `mode`, `ipc`, `network_name`, `port_<N>`, `port_inherit` |
+| `[network]` | `mode`, `ipc`, `pid`, `network_name`, `port_<N>`, `port_inherit` |
 | `[security]` | `privileged` |
 | `[volumes]` | `mount_<N>`, `mount_inherit` |
 | `[environment]` | `env_<N>`, `env_inherit` |
@@ -314,7 +314,7 @@ assertion helpers のセットを提供します。ダウンストリーム repo
 [build]    apt_mirror_ubuntu、apt_mirror_debian            # Dockerfile build args
 [deploy]   gpu_mode (auto|force|off)、gpu_count、gpu_capabilities
 [gui]      mode (auto|force|off)
-[network]  mode (host|bridge|none)、ipc、privileged
+[network]  mode (host|bridge|none)、ipc、pid (host|private)、privileged
 [volumes]  mount_1（workspace、初回 setup.sh 実行時に自動記入）
            mount_2..mount_N（ユーザ定義の追加 host mount；/dev デバイスは path 指定）
 [logging]  driver（デフォルト json-file）、max_size、max_file、compress

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -241,7 +241,7 @@ deploy.gpu_capabilities = gpu compute utility graphics video
 |---|---|
 | `[deploy]` | `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime` |
 | `[gui]` | `mode` |
-| `[network]` | `mode`, `ipc`, `network_name`, `port_<N>`, `port_inherit` |
+| `[network]` | `mode`, `ipc`, `pid`, `network_name`, `port_<N>`, `port_inherit` |
 | `[security]` | `privileged` |
 | `[volumes]` | `mount_<N>`, `mount_inherit` |
 | `[environment]` | `env_<N>`, `env_inherit` |
@@ -302,7 +302,7 @@ assertion helpers。下游 repo 应优先使用这些 helper 而非原生的
 [build]    apt_mirror_ubuntu、apt_mirror_debian            # Dockerfile build args
 [deploy]   gpu_mode (auto|force|off)、gpu_count、gpu_capabilities
 [gui]      mode (auto|force|off)
-[network]  mode (host|bridge|none)、ipc、privileged
+[network]  mode (host|bridge|none)、ipc、pid (host|private)、privileged
 [volumes]  mount_1（workspace，首次 setup.sh 执行时自动填入）
            mount_2..mount_N（用户自定义额外 host mount；/dev 设备走 path）
 [logging]  driver（默认 json-file）、max_size、max_file、compress

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -241,7 +241,7 @@ deploy.gpu_capabilities = gpu compute utility graphics video
 |---|---|
 | `[deploy]` | `gpu_mode`, `gpu_count`, `gpu_capabilities`, `runtime` |
 | `[gui]` | `mode` |
-| `[network]` | `mode`, `ipc`, `network_name`, `port_<N>`, `port_inherit` |
+| `[network]` | `mode`, `ipc`, `pid`, `network_name`, `port_<N>`, `port_inherit` |
 | `[security]` | `privileged` |
 | `[volumes]` | `mount_<N>`, `mount_inherit` |
 | `[environment]` | `env_<N>`, `env_inherit` |
@@ -302,7 +302,7 @@ assertion helpers。下游 repo 應優先使用這些 helper 而非原生的
 [build]    apt_mirror_ubuntu、apt_mirror_debian            # Dockerfile build args
 [deploy]   gpu_mode (auto|force|off)、gpu_count、gpu_capabilities
 [gui]      mode (auto|force|off)
-[network]  mode (host|bridge|none)、ipc、privileged
+[network]  mode (host|bridge|none)、ipc、pid (host|private)、privileged
 [volumes]  mount_1（workspace，首次 setup.sh 執行時自動填入）
            mount_2..mount_N（使用者自訂額外 host mount；/dev 裝置走 path）
 [logging]  driver（預設 json-file）、max_size、max_file、compress

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -77,7 +77,7 @@ Template self-tests: **1452 tests** total (1384 unit + 68 integration).
 | `_log_plain with no tag exits non-zero (param ':?' guard)` | Required tag guard |
 | `_log_plain with unknown style + FORCE_COLOR=1 falls back to no ANSI (case match miss)` | Unknown style safe fallback |
 
-### test/unit/setup_spec.bats (305)
+### test/unit/setup_spec.bats (308)
 
 Covers core detection (user/hardware/docker/GPU/GUI), the INI parser
 (`_parse_ini_section`), setup.conf section merging (`_load_setup_conf`
@@ -111,7 +111,7 @@ writeback (first-time bootstrap / user-edit respect / opt-out).
 | Per-repo setup.conf missing / empty WARN (#150 / #186: missing → WARN, empty → WARN, partial → silent, zh-TW lang) | 4 |
 | Per-repo setup.conf WARN on check-drift path (#157 / #186: missing → WARN, empty → WARN, partial → silent, zh-TW lang) | 4 |
 | `[additional_contexts]` parsing + compose emission (#199: omitted by default, devel/test block, runtime block, numeric sort, empty-slot skip, _setup_known_section) | 6 |
-| Per-section setup.conf parameter end-to-end coverage (#202: [deploy] gpu_mode/count/capabilities/runtime, [gui] mode, [network] mode/ipc/network_name/port_*, [resources] shm_size, [environment] env_*, [tmpfs] tmpfs_*, [devices] device_*/cgroup_rule_*, [volumes] mount_2..N, [security] privileged) | 25 |
+| Per-section setup.conf parameter end-to-end coverage (#202: [deploy] gpu_mode/count/capabilities/runtime, [gui] mode, [network] mode/ipc/pid/network_name/port_*, [resources] shm_size, [environment] env_*, [tmpfs] tmpfs_*, [devices] device_*/cgroup_rule_*, [volumes] mount_2..N, [security] privileged) | 28 |
 | `_validate_stage_name` (#215: format / baseline / reserved exit codes) | 4 |
 | `_parse_dockerfile_stages` (#215: extract, dedup, file-order, missing file, lowercase `as` rejection) | 6 |
 | `_compute_dockerfile_hash` (#215: stable / add / remove / non-FROM-AS edits / missing) | 5 |
@@ -180,7 +180,7 @@ target areas the issue body called out.
 | `_swap_image_rule` (both occupied / target empty / source empty / both empty / m<1) | 5 |
 | `_edit_list_section` via `_edit_section_environment` (env_ add/edit/remove, invalid → msgbox+retry, max+1 indexing, Cancel/Esc) | 7 |
 | `_edit_section_image` top-level dispatch (add max+1, click rule_N, Back) | 3 |
-| `_edit_section_network` (host+host no shm prompt, bridge prompts name+ports, ipc=private prompts shm, empty network_name allowed) | 4 |
+| `_edit_section_network` (host+host+pid no shm prompt, bridge prompts name+ports, ipc=private prompts shm, empty network_name allowed) | 4 |
 | `_edit_section_deploy` (off short-circuits — only writes gpu_mode) | 1 |
 | Multi-section dispatch from main menu (network → host → save) | 1 |
 | Per-stage UI #220 (`_list_dockerfile_stages_available` from-Dockerfile + baseline filter, `_count_stage_overrides` OVR+CURRENT dedup + empty skip, `_edit_stage_gui` mode + __inherit, `_edit_stage_scalar` write + empty-clears, `_edit_stage_list` inherit toggle + add) | 10 |
@@ -670,7 +670,7 @@ conditional GPU deploy block + GUI env/volumes + extra volumes from
 |------|-------------|
 | `outputs AUTO-GENERATED header` | Header check |
 | `always emits workspace volume` | Baseline |
-| `emits network_mode/ipc/privileged via env var` | env-var baked |
+| `emits network_mode/ipc/pid/privileged via env var` | env-var baked |
 | `emits test service with profiles: [test]` | test service |
 | `image field contains repo name` | Image name |
 | `does NOT emit /dev:/dev by default (not in baseline)` | Baseline scope |

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1452 tests** total (1384 unit + 68 integration).
+Template self-tests: **1458 tests** total (1390 unit + 68 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -77,7 +77,7 @@ Template self-tests: **1452 tests** total (1384 unit + 68 integration).
 | `_log_plain with no tag exits non-zero (param ':?' guard)` | Required tag guard |
 | `_log_plain with unknown style + FORCE_COLOR=1 falls back to no ANSI (case match miss)` | Unknown style safe fallback |
 
-### test/unit/setup_spec.bats (308)
+### test/unit/setup_spec.bats (309)
 
 Covers core detection (user/hardware/docker/GPU/GUI), the INI parser
 (`_parse_ini_section`), setup.conf section merging (`_load_setup_conf`
@@ -658,19 +658,22 @@ multiple positional args); `VAR=VALUE` guard via `MAKEOVERRIDES` (single,
 multiple, after `--` separator — all abort with error); absolute
 container path forwarding (`/nonexistent/...`, `/root/demo/...`).
 
-### test/unit/compose_gen_spec.bats (50)
+### test/unit/compose_gen_spec.bats (52)
 
 Covers `generate_compose_yaml` conditional output: AUTO-GENERATED
 header, baseline workspace volume, network/ipc/privileged env-var
-references, `test` service presence, image name threading, and
-conditional GPU deploy block + GUI env/volumes + extra volumes from
-`[volumes]` section.
+references, conditional pid emission (only for `host`; omitted for
+`private` since Docker rejects the literal), `test` service presence,
+image name threading, and conditional GPU deploy block + GUI
+env/volumes + extra volumes from `[volumes]` section.
 
 | Test | Description |
 |------|-------------|
 | `outputs AUTO-GENERATED header` | Header check |
 | `always emits workspace volume` | Baseline |
-| `emits network_mode/ipc/pid/privileged via env var` | env-var baked |
+| `emits network_mode/ipc/privileged via env var` | env-var baked |
+| `omits pid when default private` | pid omit |
+| `emits pid env-var ref when host` | pid host |
 | `emits test service with profiles: [test]` | test service |
 | `image field contains repo name` | Image name |
 | `does NOT emit /dev:/dev by default (not in baseline)` | Baseline scope |

--- a/script/docker/lib/config_summary.sh
+++ b/script/docker/lib/config_summary.sh
@@ -222,9 +222,9 @@ _print_config_summary() {
     "$(_lib_msg gpu_enabled)" "${GPU_ENABLED:--}" "${GPU_COUNT:--}" "${GPU_CAPABILITIES:--}"
   printf "[%s]   %s : %s\n" "${_tag}" \
     "$(_lib_msg gui_enabled)" "${SETUP_GUI_DETECTED:--}"
-  printf "[%s]   %s     : %s  ipc=%s  %s=%s\n" "${_tag}" \
+  printf "[%s]   %s     : %s  ipc=%s  pid=%s  %s=%s\n" "${_tag}" \
     "$(_lib_msg network)" "${NETWORK_MODE:--}" "${IPC_MODE:--}" \
-    "$(_lib_msg privileged)" "${PRIVILEGED:--}"
+    "${PID_MODE:--}" "$(_lib_msg privileged)" "${PRIVILEGED:--}"
   printf "[%s]   TZ=%s  apt_ubuntu=%s  apt_debian=%s\n" "${_tag}" \
     "${TZ:--}" "${APT_MIRROR_UBUNTU:--}" "${APT_MIRROR_DEBIAN:--}"
 

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -1153,7 +1153,7 @@ _load_stage_overrides() {
 #
 #   [deploy]      gpu_mode, gpu_count, gpu_capabilities, runtime
 #   [gui]         mode
-#   [network]     mode, ipc, network_name, port_<N>, port_inherit
+#   [network]     mode, ipc, pid, network_name, port_<N>, port_inherit
 #   [security]    privileged
 #   [volumes]     mount_<N>, mount_inherit
 #   [environment] env_<N>, env_inherit
@@ -1168,7 +1168,7 @@ _validate_stage_override_key() {
   case "${_key}" in
     deploy.gpu_mode|deploy.gpu_count|deploy.gpu_capabilities|deploy.runtime) return 0 ;;
     gui.mode) return 0 ;;
-    network.mode|network.ipc|network.network_name) return 0 ;;
+    network.mode|network.ipc|network.pid|network.network_name) return 0 ;;
     security.privileged) return 0 ;;
     network.port_inherit|volumes.mount_inherit|environment.env_inherit) return 0 ;;
   esac
@@ -1568,17 +1568,18 @@ generate_compose_yaml() {
   local _shm_size="${13:-}"
   local _net_mode="${14:-host}"
   local _ipc_mode="${15:-host}"
-  local _cap_add_str="${16:-}"
-  local _cap_drop_str="${17:-}"
-  local _sec_opt_str="${18:-}"
-  local _cgroup_rule_str="${19:-}"
-  local _user_build_args_str="${20:-}"
-  local _target_arch="${21:-}"
-  local _build_network="${22:-}"
-  local _runtime="${23:-}"
-  local _additional_contexts_str="${24:-}"
-  local _logging_global_str="${25:-}"
-  local _logging_per_svc_str="${26:-}"
+  local _pid_mode="${16:-private}"
+  local _cap_add_str="${17:-}"
+  local _cap_drop_str="${18:-}"
+  local _sec_opt_str="${19:-}"
+  local _cgroup_rule_str="${20:-}"
+  local _user_build_args_str="${21:-}"
+  local _target_arch="${22:-}"
+  local _build_network="${23:-}"
+  local _runtime="${24:-}"
+  local _additional_contexts_str="${25:-}"
+  local _logging_global_str="${26:-}"
+  local _logging_per_svc_str="${27:-}"
 
   # _logging_svc_kv <svc> <out_assoc_name>
   #
@@ -1892,6 +1893,7 @@ YAML
     container_name: \${USER_NAME}-${_name}\${INSTANCE_SUFFIX:-}
     privileged: \${PRIVILEGED}
     ipc: \${IPC_MODE}
+    pid: \${PID_MODE}
     stdin_open: true
     tty: true
 YAML
@@ -2165,9 +2167,10 @@ YAML
       _resolve_stage_scalar _so_filtered_keys _so_filtered_values "deploy.gpu_capabilities" "${_gpu_caps}" _eff_gpu_caps
       _resolve_stage_scalar _so_filtered_keys _so_filtered_values "deploy.runtime" "${_runtime}" _eff_runtime
 
-      local _eff_net_mode _eff_ipc_mode _eff_net_name _eff_privileged
+      local _eff_net_mode _eff_ipc_mode _eff_pid_mode _eff_net_name _eff_privileged
       _resolve_stage_scalar _so_filtered_keys _so_filtered_values "network.mode" "${_net_mode}" _eff_net_mode
       _resolve_stage_scalar _so_filtered_keys _so_filtered_values "network.ipc" "${_ipc_mode}" _eff_ipc_mode
+      _resolve_stage_scalar _so_filtered_keys _so_filtered_values "network.pid" "${_pid_mode}" _eff_pid_mode
       _resolve_stage_scalar _so_filtered_keys _so_filtered_values "network.network_name" "${_net_name}" _eff_net_name
       _resolve_stage_scalar _so_filtered_keys _so_filtered_values "security.privileged" "" _eff_privileged
 
@@ -2239,6 +2242,12 @@ YAML
         echo "    ipc: ${_eff_ipc_mode}"
       else
         echo "    ipc: \${IPC_MODE}"
+      fi
+      # pid: literal when stage overrides; else env-var ref.
+      if [[ "${_eff_pid_mode}" != "${_pid_mode}" ]]; then
+        echo "    pid: ${_eff_pid_mode}"
+      else
+        echo "    pid: \${PID_MODE}"
       fi
       # runtime: only when explicitly set non-empty / non-auto / non-off.
       if [[ -n "${_eff_runtime}" ]] && \
@@ -2455,7 +2464,7 @@ YAML
 #                  <hardware> <docker_hub_user> <gpu_detected>
 #                  <image_name> <ws_path>
 #                  <apt_mirror_ubuntu> <apt_mirror_debian> <tz>
-#                  <network_mode> <ipc_mode> <privileged>
+#                  <network_mode> <ipc_mode> <pid_mode> <privileged>
 #                  <gpu_count> <gpu_caps>
 #                  <gui_detected> <conf_hash>
 #                  [<network_name>] [<user_build_args>] [<target_arch>]
@@ -2487,6 +2496,7 @@ write_env() {
   local _tz="${1}"; shift
   local _network_mode="${1}"; shift
   local _ipc_mode="${1}"; shift
+  local _pid_mode="${1}"; shift
   local _privileged="${1}"; shift
   local _gpu_count="${1}"; shift
   local _gpu_caps="${1}"; shift
@@ -2532,6 +2542,7 @@ TZ=${_tz}
 NETWORK_MODE=${_network_mode}
 NETWORK_NAME=${_network_name}
 IPC_MODE=${_ipc_mode}
+PID_MODE=${_pid_mode}
 PRIVILEGED=${_privileged}
 GPU_COUNT=${_gpu_count}
 GPU_CAPABILITIES="${_gpu_caps}"
@@ -3810,7 +3821,7 @@ _setup_apply() {
 
   local gpu_mode="" gpu_count="" gpu_caps="" runtime_mode=""
   local gui_mode=""
-  local net_mode="" ipc_mode="" privileged="" network_name=""
+  local net_mode="" ipc_mode="" pid_mode="" privileged="" network_name=""
   _get_conf_value _dep_k _dep_v "gpu_mode"         "auto" gpu_mode
   _get_conf_value _dep_k _dep_v "gpu_count"        "all"  gpu_count
   _get_conf_value _dep_k _dep_v "gpu_capabilities" "gpu"  gpu_caps
@@ -3828,8 +3839,9 @@ _setup_apply() {
     esac
   fi
   _get_conf_value _net_k _net_v "mode"             "host" net_mode
-  _get_conf_value _net_k _net_v "ipc"              "host" ipc_mode
-  _get_conf_value _net_k _net_v "network_name"     ""     network_name
+  _get_conf_value _net_k _net_v "ipc"              "host"    ipc_mode
+  _get_conf_value _net_k _net_v "pid"              "private" pid_mode
+  _get_conf_value _net_k _net_v "network_name"     ""        network_name
   _get_conf_value _sec_k _sec_v "privileged"       "true" privileged
 
   # ── WS_PATH + workspace mount ──
@@ -4049,6 +4061,7 @@ _setup_apply() {
     printf 'GUI_ENABLED=%s\n' "${gui_enabled_eff}"
     printf 'NETWORK_MODE=%s\n' "${net_mode}"
     printf 'IPC_MODE=%s\n' "${ipc_mode}"
+    printf 'PID_MODE=%s\n' "${pid_mode}"
     printf 'PRIVILEGED=%s\n' "${privileged}"
     printf 'NETWORK_NAME=%s\n' "${network_name}"
     printf 'TARGET_ARCH=%s\n' "${target_arch}"
@@ -4084,7 +4097,7 @@ _setup_apply() {
     "${hardware}" "${docker_hub_user}" "${gpu_detected}" \
     "${image_name}" "${ws_path}" \
     "${apt_mirror_ubuntu}" "${apt_mirror_debian}" "${tz}" \
-    "${net_mode}" "${ipc_mode}" "${privileged}" \
+    "${net_mode}" "${ipc_mode}" "${pid_mode}" "${privileged}" \
     "${gpu_count}" "${gpu_caps}" \
     "${gui_detected}" "${conf_hash}" "${dockerfile_hash}" \
     "${network_name}" \
@@ -4106,7 +4119,7 @@ _setup_apply() {
     extra_volumes "${network_name}" \
     "${_devices_str}" \
     "${_env_str}" "${_tmpfs_str}" "${_ports_str}" \
-    "${_shm_size}" "${net_mode}" "${ipc_mode}" \
+    "${_shm_size}" "${net_mode}" "${ipc_mode}" "${pid_mode}" \
     "${_cap_add_str}" "${_cap_drop_str}" "${_sec_opt_str}" \
     "${_cgroup_rule_str}" \
     "${_user_build_args_str}" \

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -1893,7 +1893,13 @@ YAML
     container_name: \${USER_NAME}-${_name}\${INSTANCE_SUFFIX:-}
     privileged: \${PRIVILEGED}
     ipc: \${IPC_MODE}
-    pid: \${PID_MODE}
+YAML
+    # pid: only emitted for "host" — Docker rejects "private" as a
+    # literal; omitting the key gives the same private-namespace default.
+    if [[ "${_pid_mode}" == "host" ]]; then
+      echo "    pid: \${PID_MODE}"
+    fi
+    cat <<YAML
     stdin_open: true
     tty: true
 YAML
@@ -2243,11 +2249,13 @@ YAML
       else
         echo "    ipc: \${IPC_MODE}"
       fi
-      # pid: literal when stage overrides; else env-var ref.
-      if [[ "${_eff_pid_mode}" != "${_pid_mode}" ]]; then
-        echo "    pid: ${_eff_pid_mode}"
-      else
-        echo "    pid: \${PID_MODE}"
+      # pid: only emitted for "host" — Docker rejects "private" as literal.
+      if [[ "${_eff_pid_mode}" == "host" ]]; then
+        if [[ "${_eff_pid_mode}" != "${_pid_mode}" ]]; then
+          echo "    pid: ${_eff_pid_mode}"
+        else
+          echo "    pid: \${PID_MODE}"
+        fi
       fi
       # runtime: only when explicitly set non-empty / non-auto / non-off.
       if [[ -n "${_eff_runtime}" ]] && \

--- a/script/docker/setup_tui.sh
+++ b/script/docker/setup_tui.sh
@@ -50,7 +50,7 @@ _TUI_MSG_EN[title]="Docker Container Configuration"
 _TUI_MSG_EN[main.prompt]=""
 _TUI_MSG_EN[main.image]="IMAGE_NAME detection rules"
 _TUI_MSG_EN[main.build]="APT mirrors + Dockerfile build args"
-_TUI_MSG_EN[main.network]="mode / ipc / name"
+_TUI_MSG_EN[main.network]="mode / ipc / pid / name"
 _TUI_MSG_EN[main.deploy]="GPU reservation"
 _TUI_MSG_EN[main.gui]="display mode"
 _TUI_MSG_EN[main.volumes]="workspace + extra mounts"
@@ -90,7 +90,7 @@ _TUI_MSG_EN[per_stage.overrides_set]="overrides set"
 _TUI_MSG_EN[per_stage.inherits_all]="(inherits all)"
 _TUI_MSG_EN[per_stage.one.menu]="Pick a section to edit, or Back"
 _TUI_MSG_EN[per_stage.scalar.menu]="Pick a key to edit, or Back"
-_TUI_MSG_EN[per_stage.scalar.prompt]=$'Override value\n  - Empty = inherit top-level (clear this override)\n  - For mode keys: auto / force / off (gui, gpu)\n  - For network mode: host / bridge / none\n  - For ipc: host / shareable / private\n  - For privileged: true / false\n  - For runtime: auto / nvidia / off'
+_TUI_MSG_EN[per_stage.scalar.prompt]=$'Override value\n  - Empty = inherit top-level (clear this override)\n  - For mode keys: auto / force / off (gui, gpu)\n  - For network mode: host / bridge / none\n  - For ipc: host / shareable / private\n  - For pid: host / private\n  - For privileged: true / false\n  - For runtime: auto / nvidia / off'
 _TUI_MSG_EN[per_stage.list.menu]="Edit list entries, toggle inheritance, or Back"
 _TUI_MSG_EN[per_stage.list.entry_prompt]=$'List entry value\n  - Empty = delete this entry\n  - Format depends on the list (mount: host:container[:mode] / port: host:container[/proto] / env: KEY=VALUE)'
 _TUI_MSG_EN[per_stage.network.ports]="ports list (per-stage)"
@@ -152,6 +152,9 @@ _TUI_MSG_EN[network.ipc.prompt]="IPC namespace"
 _TUI_MSG_EN[network.ipc.host]="host (share host IPC / shared memory)"
 _TUI_MSG_EN[network.ipc.shareable]="shareable (own IPC, accessible to other containers)"
 _TUI_MSG_EN[network.ipc.private]="private (own IPC, isolated — Docker default)"
+_TUI_MSG_EN[network.pid.prompt]="PID namespace"
+_TUI_MSG_EN[network.pid.host]="host (share host PID namespace — required for multi-GPU-container NVIDIA driver mutex)"
+_TUI_MSG_EN[network.pid.private]="private (own PID namespace — Docker default)"
 _TUI_MSG_EN[network.priv.prompt]="Run container privileged?"
 _TUI_MSG_EN[network.name.prompt]=$'Bridge network name\n  - Empty = compose auto-creates <project>_default bridge each run\n  - Non-empty = compose creates a bridge with this name (auto-managed)\n      Example: my_bridge\n        → compose creates <project>_my_bridge on up\n        → removed on down'
 _TUI_MSG_EN[deploy.title]="Deploy"
@@ -305,7 +308,7 @@ _TUI_MSG_ZH_TW[per_stage.overrides_set]="個 override"
 _TUI_MSG_ZH_TW[per_stage.inherits_all]="(全部繼承)"
 _TUI_MSG_ZH_TW[per_stage.one.menu]="選擇要編輯的 section，或返回"
 _TUI_MSG_ZH_TW[per_stage.scalar.menu]="選擇要編輯的 key，或返回"
-_TUI_MSG_ZH_TW[per_stage.scalar.prompt]=$'Override 值\n  - 空白 = 繼承 top-level（清除此 override）\n  - mode keys：auto / force / off (gui, gpu)\n  - network mode：host / bridge / none\n  - ipc：host / shareable / private\n  - privileged：true / false\n  - runtime：auto / nvidia / off'
+_TUI_MSG_ZH_TW[per_stage.scalar.prompt]=$'Override 值\n  - 空白 = 繼承 top-level（清除此 override）\n  - mode keys：auto / force / off (gui, gpu)\n  - network mode：host / bridge / none\n  - ipc：host / shareable / private\n  - pid：host / private\n  - privileged：true / false\n  - runtime：auto / nvidia / off'
 _TUI_MSG_ZH_TW[per_stage.list.menu]="編輯 list 項目、切換繼承、或返回"
 _TUI_MSG_ZH_TW[per_stage.list.entry_prompt]=$'List 項目值\n  - 空白 = 刪除此項目\n  - 格式依 list 不同（mount: host:container[:mode] / port: host:container[/proto] / env: KEY=VALUE）'
 _TUI_MSG_ZH_TW[per_stage.network.ports]="ports list (per-stage)"
@@ -367,6 +370,9 @@ _TUI_MSG_ZH_TW[network.ipc.prompt]="IPC 命名空間"
 _TUI_MSG_ZH_TW[network.ipc.host]="host（共用主機 IPC／共享記憶體）"
 _TUI_MSG_ZH_TW[network.ipc.shareable]="shareable（獨立 IPC，其他容器可存取）"
 _TUI_MSG_ZH_TW[network.ipc.private]="private（獨立 IPC，Docker 預設）"
+_TUI_MSG_ZH_TW[network.pid.prompt]="PID 命名空間"
+_TUI_MSG_ZH_TW[network.pid.host]="host（共用主機 PID 命名空間 — 多 GPU 容器 NVIDIA 驅動 mutex 需要）"
+_TUI_MSG_ZH_TW[network.pid.private]="private（獨立 PID 命名空間 — Docker 預設）"
 _TUI_MSG_ZH_TW[network.priv.prompt]="以特權模式執行？"
 _TUI_MSG_ZH_TW[network.name.prompt]=$'Bridge 網路名稱\n  - 留空 = compose 每次自動建立 <project>_default bridge\n  - 填寫 = compose 建立以此為名的 bridge（仍由 compose 管理）\n      範例：my_bridge\n        → compose 啟動時建立 <project>_my_bridge\n        → 停止時自動移除'
 _TUI_MSG_ZH_TW[deploy.title]="Deploy"
@@ -518,7 +524,7 @@ _TUI_MSG_ZH_CN[per_stage.overrides_set]="个 override"
 _TUI_MSG_ZH_CN[per_stage.inherits_all]="(全部继承)"
 _TUI_MSG_ZH_CN[per_stage.one.menu]="选择要编辑的 section，或返回"
 _TUI_MSG_ZH_CN[per_stage.scalar.menu]="选择要编辑的 key，或返回"
-_TUI_MSG_ZH_CN[per_stage.scalar.prompt]=$'Override 值\n  - 空白 = 继承 top-level（清除此 override）\n  - mode keys：auto / force / off (gui, gpu)\n  - network mode：host / bridge / none\n  - ipc：host / shareable / private\n  - privileged：true / false\n  - runtime：auto / nvidia / off'
+_TUI_MSG_ZH_CN[per_stage.scalar.prompt]=$'Override 值\n  - 空白 = 继承 top-level（清除此 override）\n  - mode keys：auto / force / off (gui, gpu)\n  - network mode：host / bridge / none\n  - ipc：host / shareable / private\n  - pid：host / private\n  - privileged：true / false\n  - runtime：auto / nvidia / off'
 _TUI_MSG_ZH_CN[per_stage.list.menu]="编辑 list 项目、切换继承、或返回"
 _TUI_MSG_ZH_CN[per_stage.list.entry_prompt]=$'List 项目值\n  - 空白 = 删除此项目\n  - 格式依 list 不同（mount: host:container[:mode] / port: host:container[/proto] / env: KEY=VALUE）'
 _TUI_MSG_ZH_CN[per_stage.network.ports]="ports list (per-stage)"
@@ -580,6 +586,9 @@ _TUI_MSG_ZH_CN[network.ipc.prompt]="IPC 命名空间"
 _TUI_MSG_ZH_CN[network.ipc.host]="host（共用主机 IPC／共享内存）"
 _TUI_MSG_ZH_CN[network.ipc.shareable]="shareable（独立 IPC，其他容器可访问）"
 _TUI_MSG_ZH_CN[network.ipc.private]="private（独立 IPC，Docker 默认）"
+_TUI_MSG_ZH_CN[network.pid.prompt]="PID 命名空间"
+_TUI_MSG_ZH_CN[network.pid.host]="host（共用主机 PID 命名空间 — 多 GPU 容器 NVIDIA 驱动 mutex 需要）"
+_TUI_MSG_ZH_CN[network.pid.private]="private（独立 PID 命名空间 — Docker 默认）"
 _TUI_MSG_ZH_CN[network.priv.prompt]="以特权模式运行？"
 _TUI_MSG_ZH_CN[network.name.prompt]=$'Bridge 网络名称\n  - 留空 = compose 每次自动建立 <project>_default bridge\n  - 填写 = compose 建立以此为名的 bridge（仍由 compose 管理）\n      示例：my_bridge\n        → compose 启动时建立 <project>_my_bridge\n        → 停止时自动移除'
 _TUI_MSG_ZH_CN[deploy.title]="Deploy"
@@ -726,7 +735,7 @@ _TUI_MSG_JA[per_stage.overrides_set]="件の override"
 _TUI_MSG_JA[per_stage.inherits_all]="(すべて継承)"
 _TUI_MSG_JA[per_stage.one.menu]="編集する section を選択するか、戻る"
 _TUI_MSG_JA[per_stage.scalar.menu]="編集する key を選択するか、戻る"
-_TUI_MSG_JA[per_stage.scalar.prompt]=$'Override 値\n  - 空白 = top-level を継承（この override をクリア）\n  - mode keys：auto / force / off (gui, gpu)\n  - network mode：host / bridge / none\n  - ipc：host / shareable / private\n  - privileged：true / false\n  - runtime：auto / nvidia / off'
+_TUI_MSG_JA[per_stage.scalar.prompt]=$'Override 値\n  - 空白 = top-level を継承（この override をクリア）\n  - mode keys：auto / force / off (gui, gpu)\n  - network mode：host / bridge / none\n  - ipc：host / shareable / private\n  - pid：host / private\n  - privileged：true / false\n  - runtime：auto / nvidia / off'
 _TUI_MSG_JA[per_stage.list.menu]="list 項目の編集、継承の切替、または戻る"
 _TUI_MSG_JA[per_stage.list.entry_prompt]=$'List 項目の値\n  - 空白 = この項目を削除\n  - 形式は list ごとに異なります（mount: host:container[:mode] / port: host:container[/proto] / env: KEY=VALUE）'
 _TUI_MSG_JA[per_stage.network.ports]="ports list (per-stage)"
@@ -788,6 +797,9 @@ _TUI_MSG_JA[network.ipc.prompt]="IPC 名前空間"
 _TUI_MSG_JA[network.ipc.host]="host（ホスト IPC／共有メモリを共有）"
 _TUI_MSG_JA[network.ipc.shareable]="shareable（独自 IPC、他コンテナから可）"
 _TUI_MSG_JA[network.ipc.private]="private（独自 IPC、Docker デフォルト）"
+_TUI_MSG_JA[network.pid.prompt]="PID 名前空間"
+_TUI_MSG_JA[network.pid.host]="host（ホスト PID 名前空間を共有 — マルチ GPU コンテナの NVIDIA ドライバ mutex に必要）"
+_TUI_MSG_JA[network.pid.private]="private（独自 PID 名前空間 — Docker デフォルト）"
 _TUI_MSG_JA[network.priv.prompt]="特権モードで実行？"
 _TUI_MSG_JA[network.name.prompt]=$'Bridge ネットワーク名\n  - 空 = compose が実行ごとに <project>_default bridge を自動作成\n  - 非空 = この名前の bridge を compose が作成 (compose が管理)\n      例: my_bridge\n        → 起動時 <project>_my_bridge を作成\n        → 停止時に自動削除'
 _TUI_MSG_JA[deploy.title]="Deploy"
@@ -1387,6 +1399,13 @@ _edit_section_network() {
     || return 0
   _override_set "network.ipc" "${_v}"
   local _selected_ipc="${_v}"
+
+  _cur="$(_override_get "network.pid" "private")"
+  _v="$(_tui_select "$(_tui_msg network.title)" "$(_tui_msg network.pid.prompt)" \
+    host    "$(_tui_msg network.pid.host)"    "$([[ "${_cur}" == host ]]    && echo ON || echo off)" \
+    private "$(_tui_msg network.pid.private)" "$([[ "${_cur}" == private ]] && echo ON || echo off)")" \
+    || return 0
+  _override_set "network.pid" "${_v}"
 
   # mode=bridge triggers: network_name + ports list
   if [[ "${_selected_mode}" == "bridge" ]]; then

--- a/test/unit/compose_gen_spec.bats
+++ b/test/unit/compose_gen_spec.bats
@@ -305,7 +305,7 @@ teardown() {
   assert_failure
 }
 
-@test "generate_compose_yaml emits network_mode/ipc/pid/privileged via env var" {
+@test "generate_compose_yaml emits network_mode/ipc/privileged via env var" {
   local _extras=()
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
     "false" "false" "0" "gpu" _extras
@@ -313,9 +313,23 @@ teardown() {
   assert_success
   run grep -F 'ipc: ${IPC_MODE}' "${COMPOSE_OUT}"
   assert_success
-  run grep -F 'pid: ${PID_MODE}' "${COMPOSE_OUT}"
-  assert_success
   run grep -F 'privileged: ${PRIVILEGED}' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "generate_compose_yaml omits pid when default private" {
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras
+  run grep -F 'pid:' "${COMPOSE_OUT}"
+  assert_failure
+}
+
+@test "generate_compose_yaml emits pid env-var ref when host" {
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "host"
+  run grep -F 'pid: ${PID_MODE}' "${COMPOSE_OUT}"
   assert_success
 }
 

--- a/test/unit/compose_gen_spec.bats
+++ b/test/unit/compose_gen_spec.bats
@@ -258,9 +258,9 @@ teardown() {
   local _extras=()
   local _cap_add
   printf -v _cap_add '%s\n%s' "SYS_ADMIN" "NET_ADMIN"
-  # positional: out name gui gpu count caps extras net_name devices env tmpfs ports shm net_mode ipc_mode cap_add cap_drop sec_opt
+  # positional: out name gui gpu count caps extras net_name devices env tmpfs ports shm net_mode ipc_mode pid_mode cap_add cap_drop sec_opt
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "${_cap_add}" "" ""
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" "${_cap_add}" "" ""
   run grep -E '^    cap_add:$' "${COMPOSE_OUT}"
   assert_success
   run grep -F -- '- SYS_ADMIN' "${COMPOSE_OUT}"
@@ -272,7 +272,7 @@ teardown() {
 @test "generate_compose_yaml emits cap_drop from security list" {
   local _extras=()
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "" "ALL" ""
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" "" "ALL" ""
   run grep -E '^    cap_drop:$' "${COMPOSE_OUT}"
   assert_success
   run grep -F -- '- ALL' "${COMPOSE_OUT}"
@@ -284,7 +284,7 @@ teardown() {
   local _sec_opt
   printf -v _sec_opt '%s\n%s' "seccomp:unconfined" "apparmor:unconfined"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "" "" "${_sec_opt}"
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" "" "" "${_sec_opt}"
   run grep -E '^    security_opt:$' "${COMPOSE_OUT}"
   assert_success
   run grep -F -- '- seccomp:unconfined' "${COMPOSE_OUT}"
@@ -305,13 +305,15 @@ teardown() {
   assert_failure
 }
 
-@test "generate_compose_yaml emits network_mode/ipc/privileged via env var" {
+@test "generate_compose_yaml emits network_mode/ipc/pid/privileged via env var" {
   local _extras=()
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
     "false" "false" "0" "gpu" _extras
   run grep -F 'network_mode: ${NETWORK_MODE}' "${COMPOSE_OUT}"
   assert_success
   run grep -F 'ipc: ${IPC_MODE}' "${COMPOSE_OUT}"
+  assert_success
+  run grep -F 'pid: ${PID_MODE}' "${COMPOSE_OUT}"
   assert_success
   run grep -F 'privileged: ${PRIVILEGED}' "${COMPOSE_OUT}"
   assert_success
@@ -347,10 +349,10 @@ teardown() {
 
 @test "generate_compose_yaml emits TARGETARCH line in both services when target_arch set" {
   local _extras=()
-  # Positional args up to #20 are optional (defaults via ${N:-}); pos #21 is target_arch.
+  # Positional args up to #21 are optional (defaults via ${N:-}); pos #22 is target_arch.
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
     "false" "false" "0" "gpu" _extras \
-    "" "" "" "" "" "" "host" "host" \
+    "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "arm64"
   # Must appear under both devel + test service build.args blocks.
   run grep -cF 'TARGETARCH: ${TARGET_ARCH}' "${COMPOSE_OUT}"
@@ -369,10 +371,10 @@ teardown() {
 
 @test "generate_compose_yaml emits build.network line in both services when build_network set" {
   local _extras=()
-  # Pos #22 is build_network (new).
+  # Pos #23 is build_network.
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
     "false" "false" "0" "gpu" _extras \
-    "" "" "" "" "" "" "host" "host" \
+    "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "host"
   # Must appear under both devel + test service build blocks.
   run grep -cE '^      network: host$' "${COMPOSE_OUT}"
@@ -512,11 +514,11 @@ teardown() {
 @test "generate_compose_yaml emits device_cgroup_rules: when cgroup rules provided" {
   local _extras=()
   # positional: gui gpu count caps extras net_name devices env tmpfs ports
-  # shm_size net_mode ipc_mode cap_add cap_drop sec_opt cgroup_rules
+  # shm_size net_mode ipc_mode pid_mode cap_add cap_drop sec_opt cgroup_rules
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
     "false" "false" "0" "gpu" _extras "" \
     "" "" "" "" \
-    "" "host" "host" "" "" "" \
+    "" "host" "host" "private" "" "" "" \
     $'c 189:* rwm\nc 81:* rwm'
   run grep -F 'device_cgroup_rules:' "${COMPOSE_OUT}"
   assert_success
@@ -548,11 +550,11 @@ teardown() {
 
 @test "generate_compose_yaml emits runtime: nvidia under devel when runtime=nvidia" {
   local _extras=()
-  # positional args 1..22 unchanged; 23rd is _runtime.
+  # positional args 1..23 unchanged; 24th is _runtime.
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
     "false" "true" "all" "gpu" _extras "" \
     "" "" "" "" \
-    "" "host" "host" "" "" "" \
+    "" "host" "host" "private" "" "" "" \
     "" "" "" "" \
     "nvidia"
   run grep -F '    runtime: nvidia' "${COMPOSE_OUT}"
@@ -566,7 +568,7 @@ teardown() {
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
     "false" "true" "all" "gpu" _extras "" \
     "" "" "" "" \
-    "" "host" "host" "SYS_ADMIN" "" "" \
+    "" "host" "host" "private" "SYS_ADMIN" "" "" \
     "" "" "" "" \
     "nvidia"
   # runtime: must appear after `tty: true` and before `cap_add:` in devel

--- a/test/unit/compose_logging_spec.bats
+++ b/test/unit/compose_logging_spec.bats
@@ -29,7 +29,7 @@ teardown() {
 @test "generate_compose_yaml omits logging: block when both inputs empty (back-compat)" {
   local _extras=()
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "" ""
   run grep -E '^    logging:$' "${COMPOSE_OUT}"
   assert_failure
@@ -41,7 +41,7 @@ teardown() {
   printf -v _global '%s\n%s\n%s\n%s' \
     "driver=json-file" "max_size=10m" "max_file=3" "compress=true"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" ""
   run grep -E '^    logging:$' "${COMPOSE_OUT}"
   assert_success
@@ -59,7 +59,7 @@ teardown() {
   local _extras=()
   local _global="driver=local"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" ""
   # The test service block sits after devel; assert the logging line
   # appears at least twice (once for devel, once for test).
@@ -72,7 +72,7 @@ teardown() {
   local _extras=()
   local _global="driver=syslog"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" ""
   run grep -F 'driver: syslog' "${COMPOSE_OUT}"
   assert_success
@@ -85,7 +85,7 @@ teardown() {
   local _global
   printf -v _global '%s\n%s' "driver=json-file" "max_size=50m"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" ""
   run grep -E '^      options:$' "${COMPOSE_OUT}"
   assert_success
@@ -103,7 +103,7 @@ teardown() {
   printf -v _global '%s\n%s\n%s' "driver=json-file" "max_size=10m" "max_file=3"
   local _per_svc="test:max_size=50m"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" "${_per_svc}"
   # Both 10m (devel/global) and 50m (test override) should appear.
   run grep -F 'max-size: "10m"' "${COMPOSE_OUT}"
@@ -118,7 +118,7 @@ teardown() {
   printf -v _global '%s\n%s\n%s' "driver=json-file" "max_size=10m" "max_file=3"
   local _per_svc="test:max_size=50m"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" "${_per_svc}"
   # The `test` service's logging block must still emit max-file (inherited).
   # Slice from the second `logging:` line onward and assert max-file appears.
@@ -225,7 +225,7 @@ CONF
   local _global
   printf -v _global '%s\n%s' "driver=json-file" "local_path=./logs/"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" ""
   # Volume mount on devel: <resolved>:/var/log/myrepo
   run grep -F ":/var/log/myrepo" "${COMPOSE_OUT}"
@@ -239,7 +239,7 @@ CONF
   local _extras=()
   local _global="driver=json-file"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" ""
   run grep -F "LOG_FILE_PATH" "${COMPOSE_OUT}"
   assert_failure
@@ -253,7 +253,7 @@ CONF
   # Per-svc test gets its own local_path but devel inherits empty global.
   local _per_svc="test:local_path=./test-logs/"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" "${_per_svc}"
   # test service: LOG_FILE_PATH=/var/log/myrepo/test.log
   run grep -F "LOG_FILE_PATH=/var/log/myrepo/test.log" "${COMPOSE_OUT}"
@@ -268,7 +268,7 @@ CONF
   local _global
   printf -v _global '%s\n%s' "driver=json-file" "local_path=/srv/logs/"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" ""
   run grep -F "/srv/logs:/var/log/myrepo" "${COMPOSE_OUT}"
   assert_success
@@ -280,7 +280,7 @@ CONF
   # `options:` block — local_path is not a docker logging option.
   local _global="local_path=./logs/"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" ""
   # Volume + env still emitted.
   run grep -F "LOG_FILE_PATH=/var/log/myrepo/devel.log" "${COMPOSE_OUT}"
@@ -297,7 +297,7 @@ CONF
   local _global="driver=json-file"
   local _per_svc="test:local_path=./test-logs/"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" "${_per_svc}"
   # test stanza has its own volumes + environment.
   run awk '/^  test:/ { c=1 } c { print }' "${COMPOSE_OUT}"
@@ -485,7 +485,7 @@ EOF
   local _global
   printf -v _global '%s\n%s' "driver=json-file" "local_path=./logs/"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" ""
   # The runtime block must carry its OWN LOG_FILE_PATH override line
   # alongside the inherited devel.log; runtime.log filename is unique
@@ -511,7 +511,7 @@ EOF
   local _global
   printf -v _global '%s\n%s' "driver=json-file" "local_path=./logs/"
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "${_global}" ""
   # The bind mount string ends with `:/var/log/myrepo`. Expect at
   # least 3 emits in compose.yaml: devel + test + runtime (the
@@ -542,7 +542,7 @@ EOF
   local _extras=()
   # No [logging] global_str at all; local_path unset entirely.
   generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
-    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" \
+    "false" "false" "0" "gpu" _extras "" "" "" "" "" "" "host" "host" "private" \
     "" "" "" "" "" "" "" "" "" "" ""
   # Slice the runtime block: from `^  runtime:$` to the next top-level
   # service header (`^  [a-z][a-z0-9_-]*:$`) and assert neither

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -2739,6 +2739,21 @@ EOF
   assert_output "PID_MODE=private"
 }
 
+@test "[network] pid default (private) omits pid: line from compose.yaml" {
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'EOF'
+[network]
+mode = host
+ipc = host
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep 'pid:' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_failure
+}
+
 @test "[network] pid = host emits pid: host in compose.yaml" {
   cat > "${TEMP_DIR}/config/docker/setup.conf" <<'EOF'
 [network]

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -680,7 +680,7 @@ EOS
     alice alice 1000 1000 \
     x86_64 alice false myrepo /tmp/ws \
     tw.archive.ubuntu.com mirror.twds.com.tw Asia/Taipei \
-    bridge host false all "gpu compute" \
+    bridge host private false all "gpu compute" \
     true confhash dockerhash \
     "" "" "" "" \
     "/path/to/.docker.xauth"
@@ -697,7 +697,7 @@ EOS
     alice alice 1000 1000 \
     x86_64 alice false myrepo /tmp/ws \
     tw.archive.ubuntu.com mirror.twds.com.tw Asia/Taipei \
-    bridge host false all "gpu compute" \
+    bridge host private false all "gpu compute" \
     true confhash dockerhash \
     "" "" "" "" \
     ""
@@ -1179,7 +1179,7 @@ EOF
     "x86_64" "dockerhub" "true" \
     "ros_noetic" "/workspace" \
     "tw.archive.ubuntu.com" "mirror.twds.com.tw" "Asia/Taipei" \
-    "host" "host" "true" \
+    "host" "host" "private" "true" \
     "all" "gpu" \
     "true" "abc123" "df456"
 
@@ -1190,6 +1190,7 @@ EOF
   run grep 'IMAGE_NAME=ros_noetic' "${_env}"; assert_success
   run grep 'NETWORK_MODE=host'  "${_env}"; assert_success
   run grep 'IPC_MODE=host'      "${_env}"; assert_success
+  run grep 'PID_MODE=private'   "${_env}"; assert_success
   run grep 'PRIVILEGED=true'    "${_env}"; assert_success
   run grep 'GPU_COUNT=all'      "${_env}"; assert_success
   run grep -F 'GPU_CAPABILITIES="gpu"' "${_env}"; assert_success
@@ -1226,7 +1227,7 @@ EOF
     "x86_64" "hub" "false" \
     "img" "${TEMP_DIR}" \
     "tw.archive.ubuntu.com" "mirror.twds.com.tw" "Asia/Taipei" \
-    "host" "host" "true" "all" "gpu" \
+    "host" "host" "private" "true" "all" "gpu" \
     "false" "${_h}" ""
   # stub detect_gui/detect_gpu to match stored false
   detect_gui() { local -n _o=$1; _o="false"; }
@@ -1245,7 +1246,7 @@ EOF
     "x86_64" "hub" "false" \
     "img" "${TEMP_DIR}" \
     "tw.archive.ubuntu.com" "mirror.twds.com.tw" "Asia/Taipei" \
-    "host" "host" "true" "all" "gpu" \
+    "host" "host" "private" "true" "all" "gpu" \
     "false" "${_h_old}" ""
   detect_gui() { local -n _o=$1; _o="false"; }
   detect_gpu() { local -n _o=$1; _o="false"; }
@@ -1272,7 +1273,7 @@ EOF
     "x86_64" "hub" "false" \
     "img" "${TEMP_DIR}" \
     "tw.archive.ubuntu.com" "mirror.twds.com.tw" "Asia/Taipei" \
-    "host" "host" "true" "all" "gpu" \
+    "host" "host" "private" "true" "all" "gpu" \
     "false" "${_h}" ""
   # Now detection says true
   detect_gui() { local -n _o=$1; _o="false"; }
@@ -1461,7 +1462,7 @@ EOF
     "x86_64" "hub" "false" \
     "img" "${TEMP_DIR}" \
     "tw.archive.ubuntu.com" "mirror.twds.com.tw" "Asia/Taipei" \
-    "host" "host" "true" "all" "gpu" \
+    "host" "host" "private" "true" "all" "gpu" \
     "false" "${_h}" ""
   detect_gui() { local -n _o=$1; _o="false"; }
   detect_gpu() { local -n _o=$1; _o="false"; }
@@ -1478,7 +1479,7 @@ EOF
     "x86_64" "hub" "false" \
     "img" "${TEMP_DIR}" \
     "tw.archive.ubuntu.com" "mirror.twds.com.tw" "Asia/Taipei" \
-    "host" "host" "true" "all" "gpu" \
+    "host" "host" "private" "true" "all" "gpu" \
     "false" "${_h_old}" ""
   detect_gui() { local -n _o=$1; _o="false"; }
   detect_gpu() { local -n _o=$1; _o="false"; }
@@ -2707,6 +2708,53 @@ EOF
   assert_output "IPC_MODE=private"
 }
 
+@test "[network] pid = host writes PID_MODE=host to .env" {
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'EOF'
+[network]
+mode = host
+ipc = host
+pid = host
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep '^PID_MODE=' '${TEMP_DIR}/.env'
+  "
+  assert_output "PID_MODE=host"
+}
+
+@test "[network] pid default (private) writes PID_MODE=private to .env" {
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'EOF'
+[network]
+mode = host
+ipc = host
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep '^PID_MODE=' '${TEMP_DIR}/.env'
+  "
+  assert_output "PID_MODE=private"
+}
+
+@test "[network] pid = host emits pid: host in compose.yaml" {
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'EOF'
+[network]
+mode = host
+ipc = host
+pid = host
+EOF
+  unset SETUP_CONF
+  run bash -c "
+    source /source/script/docker/setup.sh
+    main apply --base-path '${TEMP_DIR}' >/dev/null 2>&1
+    grep -F 'pid: \${PID_MODE}' '${TEMP_DIR}/compose.yaml'
+  "
+  assert_success
+}
+
 @test "[network] network_name = my_bridge under mode=bridge emits external network ref" {
   cat > "${TEMP_DIR}/config/docker/setup.conf" <<'EOF'
 [network]
@@ -3568,6 +3616,7 @@ EOF
     gui.mode \
     network.mode \
     network.ipc \
+    network.pid \
     network.network_name \
     security.privileged
   do

--- a/test/unit/tui_flow.bats
+++ b/test/unit/tui_flow.bats
@@ -508,31 +508,32 @@ EOF
 # branches: bridge → network_name + ports; ipc!=host → shm_size.
 # ════════════════════════════════════════════════════════════════════
 
-@test "_edit_section_network: host + host writes both modes, no shm prompt" {
-  queue "0|host" "0|host"
+@test "_edit_section_network: host + host + private writes all modes, no shm prompt" {
+  queue "0|host" "0|host" "0|private"
   _edit_section_network
   [[ "$(ovr_get network.mode)" == "host" ]]
   [[ "$(ovr_get network.ipc)" == "host" ]]
+  [[ "$(ovr_get network.pid)" == "private" ]]
   [[ "$(ovr_get network.network_name)" == "" ]]
 }
 
 @test "_edit_section_network: bridge + host prompts for network_name + ports menu" {
-  # mode=bridge → name inputbox + ports submenu (back immediately).
-  queue "0|bridge" "0|host" "0|mynet" "0|back"
+  # mode=bridge → ipc → pid → name inputbox + ports submenu (back immediately).
+  queue "0|bridge" "0|host" "0|private" "0|mynet" "0|back"
   _edit_section_network
   [[ "$(ovr_get network.mode)" == "bridge" ]]
   [[ "$(ovr_get network.network_name)" == "mynet" ]]
 }
 
 @test "_edit_section_network: ipc=private prompts for shm_size" {
-  queue "0|host" "0|private" "0|2gb"
+  queue "0|host" "0|private" "0|private" "0|2gb"
   _edit_section_network
   [[ "$(ovr_get network.ipc)" == "private" ]]
   [[ "$(ovr_get resources.shm_size)" == "2gb" ]]
 }
 
 @test "_edit_section_network: empty network_name allowed (compose default bridge)" {
-  queue "0|bridge" "0|host" "0|" "0|back"
+  queue "0|bridge" "0|host" "0|private" "0|" "0|back"
   _edit_section_network
   [[ "$(ovr_get network.network_name)" == "" ]]
 }


### PR DESCRIPTION
## Summary

- Add `[network] pid = host|private` (default: `private`) to `setup.conf`, following the existing `[network] ipc` precedent
- Full pipeline: `setup.conf` -> `.env` `PID_MODE` -> `compose.yaml` `pid: ${PID_MODE}`
- Per-stage override support via `[stage:NAME] network.pid`
- TUI selection dialog (4 languages: EN / zh-TW / zh-CN / JA)

## Motivation

NVIDIA driver pthread robust mutex requires `--pid=host` when running multiple GPU-rendering containers on the same GPU. Without it, `pthread_mutex_lock` fails with `ESRCH` because container PID namespaces isolate thread IDs (discovered during isaac#34).

Closes #412.

## Test plan

- [x] `make -f Makefile.ci test` passes (all 1382 tests)
- [x] 3 new setup_spec tests: pid=host writes PID_MODE, default private, compose.yaml emission
- [x] Updated compose_gen_spec: env-var emission test includes pid
- [x] Updated compose_logging_spec: all 16 generate_compose_yaml calls adjusted for new parameter position
- [x] Updated tui_flow: network section tests include pid selection step
- [x] Updated _validate_stage_override_key test: network.pid in allowlist
- [x] Zero-diff guarantee: repos without `pid` in setup.conf get `private` (Docker default)
