### PR TITLE
feat(makefile): add `make start` combined build+run target (closes #428)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`make start` combined build+run target** — runs `./script/build.sh` then `./script/run.sh` in one step, reducing friction for new repo onboarding. Args after `--` are forwarded to build.sh only; run.sh runs with defaults. Closes #428.
+
 ## [v0.36.0] - 2026-05-27
 
 ### Changed

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -633,7 +633,7 @@ exists alongside the wrapper symlink; the documented "cannot find _lib.sh"
 error path still fires (with the new `.base/...` path in the diagnostic)
 when neither `.base/` nor the sibling fallback is present.
 
-### test/unit/makefile_user_spec.bats (28)
+### test/unit/makefile_user_spec.bats (32)
 
 Unit tests for the user-facing `script/docker/Makefile` rewritten in #330.
 Each named wrapper target is a thin 1:1 forward to `./script/<name>.sh`
@@ -646,10 +646,12 @@ help. Sandbox copies the Makefile into a fake repo, planting stub
 can assert exactly which underlying script ran and with what args.
 
 Covers: `.DEFAULT_GOAL` (bare `make` -> help, does not invoke wrappers);
-`make help` lists 10 user-facing targets; removed sub-cmd targets
+`make help` lists 11 user-facing targets; removed sub-cmd targets
 (`test` / `runtime` / `run-detach`) are absent from help; 1:1 invocation
-across all 10 targets (build / run / exec / stop / prune / setup /
-setup-tui / upgrade / upgrade-check / help); positional forwarding
+across all 11 targets (build / run / start / exec / stop / prune / setup /
+setup-tui / upgrade / upgrade-check / help); `make start` combined
+build+run (invokes build.sh then run.sh, correct execution order, args
+forwarded to build.sh only, visible in help); positional forwarding
 (`make build test`, `make build runtime`, `make upgrade v0.30.0`, `make
 setup foo`); `--` separator + flag forwarding (`make build -- --no-cache
 test`, `make run -- -d`, `make exec -- -t bats-src bash`); catch-all

--- a/script/docker/Makefile
+++ b/script/docker/Makefile
@@ -4,7 +4,7 @@
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 
-.PHONY: build run exec stop prune setup setup-tui upgrade upgrade-check help
+.PHONY: build run start exec stop prune setup setup-tui upgrade upgrade-check help
 
 # Default goal: bare `make` prints help instead of building. Discoverability
 # beats implicit build for a user-facing entry. RFC #330.
@@ -39,6 +39,11 @@ build: ## Build devel image (e.g. make build test  |  make build -- --no-cache)
 run: ## Run container interactively (e.g. make run  |  make run -- -d)
 	$(_check_overrides)
 	./script/run.sh $(filter-out $@,$(MAKECMDGOALS))
+
+start: ## Build + run in one step (e.g. make start  |  make start -- --no-cache)
+	$(_check_overrides)
+	./script/build.sh $(filter-out $@,$(MAKECMDGOALS))
+	./script/run.sh
 
 exec: ## Exec into running container (e.g. make exec -- -t bats-src bash)
 	$(_check_overrides)

--- a/test/unit/makefile_user_spec.bats
+++ b/test/unit/makefile_user_spec.bats
@@ -74,10 +74,10 @@ teardown() {
   refute_line --regexp '^build( |$)'
 }
 
-@test "\`make help\` lists the 10 user-facing targets" {
+@test "\`make help\` lists the 11 user-facing targets" {
   run make help
   assert_success
-  for _target in build run exec stop prune setup setup-tui upgrade upgrade-check help; do
+  for _target in build run start exec stop prune setup setup-tui upgrade upgrade-check help; do
     assert_line --partial "${_target}"
   done
 }
@@ -231,6 +231,42 @@ teardown() {
   refute_line --regexp '^build( |$)'
   refute_line --regexp '^run( |$)'
   refute_line --regexp '^upgrade( |$)'
+}
+
+# ════════════════════════════════════════════════════════════════════
+# `make start` — combined build + run (#428)
+# ════════════════════════════════════════════════════════════════════
+
+@test "\`make start\` invokes ./script/build.sh then ./script/run.sh" {
+  run make start
+  assert_success
+  assert_line "build"
+  assert_line "run"
+}
+
+@test "\`make start\` runs build before run (line order)" {
+  run make start
+  assert_success
+  local build_line=-1 run_line=-1 i=0
+  while IFS= read -r line; do
+    [[ "${line}" == "build"* ]] && build_line=$i
+    [[ "${line}" == "run"* ]] && run_line=$i
+    i=$(( i + 1 ))
+  done <<< "${output}"
+  (( build_line >= 0 && run_line >= 0 && build_line < run_line ))
+}
+
+@test "\`make start -- --no-cache\` forwards args to build.sh only" {
+  run make start -- --no-cache
+  assert_success
+  assert_line "build --no-cache"
+  assert_line "run"
+}
+
+@test "\`make start\` appears in help" {
+  run make help
+  assert_success
+  assert_line --partial "start"
 }
 
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Add `make start` target that runs `./script/build.sh` then `./script/run.sh` in sequence
- Args after `--` are forwarded to build.sh only; run.sh always runs with defaults
- Reduces friction for new repo onboarding: one command instead of two

Closes #428

## Test plan

- [x] `make start` invokes build.sh then run.sh
- [x] Execution order verified (build before run)
- [x] `make start -- --no-cache` forwards args to build.sh only
- [x] `make start` appears in `make help`
- [x] All 1402 existing tests pass
