### PR TITLE
feat(run): auto-delegate to build.sh when image missing (closes #429)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`make start` combined build+run target** — runs `./script/build.sh` then `./script/run.sh` in one step, reducing friction for new repo onboarding. Args after `--` are forwarded to build.sh only; run.sh runs with defaults. Closes #428.
 
+### Changed
+- **`run.sh` first-run auto-build gate** — when the target image is missing locally, `run.sh` now delegates to `./build.sh <target>` instead of letting Compose auto-build (which silently skips the test stage). Makes `make run` on a fresh clone equivalent to `make build && make run`. Build failure aborts the run. The `--build` flag (explicit `./build.sh test` with lint+smoke) is unchanged. Closes #429.
+
 ## [v0.36.0] - 2026-05-27
 
 ### Changed

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -517,10 +517,11 @@ routing, `--instance`, already-running guard, Wayland xhost path,
 `--lang` / `--instance` argument validation, fallback `_detect_lang`
 branches, **runtime log-line i18n** (bootstrap + already-running
 error translate in all four languages via the local `_msg()` table),
-**#216 auto-build soft guard / `--build` opt-in** (image
-present → silent, image absent + TTY → INFO, image absent + no TTY →
-silent, per-target image inspect, `--build` invokes `./build.sh test`
-before compose up, `--build` after check-drift), and **`-C` / `--chdir`
+**#216/#429 auto-build gate** (image present → silent + no build,
+image absent → auto-delegates to `./build.sh TARGET`, non-devel target
+forwarded, build failure aborts run, per-target image inspect, `--build`
+invokes `./build.sh test` before compose up, `--build` after
+check-drift), and **`-C` / `--chdir`
 flag** (docker_harness#53: redirect FILE_PATH, short + long form,
 value-required and directory guards, usage help mention), and **`-v`
 / `--verbose` / `-vv` / `--very-verbose` flag** (#311: same export +

--- a/script/docker/lib/log-events.txt
+++ b/script/docker/lib/log-events.txt
@@ -43,9 +43,8 @@ run_bootstrap
 run_drift_regen
 run_already_running
 run_no_env
-run_build_hint
 run_build_image_missing
-run_build_skips_lint
+run_build_delegating
 
 # exec.sh
 exec_not_running

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -110,7 +110,7 @@ _msg_hints() {
   esac
 }
 
-# #216 --build flow + auto-build soft-guard messages.
+# #216 --build flow + #429 first-run auto-delegate messages.
 _msg_build() {
   case "${_LANG}:${1:?}" in
     zh-TW:invoking)      echo "正在執行 ./build.sh test（lint + smoke）..." ;;
@@ -121,14 +121,10 @@ _msg_build() {
     zh-CN:image_missing) echo "本机尚无此 image" ;;
     ja:image_missing)    echo "ローカルに image なし" ;;
     *:image_missing)     echo "Image not found locally" ;;
-    zh-TW:skips_lint)    echo "Compose 即將 auto-build 此 image — 但**不會**跑 ShellCheck / Hadolint / Bats smoke。" ;;
-    zh-CN:skips_lint)    echo "Compose 即将 auto-build 此 image — 但**不会**跑 ShellCheck / Hadolint / Bats smoke。" ;;
-    ja:skips_lint)       echo "Compose が auto-build しますが、ShellCheck / Hadolint / Bats smoke は**実行されません**。" ;;
-    *:skips_lint)        echo "Compose will auto-build this image — but it will skip ShellCheck / Hadolint / Bats smoke." ;;
-    zh-TW:full_hint)     echo "完整驗證請執行: ./build.sh test   (或 ./run.sh --build 由本指令呼叫)" ;;
-    zh-CN:full_hint)     echo "完整验证请执行: ./build.sh test   (或 ./run.sh --build 由本指令调用)" ;;
-    ja:full_hint)        echo "完全な検証は: ./build.sh test を実行してください（または ./run.sh --build で本コマンド経由）" ;;
-    *:full_hint)         echo "For full verification: ./build.sh test  (or ./run.sh --build to do it now)" ;;
+    zh-TW:delegating)    echo "委派給 ./build.sh 建置..." ;;
+    zh-CN:delegating)    echo "委派给 ./build.sh 构建..." ;;
+    ja:delegating)       echo "./build.sh にビルドを委譲中..." ;;
+    *:delegating)        echo "Delegating to ./build.sh..." ;;
   esac
 }
 
@@ -530,22 +526,18 @@ main() {
   # Mute with QUIET=1 for piped / CI logs.
   [[ "${QUIET:-0}" != "1" ]] && _print_config_summary run
 
-  # ── #216: soft guard for the auto-build path ──
-  # Compose's auto-build (when image is missing locally) only walks
-  # `target: devel` (or whatever -t says) and silently skips the
-  # `target: devel-test` stage that runs ShellCheck / Hadolint / Bats
-  # smoke. (Pre-#243 this stage was named `test`.)
-  # On a fresh clone this means new contributors who reach for
-  # ./run.sh first land in a working dev container without ever
-  # hitting the lint/smoke gates that ./build.sh test enforces.
+  # ── #216 / #429: auto-build gate ──
+  # When the target image is missing locally, delegate to build.sh
+  # instead of letting compose auto-build (which silently skips the
+  # test stage). This makes the first `make run` equivalent to
+  # `make build && make run` without requiring two commands.
   #
   # Behavior:
   #   - --build → invoke ./build.sh test BEFORE compose up (full
   #     local-CI parity). Always runs, even if image is cached.
-  #   - default + image absent + interactive TTY → print INFO before
-  #     compose up so user knows the auto-build will skip lint/smoke.
-  #   - default + image absent + non-TTY → silent (CI / cron context).
-  #   - default + image present → silent (no auto-build will fire).
+  #   - default + image absent → auto-delegate to ./build.sh TARGET
+  #     so the image is built via the proper build pipeline (#429).
+  #   - default + image present → silent (no build needed).
   #
   # Image inspect is per-target so ./run.sh -t headless checks
   # ${IMAGE_NAME}:headless (per #215 auto-emit naming), not :devel.
@@ -559,13 +551,11 @@ main() {
     local _full_tag="${DOCKER_HUB_USER:-local}/${IMAGE_NAME}:${TARGET}"
     if ! docker image inspect "${_full_tag}" --format '{{.Id}}' \
          >/dev/null 2>&1; then
-      # `[[ -t 2 ]]` checks if stderr is connected to a terminal
-      # (interactive). RUN_FORCE_TTY=1 is a test-only override so unit
-      # tests can exercise the TTY branch without a real PTY.
-      if [[ "${RUN_FORCE_TTY:-0}" == "1" ]] || [[ -t 2 ]]; then
-        _log_warn run "$(_msg build image_missing): ${_full_tag}"
-        _log_warn run "$(_msg build skips_lint)"
-        _log_warn run "$(_msg build full_hint)"
+      local _build_sh="${FILE_PATH}/build.sh"
+      if [[ -x "${_build_sh}" ]]; then
+        _log_info run "$(_msg build image_missing): ${_full_tag}"
+        _log_info run "$(_msg build delegating)"
+        "${_build_sh}" "${TARGET}"
       fi
     fi
   fi

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -508,10 +508,10 @@ EOS
 }
 
 # ════════════════════════════════════════════════════════════════════
-# #216 — soft guard for the auto-build path that bypasses lint+smoke
+# #216 / #429 — auto-build gate (first-run auto-delegate to build.sh)
 # ════════════════════════════════════════════════════════════════════
 
-@test "run.sh: image present → no auto-build INFO printed" {
+@test "run.sh: image present → no build.sh invoked, no INFO printed" {
   {
     echo "USER_NAME=tester"
     echo "IMAGE_NAME=mockimg"
@@ -522,11 +522,12 @@ EOS
   export DOCKER_IMAGE_PRESENT=true
   run bash -c "exec 2>&1; bash '${SANDBOX}/run.sh' --detach"
   assert_success
-  refute_output --partial "Compose will auto-build"
-  refute_output --partial "skips ShellCheck"
+  refute_output --partial "not found locally"
+  run cat "${BUILD_SH_LOG}"
+  assert_output ""
 }
 
-@test "run.sh: image absent + TTY → INFO message printed before compose up" {
+@test "run.sh: image absent → auto-delegates to build.sh (#429)" {
   {
     echo "USER_NAME=tester"
     echo "IMAGE_NAME=mockimg"
@@ -535,17 +536,15 @@ EOS
   echo "# mock" > "${SANDBOX}/compose.yaml"
   echo "# stub" > "${SANDBOX}/config/docker/setup.conf"
   export DOCKER_IMAGE_PRESENT=false
-  # Force TTY check to true via env var so the test does not need a
-  # real PTY (run.sh respects RUN_FORCE_TTY=1 for testing).
-  export RUN_FORCE_TTY=1
   run bash -c "exec 2>&1; bash '${SANDBOX}/run.sh' --detach"
   assert_success
   assert_output --partial "not found locally"
-  assert_output --partial "auto-build"
-  assert_output --partial "ShellCheck"
+  assert_output --partial "Delegating to ./build.sh"
+  run grep -F "build.sh invoked" "${BUILD_SH_LOG}"
+  assert_output --partial "devel"
 }
 
-@test "run.sh: image absent + no TTY → silent (no INFO message)" {
+@test "run.sh: image absent + non-devel target → build.sh receives target (#429)" {
   {
     echo "USER_NAME=tester"
     echo "IMAGE_NAME=mockimg"
@@ -554,12 +553,29 @@ EOS
   echo "# mock" > "${SANDBOX}/compose.yaml"
   echo "# stub" > "${SANDBOX}/config/docker/setup.conf"
   export DOCKER_IMAGE_PRESENT=false
-  unset RUN_FORCE_TTY
-  # Without RUN_FORCE_TTY and with bats's piped stderr, the TTY check
-  # naturally returns false → no INFO.
-  run bash -c "exec 2>&1; bash '${SANDBOX}/run.sh' --detach"
+  run bash "${SANDBOX}/run.sh" --detach -t runtime
   assert_success
-  refute_output --partial "Compose will auto-build"
+  run grep -F "build.sh invoked" "${BUILD_SH_LOG}"
+  assert_output --partial "runtime"
+}
+
+@test "run.sh: image absent + build.sh fails → run.sh aborts (#429)" {
+  {
+    echo "USER_NAME=tester"
+    echo "IMAGE_NAME=mockimg"
+    echo "DOCKER_HUB_USER=mockuser"
+  } > "${SANDBOX}/.env"
+  echo "# mock" > "${SANDBOX}/compose.yaml"
+  echo "# stub" > "${SANDBOX}/config/docker/setup.conf"
+  export DOCKER_IMAGE_PRESENT=false
+  cat > "${SANDBOX}/build.sh" <<'EOS'
+#!/usr/bin/env bash
+printf 'build.sh invoked: %s\n' "$*" >> "${BUILD_SH_LOG}"
+exit 1
+EOS
+  chmod +x "${SANDBOX}/build.sh"
+  run bash "${SANDBOX}/run.sh" --detach
+  assert_failure
 }
 
 @test "run.sh: image-inspect uses per-target tag (-t headless inspects :headless)" {
@@ -570,8 +586,6 @@ EOS
   } > "${SANDBOX}/.env"
   echo "# mock" > "${SANDBOX}/compose.yaml"
   echo "# stub" > "${SANDBOX}/config/docker/setup.conf"
-  # docker stub logs every invocation to a temp file so we can assert
-  # the inspect arg.
   cat > "${BIN_DIR}/docker" <<'EOS'
 #!/usr/bin/env bash
 {
@@ -589,9 +603,7 @@ fi
 exit 0
 EOS
   chmod +x "${BIN_DIR}/docker"
-  export RUN_FORCE_TTY=1
   run bash "${SANDBOX}/run.sh" --detach -t headless
-  # Image inspect must target ${IMAGE_NAME}:headless, not :devel.
   run grep -F "image inspect" "${TEMP_DIR}/docker.log"
   assert_output --partial ":headless"
 }
@@ -607,14 +619,11 @@ EOS
   export DOCKER_IMAGE_PRESENT=true
   run bash "${SANDBOX}/run.sh" --build --detach
   assert_success
-  # build.sh was called with `test` so lint + smoke runs.
   run grep -F "build.sh invoked" "${BUILD_SH_LOG}"
   assert_output --partial "test"
 }
 
-@test "run.sh --build: skips when image present too (explicit opt-in always builds)" {
-  # User who passes --build wants a fresh lint+smoke pass even if the
-  # image is cached. Defensive: cached image may be stale wrt source.
+@test "run.sh --build: always builds even if image cached (explicit opt-in)" {
   {
     echo "USER_NAME=tester"
     echo "IMAGE_NAME=mockimg"
@@ -626,26 +635,7 @@ EOS
   run bash "${SANDBOX}/run.sh" --build --detach
   assert_success
   run wc -l < "${BUILD_SH_LOG}"
-  # exactly one build.sh invocation
   [[ "${output}" -eq 1 ]] || { echo "expected 1 build.sh call, got ${output}"; return 1; }
-}
-
-@test "run.sh: no --build, image absent → does NOT invoke build.sh (Option 4 rejected)" {
-  # Default behavior is INFO-only; build.sh is opt-in only.
-  {
-    echo "USER_NAME=tester"
-    echo "IMAGE_NAME=mockimg"
-    echo "DOCKER_HUB_USER=mockuser"
-  } > "${SANDBOX}/.env"
-  echo "# mock" > "${SANDBOX}/compose.yaml"
-  echo "# stub" > "${SANDBOX}/config/docker/setup.conf"
-  export DOCKER_IMAGE_PRESENT=false
-  export RUN_FORCE_TTY=1
-  run bash "${SANDBOX}/run.sh" --detach
-  assert_success
-  # build.sh log should be empty.
-  run cat "${BUILD_SH_LOG}"
-  assert_output ""
 }
 
 @test "run.sh --build: runs after check-drift (build sees regenerated state)" {


### PR DESCRIPTION
## Summary

- When target image is missing locally, `run.sh` now auto-delegates to `./build.sh <target>` instead of letting Compose auto-build (which silently skips the test stage)
- Makes first `make run` on a fresh clone equivalent to `make build && make run`
- Build failure aborts the run; `--build` flag (explicit `./build.sh test` with lint+smoke) unchanged
- Removed stale `skips_lint` / `full_hint` warning messages, replaced with `delegating` i18n message

Closes #429

## Test plan

- [x] Image present: no build.sh invoked, no INFO printed
- [x] Image absent: auto-delegates to build.sh with correct target
- [x] Non-devel target (e.g. runtime): build.sh receives the target name
- [x] Build failure: run.sh aborts (exit non-zero)
- [x] `--build` flag: still invokes `./build.sh test` (unchanged)
- [x] Per-target image inspect (`:headless` not `:devel`)
- [x] All existing tests pass (1402 total, 0 failures)
