### PR TITLE
feat(ci): bare stderr migration + lint enforcement (P3+P4 of #423)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - **`lib/log.sh` rewritten as OTel-aligned 5-level JSON logger** (P1 of #423). 5 functions (`_log_debug` / `_log_info` / `_log_warn` / `_log_err` / `_log_fatal`) with `(service, body, [attr=val]...)` API. Registered body emits JSON per OTel Logs Data Model; unregistered body falls back to legacy text for backward compat. W3C TRACEPARENT propagation via `_log_with_trace` / `_log_with_span` scoped wrappers. Ships `lib/log-events.txt` (body enum registry) and `lib/log.lnav-format.json`. Closes #423.
 - **`lib/log.sh` dual output + text format upgrade** (P2). Terminal always receives text with ISO 8601 timestamp + 5-char aligned level (`DEBUG`/`INFO`/`WARN`/`ERROR`/`FATAL`). `LOG_JSON_FILE` env enables parallel structured JSON output to file. `attr=val` args are filtered from text display but included in JSON. `WARNING` label shortened to `WARN` for alignment. i18n messages preserved in text mode only.
+- **P3+P4: bare stderr migration + lint enforcement**. Converted remaining bare `printf >&2` in `setup.sh`, `run.sh`, `ci.sh` to `_log_*` helpers. Added `script/ci/lint_bare_stderr.sh` to flag bare stderr output outside `_log_*` / `_die` / allowlisted patterns.
 
 ## [v0.35.0] - 2026-05-27
 

--- a/script/ci/ci.sh
+++ b/script/ci/ci.sh
@@ -370,7 +370,7 @@ main() {
       --bats-integration) bats_integration=1; shift ;;
       --coverage) mode="coverage"; shift ;;
       --behavioural) behavioural=1; shift ;;
-      *) echo "Unknown option: $1" >&2; exit 1 ;;
+      *) _die "Unknown option: $1" ;;
     esac
   done
 

--- a/script/ci/lint_bare_stderr.sh
+++ b/script/ci/lint_bare_stderr.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# lint_bare_stderr.sh - Flag bare printf/echo >&2 outside _log_* helpers.
+#
+# P4 of #423: enforce that all stderr output goes through lib/log.sh
+# helpers. Scans script/docker/**/*.sh and script/ci/**/*.sh for lines
+# that write to fd 2 without using _log_err / _log_warn / _log_fatal /
+# _log_info / _log_debug / _die.
+#
+# Exit: 0 = clean, 1 = violations found, 2 = usage error.
+
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+# Files excluded entirely (log.sh itself, i18n, entrypoint, TUI).
+_is_excluded_file() {
+  case "${1}" in
+    script/docker/lib/log.sh) return 0 ;;
+    script/docker/i18n.sh) return 0 ;;
+    script/docker/_entrypoint_logging.sh) return 0 ;;
+    script/docker/_tui_backend.sh) return 0 ;;
+    script/docker/_tui_conf.sh) return 0 ;;
+    script/docker/setup_tui.sh) return 0 ;;
+  esac
+  return 1
+}
+
+_is_allowlisted_line() {
+  local line="${1}"
+
+  # Already using _log_* or _die.
+  [[ "${line}" == *_log_* ]] && return 0
+  [[ "${line}" == *_die* ]] && return 0
+
+  # Comment line.
+  [[ "${line}" =~ ^[[:space:]]*# ]] && return 0
+
+  # getopts / OPTARG.
+  [[ "${line}" == *OPTARG* ]] && return 0
+  [[ "${line}" == *getopts* ]] && return 0
+
+  # GITHUB_OUTPUT / GITHUB_STEP_SUMMARY.
+  [[ "${line}" == *GITHUB_OUTPUT* ]] && return 0
+  [[ "${line}" == *GITHUB_STEP_SUMMARY* ]] && return 0
+
+  # Interactive prompts and confirmation context.
+  [[ "${line}" == *'[y/N]'* ]] && return 0
+  [[ "${line}" == *'[y/n]'* ]] && return 0
+  [[ "${line}" == *'[Y/n]'* ]] && return 0
+  [[ "${line}" == *'will overwrite'* ]] && return 0
+  [[ "${line}" == *'backup'* ]] && return 0
+  [[ "${line}" == *'aborted'* ]] && return 0
+  [[ "${line}" == *'_msg info volume_prompt'* ]] && return 0
+
+  # Pre-sourcing bootstrap errors (cannot find _lib.sh).
+  [[ "${line}" == *'cannot find _lib.sh'* ]] && return 0
+  [[ "${line}" == *'.base/script/docker/_lib.sh'* ]] && return 0
+  [[ "${line}" == *'/_lib.sh'* ]] && return 0
+
+  # Pre-sourcing -C/--chdir errors (before _lib.sh is loaded).
+  [[ "${line}" == *'-C/--chdir'* ]] && return 0
+  [[ "${line}" == *'-C target is not'* ]] && return 0
+
+  # Array/list output (printf '  %s\n' "${array[@]}").
+  [[ "${line}" =~ printf[[:space:]]+.+\$\{ ]] && [[ "${line}" == *'[@]}'* ]] && return 0
+  [[ "${line}" =~ printf[[:space:]]+\'\ \ %s ]] && return 0
+
+  # sed-piped output (structured list formatting).
+  [[ "${line}" == *"| sed"* ]] && return 0
+
+  return 1
+}
+
+violations=0
+
+while IFS= read -r file; do
+  rel="${file#"${repo_root}"/}"
+  _is_excluded_file "${rel}" && continue
+
+  in_usage=0
+  lineno=0
+  while IFS= read -r line; do
+    lineno=$((lineno + 1))
+
+    if [[ "${line}" =~ ^[[:space:]]*(usage|_usage)\(\) ]]; then
+      in_usage=1
+      continue
+    fi
+    if [[ "${in_usage}" -eq 1 ]] && [[ "${line}" =~ ^[[:space:]]*\} ]]; then
+      in_usage=0
+      continue
+    fi
+    [[ "${in_usage}" -eq 1 ]] && continue
+
+    _is_allowlisted_line "${line}" && continue
+
+    if [[ "${line}" =~ (printf|echo)[[:space:]].*\>\&2 ]] || \
+       [[ "${line}" =~ \>\&2[[:space:]]*(printf|echo) ]]; then
+      printf '%s:%d: %s\n' "${rel}" "${lineno}" "${line}"
+      violations=$((violations + 1))
+    fi
+  done < "${file}"
+done < <(find "${repo_root}/script/docker" "${repo_root}/script/ci" \
+  -name '*.sh' -type f 2>/dev/null | sort)
+
+if [[ "${violations}" -gt 0 ]]; then
+  printf '\n%d bare stderr output(s) found. Use _log_err/_log_warn/_log_fatal instead.\n' "${violations}" >&2
+  exit 1
+fi
+
+exit 0

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -463,9 +463,7 @@ main() {
   # override cmd, so -d + CMD is ambiguous — refuse rather than silently
   # drop the cmd.
   if [[ "${DETACH}" == true ]] && (( ${#CMD_ARGS[@]} > 0 )); then
-    printf "[run] ERROR: -d/--detach does not accept a CMD (got: %s). " "${CMD_ARGS[*]}" >&2
-    printf "Use './exec.sh -t %s %s' to run a command inside a detached container.\n" \
-      "${TARGET}" "${CMD_ARGS[*]}" >&2
+    _log_err run "-d/--detach does not accept a CMD (got: ${CMD_ARGS[*]}). Use './exec.sh -t ${TARGET} ${CMD_ARGS[*]}' to run a command inside a detached container."
     exit 2
   fi
 

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -771,7 +771,7 @@ detect_image_name() {
         _found="$(_rule_basename "${_path}")"
       elif [[ "${_rule}" == @default:* ]]; then
         _found="${_rule#@default:}"
-        printf "[setup] INFO: IMAGE_NAME using @default:%s\n" "${_found}" >&2
+        _log_info setup "IMAGE_NAME using @default:${_found}"
       fi
 
       [[ -n "${_found}" ]] && break
@@ -779,7 +779,7 @@ detect_image_name() {
   fi
 
   if [[ -z "${_found}" ]]; then
-    printf "[setup] WARNING: IMAGE_NAME could not be detected. Using 'unknown'.\n" >&2
+    _log_warn setup "IMAGE_NAME could not be detected. Using 'unknown'."
     _found="unknown"
   fi
   # Lowercase + sanitize: docker compose project names (and image tags)
@@ -2662,9 +2662,9 @@ _check_setup_drift() {
 
   if (( ${#_drift[@]} > 0 )); then
     local _d
-    printf "[setup] drift detected since last setup.sh run:\n" >&2
+    _log_warn setup "drift detected since last setup.sh run:"
     for _d in "${_drift[@]}"; do
-      printf "[setup]   - %s\n" "${_d}" >&2
+      _log_warn setup "  - ${_d}"
     done
     return 1
   fi
@@ -3610,7 +3610,7 @@ _setup_reset() {
   local _env="${_base_path}/.env"
   local _tpl_conf="${_SETUP_SCRIPT_DIR}/../../config/docker/setup.conf"
   if [[ ! -f "${_tpl_conf}" ]]; then
-    printf "[setup] template setup.conf not found at %s\n" "${_tpl_conf}" >&2
+    _log_err setup "template setup.conf not found at ${_tpl_conf}"
     return 1
   fi
 
@@ -3922,12 +3922,7 @@ _setup_apply() {
       # a stale bake from another contributor's clone. Warn loudly so
       # the user understands the rewrite, then migrate mount_1 back to
       # the portable form.
-      printf "[setup] WARNING: [volumes] mount_1 host path '%s' does not exist on this machine.\n" \
-        "${_mount_1_host}" >&2
-      printf "[setup]          This is usually a stale absolute path committed from\n" >&2
-      printf "[setup]          a different machine. Rewriting mount_1 to the portable\n" >&2
-      printf "[setup]          '\${WS_PATH}:/home/\${USER_NAME}/work' form and re-detecting\n" >&2
-      printf "[setup]          WS_PATH locally. Commit the updated setup.conf to share.\n" >&2
+      _log_warn setup "[volumes] mount_1 host path '${_mount_1_host}' does not exist on this machine. This is usually a stale absolute path committed from a different machine. Rewriting mount_1 to the portable '\${WS_PATH}:/home/\${USER_NAME}/work' form and re-detecting WS_PATH locally. Commit the updated setup.conf to share."
       ws_path=""
       detect_ws_path ws_path "${_base_path}"
       [[ -d "${ws_path}" ]] && ws_path="$(cd "${ws_path}" && pwd -P)"


### PR DESCRIPTION
## Summary

**P3: bare stderr migration**
- Convert bare `printf >&2` to `_log_*` in `setup.sh` (IMAGE_NAME detect, drift warning, template missing, stale mount_1), `run.sh` (detach+CMD error), `ci.sh` (unknown option)

**P4: lint enforcement**
- Add `script/ci/lint_bare_stderr.sh` — scans `script/docker/` and `script/ci/` for bare stderr output
- Allowlists: pre-sourcing errors (before `_lib.sh` loaded), interactive prompts (`[y/N]`), TUI subsystem, i18n.sh, entrypoint logging, list/array output
- Currently passes clean (0 violations)

## Test plan

- [x] `make -f Makefile.ci test` passes (all 1466 tests)
- [x] `lint_bare_stderr.sh` exits 0 (no violations)
- [x] Existing callers' text output preserved (only format of bare printf changed to _log_* format)

refs #423.
