### PR TITLE
fix(Makefile): guard VAR=VALUE args + fix absolute path forwarding (closes #414)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Makefile forwarding: absolute container paths** — `make exec -- /root/demo/test.sh` failed with `No rule to make target` because GNU Make's built-in implicit rules stat every goal on the host filesystem. Added `--no-builtin-rules` + `.SUFFIXES:` so the `%:` catch-all fires correctly for arbitrary absolute paths. Closes #414 (case 2).
+- **Makefile forwarding: VAR=VALUE args silently lost** — `make setup set build.arg_4 ROS2_DISTRO=jazzy` dropped the `ROS2_DISTRO=jazzy` token because Make treats any `KEY=VALUE` CLI token as a variable override, not a goal. Added a `MAKEOVERRIDES` guard that detects swallowed args and aborts with a clear error message pointing users to the underlying script. Closes #414 (case 1).
 - `upgrade.sh` #399 idempotency regex false-positive: `COPY script/*.sh /lint/script/` was matching the already-patched check because `/lint/` is a prefix of `/lint/script/`. Anchored the regex with `$` so only the exact `/lint/` destination triggers the skip. Closes #403.
 
 ## [v0.34.1] - 2026-05-25

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1447 tests** total (1379 unit + 68 integration).
+Template self-tests: **1452 tests** total (1384 unit + 68 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -633,7 +633,7 @@ exists alongside the wrapper symlink; the documented "cannot find _lib.sh"
 error path still fires (with the new `.base/...` path in the diagnostic)
 when neither `.base/` nor the sibling fallback is present.
 
-### test/unit/makefile_user_spec.bats (23)
+### test/unit/makefile_user_spec.bats (28)
 
 Unit tests for the user-facing `script/docker/Makefile` rewritten in #330.
 Each named wrapper target is a thin 1:1 forward to `./script/<name>.sh`
@@ -654,7 +654,9 @@ setup-tui / upgrade / upgrade-check / help); positional forwarding
 setup foo`); `--` separator + flag forwarding (`make build -- --no-cache
 test`, `make run -- -d`, `make exec -- -t bats-src bash`); catch-all
 no-op (`make foo` succeeds silently, `make build foo bar` forwards
-multiple positional args).
+multiple positional args); `VAR=VALUE` guard via `MAKEOVERRIDES` (single,
+multiple, after `--` separator — all abort with error); absolute
+container path forwarding (`/nonexistent/...`, `/root/demo/...`).
 
 ### test/unit/compose_gen_spec.bats (50)
 

--- a/script/docker/Makefile
+++ b/script/docker/Makefile
@@ -1,3 +1,9 @@
+# Disable built-in implicit rules so make does not stat absolute-path
+# goals (e.g. /root/demo/test.sh) which would fail with EACCES/ENOENT
+# before the catch-all `%:` fires.  Fixes #414 case 2.
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
 .PHONY: build run exec stop prune setup setup-tui upgrade upgrade-check help
 
 # Default goal: bare `make` prints help instead of building. Discoverability
@@ -14,29 +20,48 @@
 #
 #   make build test                # -> ./script/build.sh test
 #   make build -- --no-cache test  # -> ./script/build.sh --no-cache test
+#
+# Limitation: make treats VAR=VALUE tokens as variable overrides — they
+# never reach MAKECMDGOALS.  The guard below detects this via
+# MAKEOVERRIDES and aborts with a hint to call the script directly.
+
+# Guard: detect VAR=VALUE args silently swallowed by make (#414 case 1).
+define _check_overrides
+$(if $(MAKEOVERRIDES),@printf '\033[31mError:\033[0m make intercepted VAR=VALUE argument(s): $(MAKEOVERRIDES)\n' >&2; \
+	printf '       Run the underlying script directly for args containing "=".\n' >&2; \
+	exit 1;)
+endef
 
 build: ## Build devel image (e.g. make build test  |  make build -- --no-cache)
+	$(_check_overrides)
 	./script/build.sh $(filter-out $@,$(MAKECMDGOALS))
 
 run: ## Run container interactively (e.g. make run  |  make run -- -d)
+	$(_check_overrides)
 	./script/run.sh $(filter-out $@,$(MAKECMDGOALS))
 
 exec: ## Exec into running container (e.g. make exec -- -t bats-src bash)
+	$(_check_overrides)
 	./script/exec.sh $(filter-out $@,$(MAKECMDGOALS))
 
 stop: ## Stop and remove containers
+	$(_check_overrides)
 	./script/stop.sh $(filter-out $@,$(MAKECMDGOALS))
 
 prune: ## Prune build cache / dangling images
+	$(_check_overrides)
 	./script/prune.sh $(filter-out $@,$(MAKECMDGOALS))
 
 setup: ## Regenerate .env + compose.yaml from setup.conf
+	$(_check_overrides)
 	./script/setup.sh $(filter-out $@,$(MAKECMDGOALS))
 
 setup-tui: ## Interactive TUI to edit setup.conf
+	$(_check_overrides)
 	./script/setup_tui.sh $(filter-out $@,$(MAKECMDGOALS))
 
 upgrade: ## Upgrade base subtree (e.g. make upgrade v0.30.0)
+	$(_check_overrides)
 	./.base/upgrade.sh $(filter-out $@,$(MAKECMDGOALS))
 
 upgrade-check: ## Check for base updates

--- a/test/unit/makefile_user_spec.bats
+++ b/test/unit/makefile_user_spec.bats
@@ -232,3 +232,44 @@ teardown() {
   refute_line --regexp '^run( |$)'
   refute_line --regexp '^upgrade( |$)'
 }
+
+# ════════════════════════════════════════════════════════════════════
+# VAR=VALUE guard (#414 case 1)
+# ════════════════════════════════════════════════════════════════════
+
+@test "VAR=VALUE arg is detected and aborts with error (#414)" {
+  run make exec FOO=bar
+  assert_failure
+  assert_line --partial "Error:"
+  assert_line --partial "FOO=bar"
+  assert_line --partial "directly"
+}
+
+@test "multiple VAR=VALUE args are all reported (#414)" {
+  run make setup KEY1=val1 KEY2=val2
+  assert_failure
+  assert_line --partial "KEY1=val1"
+  assert_line --partial "KEY2=val2"
+}
+
+@test "VAR=VALUE after -- separator is still caught (#414)" {
+  run make exec -- FOO=bar
+  assert_failure
+  assert_line --partial "FOO=bar"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# Absolute container path forwarding (#414 case 2)
+# ════════════════════════════════════════════════════════════════════
+
+@test "absolute path is forwarded correctly (#414)" {
+  run make exec -- /nonexistent/container/path.sh
+  assert_success
+  assert_line "exec /nonexistent/container/path.sh"
+}
+
+@test "absolute path with multiple segments is forwarded (#414)" {
+  run make exec -- /root/demo/ros1_server.sh arg1
+  assert_success
+  assert_line "exec /root/demo/ros1_server.sh arg1"
+}


### PR DESCRIPTION
## Summary

- Fix two Makefile forwarding edge cases (#414)
- **Case 1 (VAR=VALUE)**: add `MAKEOVERRIDES` guard that detects `KEY=VALUE` args silently swallowed by make and aborts with a clear error pointing users to `./script/*.sh`
- **Case 2 (absolute path)**: add `--no-builtin-rules` + `.SUFFIXES:` to disable implicit rules so the `%:` catch-all correctly matches container-internal absolute paths (e.g. `/root/demo/test.sh`)

## Test plan

- [x] 5 regression tests added to `makefile_user_spec.bats` (23 -> 28)
- [x] `make -f Makefile.ci test` passes (all 1452 tests)
- [x] CHANGELOG + TEST.md updated

Closes #414.
