### PR TITLE
fix(setup): next-step hint mentions make build as alternative (closes #420)

### DIFF
--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -2999,7 +2999,7 @@ _setup_set() {
   if [[ "${_quiet}" -eq 0 ]]; then
     printf '[setup] set [%s] %s = %s\n' "${_section}" "${_key}" "${_value}"
     printf '[setup] file: %s\n' "${_conf}"
-    printf "[setup] next: run './setup.sh apply' to regenerate .env + compose.yaml\n"
+    printf "[setup] next: run 'make build' (auto-applies) or './setup.sh apply' to regenerate .env + compose.yaml\n"
   fi
 }
 
@@ -3376,7 +3376,7 @@ _setup_add() {
   if [[ "${_quiet}" -eq 0 ]]; then
     printf '[setup] add [%s] %s = %s\n' "${_section}" "${_new_key}" "${_value}"
     printf '[setup] file: %s\n' "${_conf}"
-    printf "[setup] next: run './setup.sh apply' to regenerate .env + compose.yaml\n"
+    printf "[setup] next: run 'make build' (auto-applies) or './setup.sh apply' to regenerate .env + compose.yaml\n"
   fi
 }
 
@@ -3540,7 +3540,7 @@ _setup_remove() {
   if [[ "${_quiet}" -eq 0 ]]; then
     printf '[setup] remove [%s] %s\n' "${_section}" "${_target_key}"
     printf '[setup] file: %s\n' "${_conf}"
-    printf "[setup] next: run './setup.sh apply' to regenerate .env + compose.yaml\n"
+    printf "[setup] next: run 'make build' (auto-applies) or './setup.sh apply' to regenerate .env + compose.yaml\n"
   fi
 }
 
@@ -3643,7 +3643,7 @@ _setup_reset() {
   if [[ "${_quiet}" -eq 0 ]]; then
     _log_info setup "$(_setup_msg reset "done")"
     printf '[setup] file: %s\n' "${_conf}"
-    printf "[setup] next: run './setup.sh apply' to regenerate .env + compose.yaml\n"
+    printf "[setup] next: run 'make build' (auto-applies) or './setup.sh apply' to regenerate .env + compose.yaml\n"
   fi
 }
 

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -4039,7 +4039,7 @@ EOF
   assert_success
   assert_output --partial "[setup] set [build] arg_4 = ROS2_DISTRO=jazzy"
   assert_output --partial "[setup] file:"
-  assert_output --partial "[setup] next: run './setup.sh apply'"
+  assert_output --partial "[setup] next: run 'make build' (auto-applies) or './setup.sh apply'"
 }
 
 @test "setup.sh set --quiet: produces empty stdout" {
@@ -4078,7 +4078,7 @@ EOF
   assert_success
   assert_output --partial "[setup] add [build] arg_"
   assert_output --partial "[setup] file:"
-  assert_output --partial "[setup] next: run './setup.sh apply'"
+  assert_output --partial "[setup] next: run 'make build' (auto-applies) or './setup.sh apply'"
 }
 
 @test "setup.sh add --quiet: produces empty stdout" {
@@ -4102,7 +4102,7 @@ EOC
   assert_success
   assert_output --partial "[setup] remove [build] arg_1"
   assert_output --partial "[setup] file:"
-  assert_output --partial "[setup] next: run './setup.sh apply'"
+  assert_output --partial "[setup] next: run 'make build' (auto-applies) or './setup.sh apply'"
 }
 
 @test "setup.sh remove --quiet: produces empty stdout" {
@@ -4127,7 +4127,7 @@ EOC
   assert_success
   assert_output --partial "[setup]"
   assert_output --partial "[setup] file:"
-  assert_output --partial "[setup] next: run './setup.sh apply'"
+  assert_output --partial "[setup] next: run 'make build' (auto-applies) or './setup.sh apply'"
 }
 
 @test "setup.sh reset --yes --quiet: produces empty stdout" {


### PR DESCRIPTION
## Summary

- Update next-step hint in `setup.sh set|add|remove|reset` to mention `make build` (auto-applies) alongside `./setup.sh apply`
- 4 occurrences updated + 4 test assertions

## Test plan

- [x] `make -f Makefile.ci test` passes (all 1452 tests)

Closes #420.
