### PR TITLE
refactor(lib): log.sh single-sink tty-detect + strict body (#438)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **`run.sh` first-run auto-build gate** — when the target image is missing locally, `run.sh` now delegates to `./build.sh <target>` instead of letting Compose auto-build (which silently skips the test stage). Makes `make run` on a fresh clone equivalent to `make build && make run`. Build failure aborts the run. The `--build` flag (explicit `./build.sh test` with lint+smoke) is unchanged. Closes #429.
+- **`lib/log.sh` single-sink tty-detect + strict body + microsecond UTC** (#438). (1) Dispatch switches on `test -t <fd>`: TTY emits text, pipe/redirect emits JSON; `LOG_FORMAT=auto|text|json` overrides. `LOG_JSON_FILE` dual-sink removed. (2) Unregistered body is a fatal error by default; all callers migrated to registered event names with `display=` attribute for i18n text. (3) Timestamps now ISO 8601 UTC with microsecond precision (`%6NZ`) in both text and JSON. (4) `_log_plain` removed; `config_summary.sh` uses local `_summary_print` helper. Breaking changes: `LOG_JSON_FILE` env dropped, `LOG_STRICT_BODY` env dropped (strict is now default). Closes #438.
 
 ## [v0.36.0] - 2026-05-27
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -47,35 +47,29 @@ Template self-tests: **1466 tests** total (1398 unit + 68 integration).
 | `_print_config_summary wraps dividers + section headers in ANSI when FORCE_COLOR=1 (#309)` | Color migration via _log_plain |
 | `_print_config_summary omits ANSI when NO_COLOR=1 overrides FORCE_COLOR=1 (#309)` | NO_COLOR precedence on summary |
 
-### test/unit/log_spec.bats (39)
+### test/unit/log_spec.bats (48)
 
-| Test | Description |
-|------|-------------|
-| `_log_err writes '[<tag>] ERROR: <msg>' to stderr (no TTY -> no color)` | Default routing + no-color path |
-| `_log_warn writes '[<tag>] WARNING: <msg>' to stderr (no TTY -> no color)` | Warning routing + no-color path |
-| `_log_info writes '[<tag>] INFO: <msg>' to stdout (no TTY -> no color)` | Info routing + no-color path |
-| `_log_err joins multi-token message with single spaces` | Multi-token message join |
-| `_log_err with no tag exits non-zero (param ':?' guard)` | Required tag guard |
-| `_log_warn with no tag exits non-zero (param ':?' guard)` | Required tag guard |
-| `_log_info with no tag exits non-zero (param ':?' guard)` | Required tag guard |
-| `_log_err with FORCE_COLOR=1 emits red bold ANSI on non-TTY stderr` | FORCE_COLOR overrides TTY detection |
-| `_log_warn with FORCE_COLOR=1 emits yellow ANSI on non-TTY stderr` | FORCE_COLOR overrides TTY detection |
-| `_log_info with FORCE_COLOR=1 emits dim ANSI on non-TTY stdout` | FORCE_COLOR overrides TTY detection |
-| `_log_err with NO_COLOR=1 + FORCE_COLOR=1 omits ANSI (NO_COLOR wins)` | NO_COLOR precedence |
-| `_log_warn with NO_COLOR=1 omits ANSI` | NO_COLOR strips color |
-| `_log_info with NO_COLOR=1 omits ANSI` | NO_COLOR strips color |
-| `_log_color_enabled returns non-zero on non-TTY fd 1 without overrides` | Auto-detect default off |
-| `_log_color_enabled returns 0 with FORCE_COLOR=1 on non-TTY` | FORCE_COLOR opt-in |
-| `_log_color_enabled returns non-zero with NO_COLOR=1 + FORCE_COLOR=1` | NO_COLOR wins over FORCE_COLOR |
-| `_log_color_enabled with no fd argument exits non-zero (param guard)` | Required fd guard |
-| `_log_plain writes '[<tag>] <msg>' to stdout with no style (no ANSI even with FORCE_COLOR)` | Empty style suppresses color |
-| `_log_plain with bold style + FORCE_COLOR=1 wraps message in ANSI bold` | Bold style ANSI wrap |
-| `_log_plain with dim style + FORCE_COLOR=1 wraps message in ANSI dim` | Dim style ANSI wrap |
-| `_log_plain with bold style + NO_COLOR=1 omits ANSI even with FORCE_COLOR=1` | NO_COLOR precedence on _log_plain |
-| `_log_plain on non-TTY without FORCE_COLOR omits ANSI` | Auto-detect default off |
-| `_log_plain joins multi-token message with single spaces` | Multi-token message join |
-| `_log_plain with no tag exits non-zero (param ':?' guard)` | Required tag guard |
-| `_log_plain with unknown style + FORCE_COLOR=1 falls back to no ANSI (case match miss)` | Unknown style safe fallback |
+OTel-aligned logger (#423, #438). Single-sink tty-detect dispatch,
+`LOG_FORMAT=auto|text|json` override, strict body enforcement (unregistered
+body = fatal), `display=` attribute for i18n text in text mode, UTC
+microsecond timestamps, `_log_plain` removed.
+
+| Category | Tests |
+|----------|-------|
+| Text output format (`LOG_FORMAT=text`): timestamp + aligned level + tag, multi-token join, attr=val skip, `display=` override | 10 |
+| Timestamp: UTC with microsecond precision in both text and JSON | 2 |
+| Stream routing: stdout for INFO/DEBUG, stderr for WARN/ERROR/FATAL | 2 |
+| Single-sink tty-detect dispatch (#438): non-TTY auto JSON, `LOG_FORMAT=text` force, `LOG_FORMAT=json` force, `LOG_FORMAT=auto` equiv | 5 |
+| JSON output: OTel fields, custom attributes, severity numbers, per-line structure | 4 |
+| TRACEPARENT in JSON: trace_id/span_id present/absent | 2 |
+| Strict body enforcement (#438): unregistered fatal, registered OK, empty OK, error names body + file | 4 |
+| Missing service rejected, `_log_fatal` does not auto-exit | 3 |
+| Scoped wrappers: `_log_with_trace` save/restore, `_log_with_span` trace_id | 4 |
+| `_log_plain` removed (#438) | 1 |
+| `_log_color_enabled`: TTY detect, FORCE_COLOR, NO_COLOR precedence | 3 |
+| FORCE_COLOR text: red bold ERROR, yellow WARN, NO_COLOR strips | 3 |
+| Event registry: registered/unregistered/comment detection | 3 |
+| lnav format file | 2 |
 
 ### test/unit/setup_spec.bats (309)
 

--- a/init.sh
+++ b/init.sh
@@ -37,7 +37,7 @@ source "${TEMPLATE_DIR}/script/docker/lib/gitignore.sh"
 # shellcheck disable=SC1091
 source "${TEMPLATE_DIR}/script/docker/_lib.sh"
 
-_log() { _log_info init "$*"; }
+_log() { _log_info init init_progress "display=$*"; }
 
 # ── Symlink helper ──────────────────────────────────────────────────────────
 

--- a/script/ci/ci.sh
+++ b/script/ci/ci.sh
@@ -91,7 +91,7 @@ EOF
 
 # ── CI container setup ───────────────────────────────────────────────────────
 
-_die() { _log_err ci "$*"; exit 1; }
+_die() { local _ev="${1}"; shift; _log_err ci "${_ev}" "display=$*"; exit 1; }
 
 _install_deps() {
   command -v bats >/dev/null 2>&1 && return 0
@@ -114,7 +114,7 @@ _install_deps() {
   fi
 
   apt-get update -qq \
-    || _die "apt-get update failed. Check network / apt mirror reachability."
+    || _die ci_apt_update_failed "apt-get update failed. Check network / apt mirror reachability."
 
   # `make` is needed by integration tests that exercise the downstream
   # Makefile recipes (#175 / #182). The kcov image's apt repo doesn't
@@ -126,13 +126,13 @@ _install_deps() {
       bats bats-support bats-assert \
       shellcheck git ca-certificates \
       parallel make \
-    || _die "apt-get install failed for bats/shellcheck deps."
+    || _die ci_apt_install_failed "apt-get install failed for bats/shellcheck deps."
 
   # bats-mock is distro-packaged on newer distros but missing on bookworm,
   # so we always pin to upstream v1.2.5 for reproducibility.
   git clone --depth 1 -b v1.2.5 \
       https://github.com/jasonkarns/bats-mock /usr/lib/bats/bats-mock \
-    || _die "git clone bats-mock failed. Check network / GitHub access."
+    || _die ci_bats_mock_clone_failed "git clone bats-mock failed. Check network / GitHub access."
 }
 
 # ── ShellCheck ───────────────────────────────────────────────────────────────
@@ -211,20 +211,20 @@ _run_unit_shard() {
   # the current 30-ish unit spec scale.
   local _spec="${1:?BUG: _run_unit_shard expects <n>/<total>}"
   if [[ "${_spec}" != */* ]]; then
-    _die "Invalid shard spec '${_spec}'. Expected <n>/<total> (e.g. 1/2)."
+    _die ci_invalid_shard "Invalid shard spec '${_spec}'. Expected <n>/<total> (e.g. 1/2)."
   fi
   local _shard="${_spec%/*}"
   local _total="${_spec#*/}"
   if ! [[ "${_shard}" =~ ^[0-9]+$ && "${_total}" =~ ^[0-9]+$ ]] \
        || (( _shard < 1 || _shard > _total )); then
-    _die "Invalid shard spec '${_spec}'. Need 1<=n<=total."
+    _die ci_invalid_shard "Invalid shard spec '${_spec}'. Need 1<=n<=total."
   fi
   local _files
   _files=$(find "${REPO_ROOT}/test/unit" -maxdepth 1 -name '*_spec.bats' -print \
              | sort \
              | awk -v s="${_shard}" -v t="${_total}" 'NR % t == (s - 1) % t')
   if [[ -z "${_files}" ]]; then
-    _die "No spec files matched shard ${_spec}. Empty test/unit/ ?"
+    _die ci_empty_shard "No spec files matched shard ${_spec}. Empty test/unit/ ?"
   fi
   local -a _bats_args
   local _label
@@ -314,9 +314,9 @@ readonly _BEHAVIOURAL_BUILDER="template-behavioural"
 
 _behavioural_setup() {
   [[ -S /var/run/docker.sock ]] \
-    || _die "behavioural mode requires /var/run/docker.sock; run via 'make test-behavioural' (ci-behavioural service)."
+    || _die ci_no_docker_socket "behavioural mode requires /var/run/docker.sock; run via 'make test-behavioural' (ci-behavioural service)."
   command -v docker >/dev/null 2>&1 \
-    || _die "behavioural mode requires docker CLI in the test-tools image (test-tools < v0.23.2 lacks it)."
+    || _die ci_no_docker_cli "behavioural mode requires docker CLI in the test-tools image (test-tools < v0.23.2 lacks it)."
 
   # Dedicated buildx builder isolates the cache from the host's default
   # context, so prune at the end only touches our cache (not the user's
@@ -370,7 +370,7 @@ main() {
       --bats-integration) bats_integration=1; shift ;;
       --coverage) mode="coverage"; shift ;;
       --behavioural) behavioural=1; shift ;;
-      *) _die "Unknown option: $1" ;;
+      *) _die ci_unknown_option "Unknown option: $1" ;;
     esac
   done
 

--- a/script/docker/build.sh
+++ b/script/docker/build.sh
@@ -494,7 +494,7 @@ main() {
   elif [[ ! -f "${FILE_PATH}/.env" ]] \
       || [[ ! -f "${FILE_PATH}/config/docker/setup.conf" ]] \
       || [[ ! -f "${FILE_PATH}/compose.yaml" ]]; then
-    _log_info build "$(_msg bootstrap info)"
+    _log_info build build_bootstrap "display=$(_msg bootstrap info)"
     "${_setup}" apply --base-path "${FILE_PATH}" --lang "${_LANG}"
   else
     # Drift-check path. When setup.conf / GPU / GUI / USER_UID changed
@@ -510,7 +510,7 @@ main() {
     # build.sh's _msg() and silently blank out drift_regen / err_no_env
     # status lines.
     if ! "${_setup}" check-drift --base-path "${FILE_PATH}" --lang "${_LANG}"; then
-      _log_info build "$(_msg drift regen)"
+      _log_info build build_drift_regen "display=$(_msg drift regen)"
       "${_setup}" apply --base-path "${FILE_PATH}" --lang "${_LANG}"
     fi
   fi
@@ -519,8 +519,8 @@ main() {
   # (user cancelled an interactive TUI, setup.sh crashed, ...), surface
   # a useful error instead of letting _load_env fail on a missing file.
   if [[ ! -f "${FILE_PATH}/.env" ]]; then
-    _log_err  build "$(_msg errors no_env)"
-    _log_info build "$(_msg errors rerun_setup)"
+    _log_err  build build_no_env "display=$(_msg errors no_env)"
+    _log_info build build_rerun_setup "display=$(_msg errors rerun_setup)"
     exit 1
   fi
 
@@ -643,10 +643,10 @@ _prune_predecessor() {
     --filter "reference=${_pre_build_id}" 2>/dev/null \
     | grep -v '^<none>:<none>$' || true)"
   if [[ -n "${_other_tags}" ]]; then
-    _log_info build "skip prune: predecessor still tagged (${_other_tags})"
+    _log_info build build_prune_skip_tagged "display=skip prune: predecessor still tagged (${_other_tags})" "tags=${_other_tags}"
     return 0
   fi
-  _log_info build "pruning displaced predecessor ${_pre_build_id:7:12}"
+  _log_info build build_prune_displaced "display=pruning displaced predecessor ${_pre_build_id:7:12}" "image_id=${_pre_build_id:7:12}"
   docker rmi "${_pre_build_id}" >/dev/null 2>&1 || true
 }
 

--- a/script/docker/exec.sh
+++ b/script/docker/exec.sh
@@ -412,7 +412,7 @@ main() {
     else
       _hint="$(_msg hints start_default)"
     fi
-    _log_err exec "${_not_running}
+    _log_err exec exec_not_running "display=${_not_running}
 ${_hint}"
     exit 1
   fi

--- a/script/docker/lib/config_summary.sh
+++ b/script/docker/lib/config_summary.sh
@@ -25,13 +25,26 @@ if [[ -n "${_DOCKER_LIB_CONFIG_SUMMARY_SOURCED:-}" ]]; then
 fi
 _DOCKER_LIB_CONFIG_SUMMARY_SOURCED=1
 
-# Pull in _dump_conf_section + _log_plain. Idempotent — each has its own guard.
+# Pull in _dump_conf_section + _log_color_enabled. Idempotent — each has its own guard.
 _config_summary_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck disable=SC1091
 source "${_config_summary_dir}/conf.sh"
 # shellcheck disable=SC1091
 source "${_config_summary_dir}/log.sh"
 unset _config_summary_dir
+
+_summary_print() {
+  local tag="${1}" style="${2-}"
+  shift 2
+  local prefix="" suffix=""
+  if _log_color_enabled 1 && [[ -n "${style}" ]]; then
+    case "${style}" in
+      bold) prefix=$'\033[1m'; suffix=$'\033[0m' ;;
+      dim)  prefix=$'\033[2m'; suffix=$'\033[0m' ;;
+    esac
+  fi
+  printf '[%s] %s%s%s\n' "${tag}" "${prefix}" "$*" "${suffix}"
+}
 
 # _lib_msg <key>
 #
@@ -158,12 +171,12 @@ _print_config_summary() {
   local _img="${DOCKER_HUB_USER:-local}/${IMAGE_NAME:-unknown}"
   local _proj="${PROJECT_NAME:-${DOCKER_HUB_USER:-local}-${IMAGE_NAME:-unknown}}"
 
-  _log_plain "${_tag}" dim  "${_line}"
-  _log_plain "${_tag}" bold "$(_lib_msg files)"
+  _summary_print "${_tag}" dim  "${_line}"
+  _summary_print "${_tag}" bold "$(_lib_msg files)"
   printf "[%s]   setup.conf   : %s\n"   "${_tag}" "${_conf}"
   printf "[%s]   .env         : %s\n"   "${_tag}" "${_fp}/.env"
   printf "[%s]   compose.yaml : %s\n"   "${_tag}" "${_fp}/compose.yaml"
-  _log_plain "${_tag}" bold "$(_lib_msg identity)"
+  _summary_print "${_tag}" bold "$(_lib_msg identity)"
   printf "[%s]   %-12s : %s (uid=%s)  %s=%s (gid=%s)\n" "${_tag}" \
     "$(_lib_msg user)" "${USER_NAME:--}" "${USER_UID:--}" \
     "$(_lib_msg group)" "${USER_GROUP:--}" "${USER_GID:--}"
@@ -178,7 +191,7 @@ _print_config_summary() {
   # `${USER_NAME}` / `${WS_PATH}` placeholders. This block bridges the
   # two so users can read mount_* lines without re-deriving the mapping
   # from translated labels.
-  _log_plain "${_tag}" bold "$(_lib_msg variables)"
+  _summary_print "${_tag}" bold "$(_lib_msg variables)"
   printf "[%s]   \${USER_NAME} = %s\n"  "${_tag}" "${USER_NAME:--}"
   printf "[%s]   \${USER_UID}  = %s\n"  "${_tag}" "${USER_UID:--}"
   printf "[%s]   \${USER_GROUP} = %s\n" "${_tag}" "${USER_GROUP:--}"
@@ -189,7 +202,7 @@ _print_config_summary() {
   # non-empty to stay readable. Order matches the TUI main menu so
   # the printout and setup_tui.sh layout mirror each other.
   if [[ -f "${_conf}" ]]; then
-    _log_plain "${_tag}" bold "setup.conf"
+    _summary_print "${_tag}" bold "setup.conf"
     # When the file exists but contains no [section] headers (empty file
     # / comments-only / whitespace-only), every section silently falls
     # back to template defaults. Surface a parallel hint to the
@@ -217,7 +230,7 @@ _print_config_summary() {
 
   # Resolved post-merge flags that the user can't infer from setup.conf
   # alone (GPU/GUI depend on host detection in addition to mode=auto).
-  _log_plain "${_tag}" bold "$(_lib_msg resolved)"
+  _summary_print "${_tag}" bold "$(_lib_msg resolved)"
   printf "[%s]   %s : %s  count=%s  caps=%s\n" "${_tag}" \
     "$(_lib_msg gpu_enabled)" "${GPU_ENABLED:--}" "${GPU_COUNT:--}" "${GPU_CAPABILITIES:--}"
   printf "[%s]   %s : %s\n" "${_tag}" \
@@ -230,5 +243,5 @@ _print_config_summary() {
 
   printf "[%s] %s: ./setup_tui.sh  |  ./%s.sh --setup  |  edit setup.conf\n" \
     "${_tag}" "$(_lib_msg customize)" "${_tag}"
-  _log_plain "${_tag}" dim "${_line}"
+  _summary_print "${_tag}" dim "${_line}"
 }

--- a/script/docker/lib/log-events.txt
+++ b/script/docker/lib/log-events.txt
@@ -1,8 +1,8 @@
-# log-events.txt - Registered body enum for _log_* (#423).
+# log-events.txt - Registered body enum for _log_* (#423, #438).
 #
-# One event name per line. _log_* with a body listed here emits JSON;
-# unlisted body falls back to legacy text (until P4 strict enforcement).
-# Adding a new event requires a same-PR addition here.
+# One event name per line. _log_* with an unregistered body is a fatal
+# error (strict enforcement, #438). Adding a new event requires a
+# same-PR addition here.
 
 # setup.sh
 env_regenerated
@@ -27,6 +27,16 @@ ssh_x11_no_xauth
 ssh_x11_network_mismatch
 xauth_rewrite_failed
 xauth_empty_cookie
+conf_image_name_default
+conf_image_name_unknown
+conf_no_repo_conf
+conf_empty_repo_conf
+conf_template_missing
+conf_reset_aborted
+conf_reset_needs_yes
+conf_mount_stale_path
+stage_devel_reserved
+env_drift_detail
 
 # build.sh
 build_started
@@ -45,6 +55,9 @@ run_already_running
 run_no_env
 run_build_image_missing
 run_build_delegating
+run_rerun_setup
+run_build_invoking
+run_detach_cmd_rejected
 
 # exec.sh
 exec_not_running
@@ -69,6 +82,7 @@ prune_nothing_selected
 prune_aborted
 prune_volume_aborted
 prune_no_workspace
+prune_unknown_flag
 
 # upgrade.sh
 upgrade_started
@@ -81,6 +95,17 @@ upgrade_rollback
 init_started
 init_completed
 init_missing_required_arg
+init_progress
+
+# ci.sh
+ci_apt_update_failed
+ci_apt_install_failed
+ci_bats_mock_clone_failed
+ci_invalid_shard
+ci_empty_shard
+ci_no_docker_socket
+ci_no_docker_cli
+ci_unknown_option
 
 # general
 dry_run_cmd

--- a/script/docker/lib/log.sh
+++ b/script/docker/lib/log.sh
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 #
-# log.sh - OTel-aligned 5-level JSON logger (#423).
+# log.sh - OTel-aligned 5-level logger (#423, #438).
 #
 # 5 functions: _log_debug, _log_info, _log_warn, _log_err, _log_fatal.
 # API: _log_<level> <service> <body> [attr=val]...
 #
-# When <body> is a registered event (in log-events.txt), emits one JSON
-# line per the OTel Logs Data Model. When <body> is NOT registered,
-# falls back to legacy text output for backward compatibility (P2
-# migrates all callers; P4 enables strict rejection via LOG_STRICT_BODY).
+# Single-sink tty-detect dispatch: text when fd is a TTY, JSON when
+# piped/redirected. Override with LOG_FORMAT=auto|text|json.
+# Unregistered body (not in log-events.txt) is a fatal error.
 #
 # Stream routing (matches OTel severity mapping):
 #   _log_debug / _log_info -> stdout
@@ -18,7 +17,7 @@
 #   When set, trace_id and span_id are extracted and included in JSON.
 #   Scoped wrappers: _log_with_trace / _log_with_span.
 #
-# Refs: #423, OTel Logs Data Model, W3C Trace Context.
+# Refs: #423, #438, OTel Logs Data Model, W3C Trace Context.
 
 if [[ -n "${_DOCKER_LIB_LOG_SOURCED:-}" ]]; then
   return 0
@@ -31,8 +30,8 @@ readonly _LOG_EVENTS_FILE="${_LOG_LIB_DIR}/log-events.txt"
 # ── Event registry ─────────────────────────────────────────────────
 
 _log_is_registered() {
-  [[ -n "${1}" ]] && [[ -f "${_LOG_EVENTS_FILE}" ]] && \
-    grep -v '^[[:space:]]*#' "${_LOG_EVENTS_FILE}" | grep -v '^[[:space:]]*$' | grep -Fxq "${1}" 2>/dev/null
+  [[ -n "${1}" ]] && [[ "${1}" != \#* ]] && [[ -f "${_LOG_EVENTS_FILE}" ]] && \
+    grep -Fxq "${1}" "${_LOG_EVENTS_FILE}" 2>/dev/null
 }
 
 # ── JSON helpers ───────────────────────────────────────────────────
@@ -55,8 +54,7 @@ _log_emit_json() {
   shift 4
 
   local timestamp
-  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%S.%NZ' 2>/dev/null \
-    || date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%S.%6NZ')"
 
   local trace_id="" span_id=""
   if [[ -n "${TRACEPARENT:-}" ]]; then
@@ -107,14 +105,20 @@ _log_color_enabled() {
 _log_text() {
   local level="${1}" fd="${2}" tag="${3}"
   shift 3
-  local msg=""
+  local msg="" display=""
   local arg
   for arg in "$@"; do
-    [[ "${arg}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*= ]] && continue
-    msg+="${msg:+ }${arg}"
+    if [[ "${arg}" == display=* ]]; then
+      display="${arg#display=}"
+    elif [[ "${arg}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*= ]]; then
+      continue
+    else
+      msg+="${msg:+ }${arg}"
+    fi
   done
+  [[ -n "${display}" ]] && msg="${display}"
   local ts
-  ts="$(date '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%S')"
+  ts="$(date -u '+%Y-%m-%dT%H:%M:%S.%6NZ')"
   if [[ "${level}" == "ERROR" || "${level}" == "FATAL" ]] && _log_color_enabled "${fd}"; then
     printf '%s \033[1;31m[%s] %-5s:\033[0m %s\n' "${ts}" "${tag}" "${level}" "${msg}" >&"${fd}"
   elif [[ "${level}" == "WARN" ]] && _log_color_enabled "${fd}"; then
@@ -126,8 +130,9 @@ _log_text() {
 
 # ── Core dispatch ──────────────────────────────────────────────────
 #
-# Dual output: terminal always gets text (with i18n); LOG_JSON_FILE
-# gets structured JSON. i18n messages only exist in text mode.
+# Single-sink tty-detect (#438): text when fd is a TTY, JSON when
+# piped/redirected. LOG_FORMAT=auto|text|json overrides detection.
+# Unregistered body is a fatal error (strict by default).
 
 _log_dispatch() {
   local severity_text="${1}" severity_number="${2}" fd="${3}"
@@ -135,12 +140,31 @@ _log_dispatch() {
   local body="${5:-}"
   shift 5 2>/dev/null || shift 4
 
-  _log_text "${severity_text}" "${fd}" "${service}" "${body}" "$@"
-
-  if [[ -n "${LOG_JSON_FILE:-}" ]]; then
-    _log_emit_json "${severity_text}" "${severity_number}" \
-      "${service}" "${body}" "$@" >> "${LOG_JSON_FILE}"
+  if [[ -n "${body}" ]] && [[ -f "${_LOG_EVENTS_FILE}" ]] \
+     && ! _log_is_registered "${body}"; then
+    printf 'FATAL: unregistered log body "%s" -- add it to %s\n' \
+      "${body}" "${_LOG_EVENTS_FILE}" >&2
+    return 1
   fi
+
+  local format="${LOG_FORMAT:-auto}"
+  case "${format}" in
+    text)
+      _log_text "${severity_text}" "${fd}" "${service}" "${body}" "$@"
+      ;;
+    json)
+      _log_emit_json "${severity_text}" "${severity_number}" \
+        "${service}" "${body}" "$@" >&"${fd}"
+      ;;
+    *)
+      if test -t "${fd}"; then
+        _log_text "${severity_text}" "${fd}" "${service}" "${body}" "$@"
+      else
+        _log_emit_json "${severity_text}" "${severity_number}" \
+          "${service}" "${body}" "$@" >&"${fd}"
+      fi
+      ;;
+  esac
 }
 
 # ── Public API ─────────────────────────────────────────────────────
@@ -150,22 +174,6 @@ _log_info()  { _log_dispatch INFO  9 1 "$@"; }
 _log_warn()  { _log_dispatch WARN 13 2 "$@"; }
 _log_err()   { _log_dispatch ERROR 17 2 "$@"; }
 _log_fatal() { _log_dispatch FATAL 21 2 "$@"; }
-
-# ── _log_plain (deprecated, removed in P2+) ────────────────────────
-
-_log_plain() {
-  local tag="${1:?_log_plain requires tag}"
-  local style="${2-}"
-  shift 2
-  local prefix="" suffix=""
-  if _log_color_enabled 1 && [[ -n "${style}" ]]; then
-    case "${style}" in
-      bold) prefix=$'\033[1m'; suffix=$'\033[0m' ;;
-      dim)  prefix=$'\033[2m'; suffix=$'\033[0m' ;;
-    esac
-  fi
-  printf '[%s] %s%s%s\n' "${tag}" "${prefix}" "$*" "${suffix}"
-}
 
 # ── TRACEPARENT scoped wrappers ────────────────────────────────────
 

--- a/script/docker/prune.sh
+++ b/script/docker/prune.sh
@@ -334,7 +334,7 @@ _resolve_workspace() {
     _RESOLVED_WORKSPACE="${WS_PATH}"
     return 0
   fi
-  _log_err prune "cannot resolve workspace; pass --workspace <dir> or run from a repo with .env (no WS_PATH found)"
+  _log_err prune prune_no_workspace "display=cannot resolve workspace; pass --workspace <dir> or run from a repo with .env (no WS_PATH found)"
   exit 2
 }
 
@@ -386,7 +386,7 @@ _run_worktree_orphans_prune() {
   _resolve_owner
   local _worktree_root="${_RESOLVED_WORKSPACE%/}/worktree"
 
-  _log_info prune "Scanning worktree-orphan images (owner=${_RESOLVED_OWNER}, workspace=${_RESOLVED_WORKSPACE})..."
+  _log_info prune prune_worktree_scan "display=Scanning worktree-orphan images (owner=${_RESOLVED_OWNER}, workspace=${_RESOLVED_WORKSPACE})..." "owner=${_RESOLVED_OWNER}" "workspace=${_RESOLVED_WORKSPACE}"
 
   # IFS read into array — `docker images` output is one tag per line.
   local -a _all_images=()
@@ -448,20 +448,20 @@ _run_worktree_orphans_prune() {
   # Always emit the safety summary so the user knows we deliberately
   # left other-user / bare-name images alone.
   if (( ${#_skipped_other_owner[@]} > 0 )); then
-    _log_info prune "Skipping ${#_skipped_other_owner[@]} image(s) owned by another user (safety):"
+    _log_info prune prune_skip_other_owner "display=Skipping ${#_skipped_other_owner[@]} image(s) owned by another user (safety):" "count=${#_skipped_other_owner[@]}"
     printf '  %s\n' "${_skipped_other_owner[@]}" >&2
   fi
   if (( ${#_skipped_bare[@]} > 0 )); then
-    _log_info prune "Skipping ${#_skipped_bare[@]} bare-name image(s) — ownership unknown:"
+    _log_info prune prune_skip_bare "display=Skipping ${#_skipped_bare[@]} bare-name image(s) — ownership unknown:" "count=${#_skipped_bare[@]}"
     printf '  %s\n' "${_skipped_bare[@]}" >&2
   fi
 
   if (( ${#_candidates[@]} == 0 )); then
-    _log_info prune "No worktree orphans found."
+    _log_info prune prune_worktree_none "display=No worktree orphans found."
     return 0
   fi
 
-  _log_info prune "Worktree-orphan candidates (${#_candidates[@]}):"
+  _log_info prune prune_worktree_candidates "display=Worktree-orphan candidates (${#_candidates[@]}):" "count=${#_candidates[@]}"
   printf '  %s\n' "${_candidates[@]}" >&2
 
   if [[ "${ASSUME_YES}" != true && "${DRY_RUN}" != true ]]; then
@@ -471,7 +471,7 @@ _run_worktree_orphans_prune() {
     case "${_reply}" in
       y|Y|yes|YES) ;;
       *)
-        _log_info prune "aborted by user."
+        _log_info prune prune_aborted "display=aborted by user."
         return 1
         ;;
     esac
@@ -585,7 +585,7 @@ main() {
         shift 2
         ;;
       *)
-        _log_err prune "unknown flag: $1"
+        _log_err prune prune_unknown_flag "display=unknown flag: $1" "flag=$1"
         exit 2
         ;;
     esac
@@ -597,7 +597,7 @@ main() {
   if [[ "${DO_NETWORKS}" != true && "${DO_IMAGES}" != true \
         && "${DO_VOLUMES}" != true && "${DO_BUILDER}" != true \
         && "${DO_WORKTREE_ORPHANS}" != true ]]; then
-    _log_err prune "$(_msg info nothing_selected)"
+    _log_err prune prune_nothing_selected "display=$(_msg info nothing_selected)"
     exit 2
   fi
 
@@ -608,17 +608,17 @@ main() {
   local _vol_until="${UNTIL_OVERRIDE}"  # default: no filter for volumes
 
   if [[ "${DO_NETWORKS}" == true ]]; then
-    _log_info prune "Pruning networks (until=${_net_until})..."
+    _log_info prune prune_networks "display=Pruning networks (until=${_net_until})..." "until=${_net_until}"
     _run_prune network "${_net_until}"
   fi
 
   if [[ "${DO_IMAGES}" == true ]]; then
-    _log_info prune "Pruning dangling images (until=${_img_until})..."
+    _log_info prune prune_images "display=Pruning dangling images (until=${_img_until})..." "until=${_img_until}"
     _run_prune image "${_img_until}"
   fi
 
   if [[ "${DO_BUILDER}" == true ]]; then
-    _log_info prune "Pruning buildx cache (until=${_bldr_until})..."
+    _log_info prune prune_buildx "display=Pruning buildx cache (until=${_bldr_until})..." "until=${_bldr_until}"
     _run_prune builder "${_bldr_until}"
   fi
 
@@ -631,12 +631,12 @@ main() {
       case "${_reply}" in
         y|Y|yes|YES) ;;
         *)
-          _log_info prune "$(_msg info volume_aborted)"
+          _log_info prune prune_volume_aborted "display=$(_msg info volume_aborted)"
           exit 1
           ;;
       esac
     fi
-    _log_info prune "Pruning volumes (until=${_vol_until:-<none>})..."
+    _log_info prune prune_volumes "display=Pruning volumes (until=${_vol_until:-<none>})..." "until=${_vol_until:-<none>}"
     _run_prune volume "${_vol_until}"
   fi
 

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -459,7 +459,7 @@ main() {
   # override cmd, so -d + CMD is ambiguous — refuse rather than silently
   # drop the cmd.
   if [[ "${DETACH}" == true ]] && (( ${#CMD_ARGS[@]} > 0 )); then
-    _log_err run "-d/--detach does not accept a CMD (got: ${CMD_ARGS[*]}). Use './exec.sh -t ${TARGET} ${CMD_ARGS[*]}' to run a command inside a detached container."
+    _log_err run run_detach_cmd_rejected "display=-d/--detach does not accept a CMD (got: ${CMD_ARGS[*]}). Use './exec.sh -t ${TARGET} ${CMD_ARGS[*]}' to run a command inside a detached container."
     exit 2
   fi
 
@@ -499,21 +499,21 @@ main() {
   elif [[ ! -f "${FILE_PATH}/.env" ]] \
       || [[ ! -f "${FILE_PATH}/config/docker/setup.conf" ]] \
       || [[ ! -f "${FILE_PATH}/compose.yaml" ]]; then
-    _log_info run "$(_msg bootstrap info)"
+    _log_info run run_bootstrap "display=$(_msg bootstrap info)"
     "${_setup}" apply --base-path "${FILE_PATH}" --lang "${_LANG}"
   else
     # Drift → auto-regen via subprocess (see build.sh for the full
     # rationale; subprocess avoids the #101 _msg shadow class).
     if ! "${_setup}" check-drift --base-path "${FILE_PATH}" --lang "${_LANG}"; then
-      _log_info run "$(_msg drift regen)"
+      _log_info run run_drift_regen "display=$(_msg drift regen)"
       "${_setup}" apply --base-path "${FILE_PATH}" --lang "${_LANG}"
     fi
   fi
 
   # Defensive: bootstrap must leave .env in place. See build.sh.
   if [[ ! -f "${FILE_PATH}/.env" ]]; then
-    _log_err  run "$(_msg errors no_env)"
-    _log_info run "$(_msg errors rerun_setup)"
+    _log_err  run run_no_env "display=$(_msg errors no_env)"
+    _log_info run run_rerun_setup "display=$(_msg errors rerun_setup)"
     exit 1
   fi
 
@@ -544,7 +544,7 @@ main() {
   if [[ "${PRE_BUILD}" == true && "${DRY_RUN}" != true ]]; then
     local _build_sh="${FILE_PATH}/build.sh"
     if [[ -x "${_build_sh}" ]]; then
-      _log_info run "$(_msg build invoking)"
+      _log_info run run_build_invoking "display=$(_msg build invoking)"
       "${_build_sh}" test
     fi
   elif [[ "${DRY_RUN}" != true ]]; then
@@ -553,8 +553,8 @@ main() {
          >/dev/null 2>&1; then
       local _build_sh="${FILE_PATH}/build.sh"
       if [[ -x "${_build_sh}" ]]; then
-        _log_info run "$(_msg build image_missing): ${_full_tag}"
-        _log_info run "$(_msg build delegating)"
+        _log_info run run_build_image_missing "display=$(_msg build image_missing): ${_full_tag}" "tag=${_full_tag}"
+        _log_info run run_build_delegating "display=$(_msg build delegating)"
         "${_build_sh}" "${TARGET}"
       fi
     fi
@@ -591,7 +591,7 @@ main() {
       # shellcheck disable=SC2059
       printf -v _stop "$(_msg hints stop_hint)" "${_instance_arg}"
       _parallel="$(_msg hints parallel_hint)"
-      _log_err run "${_already}
+      _log_err run run_already_running "display=${_already}
 ${_stop}
 ${_parallel}"
       exit 1

--- a/script/docker/setup.sh
+++ b/script/docker/setup.sh
@@ -422,7 +422,7 @@ _is_ssh_x11() {
 _setup_ssh_x11_cookie() {
   local _file_path="${1:?_setup_ssh_x11_cookie requires <file_path>}"
   if ! command -v xauth >/dev/null 2>&1; then
-    _log_warn setup "SSH X11 forwarding detected but 'xauth' is not in PATH; skipping cookie rewrite. Install xauth (apt: x11-xauth-utils) and re-run setup."
+    _log_warn setup ssh_x11_no_xauth "display=SSH X11 forwarding detected but 'xauth' is not in PATH; skipping cookie rewrite. Install xauth (apt: x11-xauth-utils) and re-run setup."
     return 1
   fi
   local _out="${_file_path}/.docker.xauth"
@@ -439,7 +439,7 @@ _setup_ssh_x11_cookie() {
   xauth -i nlist "${DISPLAY}" 2>/dev/null \
     | sed -e 's/^..../ffff/' \
     | xauth -i -f "${_out}" nmerge - >/dev/null 2>&1 || {
-        _log_warn setup "xauth cookie rewrite failed; XAUTHORITY left at host value."
+        _log_warn setup xauth_rewrite_failed "display=xauth cookie rewrite failed; XAUTHORITY left at host value."
         return 1
       }
   # Defensive: verify the rewrite actually produced content. The pipe
@@ -450,7 +450,7 @@ _setup_ssh_x11_cookie() {
   # cookie path into .env (which then makes the container mount a
   # 0-byte cookie and fail X11 auth silently).
   if [[ ! -s "${_out}" ]]; then
-    _log_warn setup "xauth cookie rewrite produced an empty cookie file; XAUTHORITY left at host value."
+    _log_warn setup xauth_empty_cookie "display=xauth cookie rewrite produced an empty cookie file; XAUTHORITY left at host value."
     return 1
   fi
   printf '%s\n' "${_out}"
@@ -771,7 +771,7 @@ detect_image_name() {
         _found="$(_rule_basename "${_path}")"
       elif [[ "${_rule}" == @default:* ]]; then
         _found="${_rule#@default:}"
-        _log_info setup "IMAGE_NAME using @default:${_found}"
+        _log_info setup conf_image_name_default "display=IMAGE_NAME using @default:${_found}" "default=${_found}"
       fi
 
       [[ -n "${_found}" ]] && break
@@ -779,7 +779,7 @@ detect_image_name() {
   fi
 
   if [[ -z "${_found}" ]]; then
-    _log_warn setup "IMAGE_NAME could not be detected. Using 'unknown'."
+    _log_warn setup conf_image_name_unknown "display=IMAGE_NAME could not be detected. Using 'unknown'."
     _found="unknown"
   fi
   # Lowercase + sanitize: docker compose project names (and image tags)
@@ -1786,9 +1786,9 @@ generate_compose_yaml() {
     _validate_stage_name "${_stage}" || _vrc=$?
     case "${_vrc}" in
       0) _emit_stages+=("${_stage}") ;;
-      1) _log_warn setup "$(_setup_msg stage invalid_format): $(printf '%q' "${_stage}")" ;;
-      2) _log_err setup "$(_setup_msg stage baseline_collision): $(printf '%q' "${_stage}")"; return 1 ;;
-      3) _log_err setup "$(_setup_msg stage reserved_tag): $(printf '%q' "${_stage}")"; return 1 ;;
+      1) _log_warn setup stage_invalid_format "display=$(_setup_msg stage invalid_format): $(printf '%q' "${_stage}")" "stage=$(printf '%q' "${_stage}")" ;;
+      2) _log_err setup stage_baseline_collision "display=$(_setup_msg stage baseline_collision): $(printf '%q' "${_stage}")" "stage=$(printf '%q' "${_stage}")"; return 1 ;;
+      3) _log_err setup stage_reserved_tag "display=$(_setup_msg stage reserved_tag): $(printf '%q' "${_stage}")" "stage=$(printf '%q' "${_stage}")"; return 1 ;;
     esac
   done < <(_parse_dockerfile_stages "${_dockerfile}")
 
@@ -1809,15 +1809,15 @@ generate_compose_yaml() {
   for _cs in "${_conf_stages[@]}"; do
     case "${_cs}" in
       sys|base|test)
-        _log_err setup "$(_setup_msg stage baseline_collision): [stage:${_cs}]"
+        _log_err setup stage_baseline_collision "display=$(_setup_msg stage baseline_collision): [stage:${_cs}]" "stage=${_cs}"
         return 1
         ;;
       latest|v[0-9]*)
-        _log_err setup "$(_setup_msg stage reserved_tag): [stage:${_cs}]"
+        _log_err setup stage_reserved_tag "display=$(_setup_msg stage reserved_tag): [stage:${_cs}]" "stage=${_cs}"
         return 1
         ;;
       devel)
-        _log_warn setup "[stage:devel] is reserved; not applied in v1 (#220). Edit top-level sections to tune devel."
+        _log_warn setup stage_devel_reserved "display=[stage:devel] is reserved; not applied in v1 (#220). Edit top-level sections to tune devel."
         continue
         ;;
     esac
@@ -1827,7 +1827,7 @@ generate_compose_yaml() {
       [[ "${_es}" == "${_cs}" ]] && _is_emitted=1 && break
     done
     if (( ! _is_emitted )); then
-      _log_warn setup "$(_setup_msg stage unknown_referenced): [stage:${_cs}]"
+      _log_warn setup stage_unknown_referenced "display=$(_setup_msg stage unknown_referenced): [stage:${_cs}]" "stage=${_cs}"
     fi
   done
 
@@ -2089,7 +2089,7 @@ YAML
           _so_filtered_keys+=("${_so_keys[_ki]}")
           _so_filtered_values+=("${_so_values[_ki]}")
         else
-          _log_warn setup "$(_setup_msg stage override_key_not_allowed): $(printf '%q' "${_so_keys[_ki]}") (stage=${_emit_stage})"
+          _log_warn setup stage_override_key_not_allowed "display=$(_setup_msg stage override_key_not_allowed): $(printf '%q' "${_so_keys[_ki]}") (stage=${_emit_stage})" "key=$(printf '%q' "${_so_keys[_ki]}")" "stage=${_emit_stage}"
         fi
       done
       local _has_overrides=0
@@ -2662,9 +2662,9 @@ _check_setup_drift() {
 
   if (( ${#_drift[@]} > 0 )); then
     local _d
-    _log_warn setup "drift detected since last setup.sh run:"
+    _log_warn setup env_drift_detected "display=drift detected since last setup.sh run:"
     for _d in "${_drift[@]}"; do
-      _log_warn setup "  - ${_d}"
+      _log_warn setup env_drift_detail "display=  - ${_d}" "detail=${_d}"
     done
     return 1
   fi
@@ -2703,7 +2703,7 @@ _setup_check_drift() {
         shift 2
         ;;
       *)
-        _log_err setup "$(_setup_msg errors unknown_arg): $1"
+        _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
         return 1
         ;;
     esac
@@ -2735,9 +2735,9 @@ _announce_template_default_fallback() {
   # source of truth post-#201.
   local _repo_conf="${_base}/config/docker/setup.conf"
   if [[ ! -f "${_repo_conf}" ]]; then
-    _log_warn setup "$(_setup_msg warnings no_repo_conf)"
+    _log_warn setup conf_no_repo_conf "display=$(_setup_msg warnings no_repo_conf)"
   elif ! grep -qE '^[[:space:]]*\[[^]]+\]' "${_repo_conf}"; then
-    _log_warn setup "$(_setup_msg warnings empty_repo_conf)"
+    _log_warn setup conf_empty_repo_conf "display=$(_setup_msg warnings empty_repo_conf)"
   fi
 }
 
@@ -2929,7 +2929,7 @@ _setup_set() {
         fi
         ;;
       -*)
-        _log_err setup "$(_setup_msg errors unknown_arg): $1"
+        _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
         return 1
         ;;
       *)
@@ -2938,7 +2938,7 @@ _setup_set() {
         elif [[ "${_have_value}" -eq 0 ]]; then
           _value="$1"; _have_value=1
         else
-          _log_err setup "$(_setup_msg errors unknown_arg): $1"
+          _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
           return 1
         fi
         shift
@@ -2973,12 +2973,12 @@ _setup_set() {
   fi
 
   if ! _setup_known_section "${_section}"; then
-    _log_err setup "$(_setup_msg errors unknown_section): ${_section}"
+    _log_err setup conf_section_not_found "display=$(_setup_msg errors unknown_section): ${_section}" "section=${_section}"
     return 2
   fi
 
   if ! _setup_validate_kv "${_section}" "${_key}" "${_value}"; then
-    _log_err setup "$(_setup_msg errors invalid_value): ${_section}.${_key} = ${_value}"
+    _log_err setup conf_invalid_value "display=$(_setup_msg errors invalid_value): ${_section}.${_key} = ${_value}" "section=${_section}" "key=${_key}" "value=${_value}"
     return 2
   fi
 
@@ -3037,14 +3037,14 @@ _setup_show() {
         shift 2
         ;;
       -*)
-        _log_err setup "$(_setup_msg errors unknown_arg): $1"
+        _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
         return 1
         ;;
       *)
         if [[ -z "${_spec}" ]]; then
           _spec="$1"
         else
-          _log_err setup "$(_setup_msg errors unknown_arg): $1"
+          _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
           return 1
         fi
         shift
@@ -3072,7 +3072,7 @@ _setup_show() {
   fi
 
   if ! _setup_known_section "${_section}"; then
-    _log_err setup "$(_setup_msg errors unknown_section): ${_section}"
+    _log_err setup conf_section_not_found "display=$(_setup_msg errors unknown_section): ${_section}" "section=${_section}"
     return 2
   fi
 
@@ -3097,7 +3097,7 @@ _setup_show() {
         return 0
       fi
     done
-    _log_err setup "$(_setup_msg errors key_not_found): ${_ns_key}"
+    _log_err setup conf_key_not_found "display=$(_setup_msg errors key_not_found): ${_ns_key}" "key=${_ns_key}"
     return 1
   fi
 
@@ -3110,7 +3110,7 @@ _setup_show() {
     fi
   done
   if (( _printed == 0 )); then
-    _log_err setup "$(_setup_msg errors section_not_found): ${_section}"
+    _log_err setup conf_section_not_found "display=$(_setup_msg errors section_not_found): ${_section}" "section=${_section}"
     return 1
   fi
   return 0
@@ -3145,14 +3145,14 @@ _setup_list() {
         shift 2
         ;;
       -*)
-        _log_err setup "$(_setup_msg errors unknown_arg): $1"
+        _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
         return 1
         ;;
       *)
         if [[ -z "${_spec}" ]]; then
           _spec="$1"
         else
-          _log_err setup "$(_setup_msg errors unknown_arg): $1"
+          _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
           return 1
         fi
         shift
@@ -3266,7 +3266,7 @@ _setup_add() {
         fi
         ;;
       -*)
-        _log_err setup "$(_setup_msg errors unknown_arg): $1"
+        _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
         return 1
         ;;
       *)
@@ -3275,7 +3275,7 @@ _setup_add() {
         elif [[ "${_have_value}" -eq 0 ]]; then
           _value="$1"; _have_value=1
         else
-          _log_err setup "$(_setup_msg errors unknown_arg): $1"
+          _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
           return 1
         fi
         shift
@@ -3300,7 +3300,7 @@ _setup_add() {
   fi
 
   if ! _setup_known_section "${_section}"; then
-    _log_err setup "$(_setup_msg errors unknown_section): ${_section}"
+    _log_err setup conf_section_not_found "display=$(_setup_msg errors unknown_section): ${_section}" "section=${_section}"
     return 2
   fi
 
@@ -3367,7 +3367,7 @@ _setup_add() {
   local _new_key="${_list}_${_new_idx}"
 
   if ! _setup_validate_kv "${_section}" "${_new_key}" "${_value}"; then
-    _log_err setup "$(_setup_msg errors invalid_value): ${_section}.${_new_key} = ${_value}"
+    _log_err setup conf_invalid_value "display=$(_setup_msg errors invalid_value): ${_section}.${_new_key} = ${_value}" "section=${_section}" "key=${_new_key}" "value=${_value}"
     return 2
   fi
 
@@ -3442,7 +3442,7 @@ _setup_remove() {
         fi
         ;;
       -*)
-        _log_err setup "$(_setup_msg errors unknown_arg): $1"
+        _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
         return 1
         ;;
       *)
@@ -3451,7 +3451,7 @@ _setup_remove() {
         elif [[ "${_have_value}" -eq 0 ]]; then
           _value="$1"; _have_value=1
         else
-          _log_err setup "$(_setup_msg errors unknown_arg): $1"
+          _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
           return 1
         fi
         shift
@@ -3477,7 +3477,7 @@ _setup_remove() {
   fi
 
   if ! _setup_known_section "${_section}"; then
-    _log_err setup "$(_setup_msg errors unknown_section): ${_section}"
+    _log_err setup conf_section_not_found "display=$(_setup_msg errors unknown_section): ${_section}" "section=${_section}"
     return 2
   fi
 
@@ -3489,7 +3489,7 @@ _setup_remove() {
   # a removable input).
   local _conf="${_base_path}/config/docker/setup.conf"
   if [[ ! -f "${_conf}" ]]; then
-    _log_err setup "$(_setup_msg errors key_not_found): ${_spec}"
+    _log_err setup conf_key_not_found "display=$(_setup_msg errors key_not_found): ${_spec}" "key=${_spec}"
     return 1
   fi
 
@@ -3507,7 +3507,7 @@ _setup_remove() {
       fi
     done
     if [[ -z "${_target_key}" ]]; then
-      _log_err setup "$(_setup_msg errors key_not_found): ${_section}.${_rest} = ${_value}"
+      _log_err setup conf_key_not_found "display=$(_setup_msg errors key_not_found): ${_section}.${_rest} = ${_value}" "key=${_section}.${_rest}" "value=${_value}"
       return 1
     fi
   else
@@ -3520,7 +3520,7 @@ _setup_remove() {
       fi
     done
     if (( ! _found )); then
-      _log_err setup "$(_setup_msg errors key_not_found): ${_spec}"
+      _log_err setup conf_key_not_found "display=$(_setup_msg errors key_not_found): ${_spec}" "key=${_spec}"
       return 1
     fi
     _target_key="${_rest}"
@@ -3592,7 +3592,7 @@ _setup_reset() {
         shift 2
         ;;
       *)
-        _log_err setup "$(_setup_msg errors unknown_arg): $1"
+        _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
         return 1
         ;;
     esac
@@ -3610,13 +3610,13 @@ _setup_reset() {
   local _env="${_base_path}/.env"
   local _tpl_conf="${_SETUP_SCRIPT_DIR}/../../config/docker/setup.conf"
   if [[ ! -f "${_tpl_conf}" ]]; then
-    _log_err setup "template setup.conf not found at ${_tpl_conf}"
+    _log_err setup conf_template_missing "display=template setup.conf not found at ${_tpl_conf}" "path=${_tpl_conf}"
     return 1
   fi
 
   if (( ! _yes )); then
     if [[ ! -t 0 ]]; then
-      _log_err setup "$(_setup_msg reset needs_yes)"
+      _log_err setup conf_reset_needs_yes "display=$(_setup_msg reset needs_yes)"
       return 1
     fi
     printf "[setup] %s [y/N]: " "$(_setup_msg reset confirm)"
@@ -3625,7 +3625,7 @@ _setup_reset() {
     case "${_ans}" in
       y|Y|yes|YES) ;;
       *)
-        _log_warn setup "$(_setup_msg reset aborted)"
+        _log_warn setup conf_reset_aborted "display=$(_setup_msg reset aborted)"
         return 1
         ;;
     esac
@@ -3641,7 +3641,7 @@ _setup_reset() {
   fi
 
   if [[ "${_quiet}" -eq 0 ]]; then
-    _log_info setup "$(_setup_msg reset "done")"
+    _log_info setup conf_reset "display=$(_setup_msg reset "done")"
     printf '[setup] file: %s\n' "${_conf}"
     printf "[setup] next: run 'make build' (auto-applies) or './setup.sh apply' to regenerate .env + compose.yaml\n"
   fi
@@ -3702,7 +3702,7 @@ _setup_apply() {
         shift
         ;;
       *)
-        _log_err setup "$(_setup_msg errors unknown_arg): $1"
+        _log_err setup conf_unknown_arg "display=$(_setup_msg errors unknown_arg): $1" "arg=$1"
         return 1
         ;;
     esac
@@ -3714,7 +3714,7 @@ _setup_apply() {
     case "${_gui_override}" in
       auto|force|off) ;;
       *)
-        _log_err setup "$(_setup_msg errors invalid_value): --gui = ${_gui_override} (expected auto|force|off)"
+        _log_err setup gui_override_invalid "display=$(_setup_msg errors invalid_value): --gui = ${_gui_override} (expected auto|force|off)" "value=${_gui_override}"
         return 2
         ;;
     esac
@@ -3922,7 +3922,7 @@ _setup_apply() {
       # a stale bake from another contributor's clone. Warn loudly so
       # the user understands the rewrite, then migrate mount_1 back to
       # the portable form.
-      _log_warn setup "[volumes] mount_1 host path '${_mount_1_host}' does not exist on this machine. This is usually a stale absolute path committed from a different machine. Rewriting mount_1 to the portable '\${WS_PATH}:/home/\${USER_NAME}/work' form and re-detecting WS_PATH locally. Commit the updated setup.conf to share."
+      _log_warn setup conf_mount_stale_path "display=[volumes] mount_1 host path '${_mount_1_host}' does not exist on this machine. This is usually a stale absolute path committed from a different machine. Rewriting mount_1 to the portable '\${WS_PATH}:/home/\${USER_NAME}/work' form and re-detecting WS_PATH locally. Commit the updated setup.conf to share." "path=${_mount_1_host}"
       ws_path=""
       detect_ws_path ws_path "${_base_path}"
       [[ -d "${ws_path}" ]] && ws_path="$(cd "${ws_path}" && pwd -P)"
@@ -4090,7 +4090,7 @@ _setup_apply() {
       && (( _no_x11_cookie == 0 )); then
     _ssh_x11_xauth="$(_setup_ssh_x11_cookie "${_base_path}")" || _ssh_x11_xauth=""
     if [[ "${net_mode}" != "host" ]]; then
-      _log_warn setup "SSH X11 forwarding detected but [network] mode = ${net_mode}; localhost:${DISPLAY##*:} from inside the container will not reach the host's SSH X11 listener. Set [network] mode = host in setup.conf to fix. See base#321."
+      _log_warn setup ssh_x11_network_mismatch "display=SSH X11 forwarding detected but [network] mode = ${net_mode}; localhost:${DISPLAY##*:} from inside the container will not reach the host's SSH X11 listener. Set [network] mode = host in setup.conf to fix. See base#321." "mode=${net_mode}"
     fi
   fi
 
@@ -4142,7 +4142,7 @@ _setup_apply() {
     "${_logging_global_str}" "${_logging_per_svc_str}"
 
   if [[ "${_quiet}" -eq 0 ]]; then
-    _log_info setup "$(_setup_msg env "done")"
+    _log_info setup env_regenerated "display=$(_setup_msg env "done")"
     printf "[setup] USER=%s (%s:%s)  GPU=%s/%s  GUI=%s/%s  IMAGE=%s  WS=%s\n" \
       "${user_name}" "${user_uid}" "${user_gid}" \
       "${gpu_enabled_eff}" "${gpu_mode}" \
@@ -4185,7 +4185,7 @@ main() {
       shift
       ;;
     *)
-      _log_err setup "$(_setup_msg errors unknown_subcmd): $1"
+      _log_err setup conf_unknown_subcmd "display=$(_setup_msg errors unknown_subcmd): $1" "subcmd=$1"
       return 1
       ;;
   esac

--- a/script/docker/stop.sh
+++ b/script/docker/stop.sh
@@ -205,10 +205,10 @@ _down_one() {
       --filter "label=com.docker.compose.project=${_project_name}" \
       --format '{{.Names}} ({{.State}})' 2>/dev/null || true)"
     if [[ -n "${_matches}" ]]; then
-      _log_info stop "Tearing down containers in project ${_project_name}:"
+      _log_info stop stop_teardown "display=Tearing down containers in project ${_project_name}:" "project=${_project_name}"
       printf '%s\n' "${_matches}" | sed 's/^/  /' >&2
     else
-      _log_info stop "No containers found for project ${_project_name}"
+      _log_info stop stop_no_containers "display=No containers found for project ${_project_name}" "project=${_project_name}"
     fi
   fi
   COMPOSE_PROFILES='*' _compose_project down --remove-orphans "${PASSTHROUGH[@]}"
@@ -309,7 +309,7 @@ main() {
       local _no_inst
       # shellcheck disable=SC2059
       printf -v _no_inst "$(_msg info no_instances)" "${IMAGE_NAME}"
-      _log_info stop "${_no_inst}"
+      _log_info stop stop_no_containers "display=${_no_inst}"
       # Still honor --prune even when no instance found, so a stale repo
       # with orphan networks/images from past runs gets cleaned.
       _maybe_prune
@@ -343,9 +343,9 @@ _maybe_prune() {
     printf '[dry-run]'; printf ' %q' "${_img_cmd[@]}"; printf '\n'
     return 0
   fi
-  _log_info stop "Pruning orphan networks (until=10m)..."
+  _log_info stop stop_prune_networks "display=Pruning orphan networks (until=10m)..."
   "${_net_cmd[@]}" || true
-  _log_info stop "Pruning dangling images (until=24h)..."
+  _log_info stop stop_prune_images "display=Pruning dangling images (until=24h)..."
   "${_img_cmd[@]}" || true
 }
 

--- a/test/integration/fresh_clone_portability_spec.bats
+++ b/test/integration/fresh_clone_portability_spec.bats
@@ -23,6 +23,7 @@
 # Level-1 (file generation only) — docker is not invoked.
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/../unit/test_helper"
 
   REPO_NAME="myapp_test"

--- a/test/integration/gitignore_sync_spec.bats
+++ b/test/integration/gitignore_sync_spec.bats
@@ -10,6 +10,7 @@
 bats_require_minimum_version 1.5.0
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/../unit/test_helper"
 
   TMP_ROOT="$(mktemp -d)"
@@ -166,7 +167,7 @@ _seed_upgrade_fixture() {
   # sub-libs (#284), so copy all three surfaces.
   cp /source/script/docker/_lib.sh "${TMPL_WORK}/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${TMPL_WORK}/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${TMPL_WORK}/script/docker/lib/"
+  cp /source/script/docker/lib/* "${TMPL_WORK}/script/docker/lib/"
   printf '#!/usr/bin/env bash\nexit 0\n' > "${TMPL_WORK}/script/docker/setup.sh"
   # _create_symlinks references these paths; empty stubs keep ln -sf happy.
   for _f in build.sh run.sh exec.sh stop.sh setup_tui.sh Makefile; do

--- a/test/integration/init_new_repo_spec.bats
+++ b/test/integration/init_new_repo_spec.bats
@@ -11,6 +11,7 @@
 # separate self-test.yaml job that has access to the host Docker daemon.
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/../unit/test_helper"
 
   # Stage a fake repo dir whose basename will become IMAGE_NAME

--- a/test/integration/upgrade_spec.bats
+++ b/test/integration/upgrade_spec.bats
@@ -10,6 +10,7 @@
 bats_require_minimum_version 1.5.0
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/../unit/test_helper"
   UPGRADE="/source/upgrade.sh"
 
@@ -47,7 +48,7 @@ _seed_template_remote() {
   mkdir -p "${TMPL_WORK}/script/docker/lib"
   cp /source/script/docker/_lib.sh "${TMPL_WORK}/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${TMPL_WORK}/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${TMPL_WORK}/script/docker/lib/"
+  cp /source/script/docker/lib/* "${TMPL_WORK}/script/docker/lib/"
   chmod +x "${TMPL_WORK}/init.sh" "${TMPL_WORK}/script/docker/setup.sh" "${TMPL_WORK}/upgrade.sh"
   git -C "${TMPL_WORK}" add -A
   git -C "${TMPL_WORK}" commit -q -m "v0.9.5"

--- a/test/unit/build_sh_prune_spec.bats
+++ b/test/unit/build_sh_prune_spec.bats
@@ -24,6 +24,7 @@
 bats_require_minimum_version 1.5.0
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/test_helper"
 
   # shellcheck disable=SC2154
@@ -36,7 +37,7 @@ setup() {
 
   cp /source/script/docker/_lib.sh  "${SANDBOX}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh  "${SANDBOX}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${SANDBOX}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${SANDBOX}/.base/script/docker/lib/"
   ln -s /source/script/docker/build.sh "${SANDBOX}/build.sh"
 
   MOCK_SETUP_LOG="${TEMP_DIR}/setup.log"

--- a/test/unit/build_sh_spec.bats
+++ b/test/unit/build_sh_spec.bats
@@ -14,6 +14,7 @@
 bats_require_minimum_version 1.5.0
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/test_helper"
 
   # shellcheck disable=SC2154
@@ -28,7 +29,7 @@ setup() {
   cp /source/script/docker/_lib.sh     "${SANDBOX}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh     "${SANDBOX}/.base/script/docker/i18n.sh"
   # _lib.sh post-#284 is an umbrella that sources lib/*.sh sub-libs.
-  cp /source/script/docker/lib/*.sh    "${SANDBOX}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/*    "${SANDBOX}/.base/script/docker/lib/"
   # Symlink (not copy) so kcov attributes coverage to /source/script/docker/build.sh.
   ln -s /source/script/docker/build.sh "${SANDBOX}/build.sh"
   touch "${SANDBOX}/.base/dockerfile/Dockerfile.test-tools"
@@ -418,7 +419,7 @@ EOS
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=zh_TW.UTF-8 run bash "${_tmp}/build.sh" -h
   assert_success
   assert_output --partial "用法"
@@ -432,7 +433,7 @@ EOS
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=zh_CN.UTF-8 run bash "${_tmp}/build.sh" -h
   assert_success
   assert_output --partial "用法"
@@ -446,7 +447,7 @@ EOS
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=ja_JP.UTF-8 run bash "${_tmp}/build.sh" -h
   assert_success
   assert_output --partial "使用法"
@@ -632,7 +633,7 @@ EOS
   mkdir -p "${ALT}/.base/script/docker/lib" "${ALT}/.base/dockerfile"
   cp /source/script/docker/_lib.sh "${ALT}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${ALT}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${ALT}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${ALT}/.base/script/docker/lib/"
   cp "${SANDBOX}/.base/script/docker/setup.sh" "${ALT}/.base/script/docker/setup.sh"
   chmod +x "${ALT}/.base/script/docker/setup.sh"
   touch "${ALT}/.base/dockerfile/Dockerfile.test-tools"
@@ -650,7 +651,7 @@ EOS
   mkdir -p "${ALT}/.base/script/docker/lib" "${ALT}/.base/dockerfile"
   cp /source/script/docker/_lib.sh "${ALT}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${ALT}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${ALT}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${ALT}/.base/script/docker/lib/"
   cp "${SANDBOX}/.base/script/docker/setup.sh" "${ALT}/.base/script/docker/setup.sh"
   chmod +x "${ALT}/.base/script/docker/setup.sh"
   touch "${ALT}/.base/dockerfile/Dockerfile.test-tools"

--- a/test/unit/ci_spec.bats
+++ b/test/unit/ci_spec.bats
@@ -9,8 +9,14 @@
 # (b) apt-get / git resolve to our mocks instead of the real binaries.
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/test_helper"
   create_mock_dir
+  local _cmd
+  for _cmd in grep date cat printf; do
+    local _path
+    _path="$(command -v "${_cmd}" 2>/dev/null)" && ln -sf "${_path}" "${MOCK_DIR}/${_cmd}"
+  done
 }
 
 teardown() {

--- a/test/unit/exec_sh_spec.bats
+++ b/test/unit/exec_sh_spec.bats
@@ -10,6 +10,7 @@
 bats_require_minimum_version 1.5.0
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/test_helper"
 
   # shellcheck disable=SC2154
@@ -22,7 +23,7 @@ setup() {
   cp /source/script/docker/_lib.sh  "${SANDBOX}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh  "${SANDBOX}/.base/script/docker/i18n.sh"
   # _lib.sh post-#284 is an umbrella that sources lib/*.sh sub-libs.
-  cp /source/script/docker/lib/*.sh "${SANDBOX}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${SANDBOX}/.base/script/docker/lib/"
   ln -s /source/script/docker/exec.sh "${SANDBOX}/exec.sh"
 
   # Seed .env so _load_env / _compute_project_name succeed without bootstrap.
@@ -242,7 +243,7 @@ teardown() {
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=zh_TW.UTF-8 run bash "${_tmp}/exec.sh" -h
   assert_success
   assert_output --partial "用法"
@@ -256,7 +257,7 @@ teardown() {
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=zh_CN.UTF-8 run bash "${_tmp}/exec.sh" -h
   assert_success
   assert_output --partial "用法"
@@ -270,7 +271,7 @@ teardown() {
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=ja_JP.UTF-8 run bash "${_tmp}/exec.sh" -h
   assert_success
   assert_output --partial "使用法"
@@ -289,7 +290,7 @@ teardown() {
   mkdir -p "${ALT}/.base/script/docker/lib"
   cp /source/script/docker/_lib.sh "${ALT}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${ALT}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${ALT}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${ALT}/.base/script/docker/lib/"
   {
     echo "USER_NAME=tester"
     echo "IMAGE_NAME=altimg"
@@ -313,7 +314,7 @@ teardown() {
   mkdir -p "${ALT}/.base/script/docker/lib"
   cp /source/script/docker/_lib.sh "${ALT}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${ALT}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${ALT}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${ALT}/.base/script/docker/lib/"
   {
     echo "USER_NAME=tester"
     echo "IMAGE_NAME=altimg2"

--- a/test/unit/init_spec.bats
+++ b/test/unit/init_spec.bats
@@ -8,6 +8,7 @@
 # fallback, _create_version_file with no argument).
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/test_helper"
   create_mock_dir
 
@@ -35,6 +36,8 @@ setup() {
           "${TMP_REPO}/.base/script/docker/lib/${_sl}.sh"
   done
   unset _sl
+  ln -s /source/script/docker/lib/log-events.txt \
+        "${TMP_REPO}/.base/script/docker/lib/log-events.txt"
 
   # Minimal Dockerfile.example stub for _create_new_repo's `cp` step.
   cat > "${TMP_REPO}/.base/dockerfile/Dockerfile.example" <<'EOF'

--- a/test/unit/log_spec.bats
+++ b/test/unit/log_spec.bats
@@ -1,94 +1,146 @@
 #!/usr/bin/env bats
 #
-# log_spec.bats - Tests for OTel-aligned log.sh (#423).
-# Dual output: terminal = text (with timestamp + aligned level);
-# LOG_JSON_FILE = structured JSON per OTel Logs Data Model.
+# log_spec.bats - Tests for OTel-aligned log.sh (#423, #438).
+# Single-sink tty-detect dispatch: text on TTY, JSON on non-TTY.
+# LOG_FORMAT=auto|text|json override. Strict body enforcement.
 
 bats_require_minimum_version 1.5.0
 
 setup() {
   load "${BATS_TEST_DIRNAME}/test_helper"
   LOG_SH="/source/script/docker/lib/log.sh"
-  JSON_FILE="${BATS_TEST_TMPDIR}/log.jsonl"
 }
 
-# ── Text output format (terminal) ──────────────────────────────────
+# ── Text output format (LOG_FORMAT=text) ──────────────────────────
 
 @test "_log_info text output has timestamp + aligned level + tag" {
-  run --separate-stderr bash -c "source ${LOG_SH}; _log_info setup 'phase done'"
+  run --separate-stderr bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_info setup env_regenerated"
   assert_success
   assert_equal "${stderr}" ""
   [[ "${output}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]]
-  [[ "${output}" == *"[setup] INFO : phase done" ]]
+  [[ "${output}" == *"[setup] INFO : env_regenerated" ]]
 }
 
 @test "_log_err text output to stderr with timestamp" {
-  run --separate-stderr bash -c "source ${LOG_SH}; _log_err build 'something broke'"
+  run --separate-stderr bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_err build build_no_env"
   assert_success
   assert_equal "${output}" ""
   [[ "${stderr}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]]
-  [[ "${stderr}" == *"[build] ERROR: something broke" ]]
+  [[ "${stderr}" == *"[build] ERROR: build_no_env" ]]
 }
 
 @test "_log_warn text output uses WARN (not WARNING)" {
-  run --separate-stderr bash -c "source ${LOG_SH}; _log_warn run 'deprecated flag'"
+  run --separate-stderr bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_warn run run_no_env"
   assert_success
-  [[ "${stderr}" =~ 'WARN : deprecated flag'$ ]]
+  [[ "${stderr}" =~ 'WARN : run_no_env'$ ]]
 }
 
 @test "_log_debug text output to stdout" {
-  run --separate-stderr bash -c "source ${LOG_SH}; _log_debug build 'trace msg'"
+  run --separate-stderr bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_debug build dry_run_cmd"
   assert_success
-  [[ "${output}" =~ 'DEBUG: trace msg'$ ]]
+  [[ "${output}" =~ 'DEBUG: dry_run_cmd'$ ]]
   assert_equal "${stderr}" ""
 }
 
 @test "_log_fatal text output to stderr" {
-  run --separate-stderr bash -c "source ${LOG_SH}; _log_fatal init 'unrecoverable'"
+  run --separate-stderr bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_fatal init init_missing_required_arg"
   assert_success
-  [[ "${stderr}" =~ 'FATAL: unrecoverable'$ ]]
+  [[ "${stderr}" =~ 'FATAL: init_missing_required_arg'$ ]]
 }
 
 @test "text levels are right-aligned to 5 chars" {
   run --separate-stderr bash -c "
+    export LOG_FORMAT=text
     source ${LOG_SH}
-    _log_info  setup 'i'
-    _log_debug setup 'd'
+    _log_info  setup env_regenerated
+    _log_debug setup dry_run_cmd
   "
   assert_success
-  [[ "${lines[0]}" =~ 'INFO : i'$ ]]
-  [[ "${lines[1]}" =~ 'DEBUG: d'$ ]]
+  [[ "${lines[0]}" =~ 'INFO : env_regenerated'$ ]]
+  [[ "${lines[1]}" =~ 'DEBUG: dry_run_cmd'$ ]]
 }
 
 @test "text output joins multi-token message with spaces" {
-  run --separate-stderr bash -c "source ${LOG_SH}; _log_err build word1 word2 word3"
+  run --separate-stderr bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_err build build_no_env word2 word3"
   assert_success
-  [[ "${stderr}" =~ 'ERROR: word1 word2 word3'$ ]]
+  [[ "${stderr}" =~ 'ERROR: build_no_env word2 word3'$ ]]
 }
 
 @test "text output skips attr=val args in message" {
-  run bash -c "source ${LOG_SH}; _log_info setup 'regen done' ws_path=/tmp conf_hash=abc"
+  run bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_info setup env_regenerated ws_path=/tmp conf_hash=abc"
   assert_success
-  [[ "${output}" =~ 'INFO : regen done'$ ]]
+  [[ "${output}" =~ 'INFO : env_regenerated'$ ]]
   refute_line --partial "ws_path"
 }
 
-# ── Stream routing ─────────────────────────────────────────────────
+@test "text output uses display= attribute over body when present" {
+  run bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_info setup env_regenerated 'display=Env regenerated OK' ws_path=/tmp"
+  assert_success
+  [[ "${output}" =~ 'INFO : Env regenerated OK'$ ]]
+  refute_line --partial "env_regenerated"
+  refute_line --partial "ws_path"
+}
+
+@test "JSON includes display= as attribute alongside registered body" {
+  run bash -c "source ${LOG_SH}; _log_info setup env_regenerated 'display=Env regenerated OK'"
+  assert_success
+  [[ "${output}" == *'"body":"env_regenerated"'* ]]
+  [[ "${output}" == *'"display":"Env regenerated OK"'* ]]
+}
+
+# ── Timestamp: UTC + microsecond (#438) ───────────────────────────
+
+@test "text timestamp is UTC with microsecond precision" {
+  run bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_info setup env_regenerated"
+  assert_success
+  [[ "${output}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}Z ]]
+}
+
+@test "JSON timestamp is UTC with microsecond precision" {
+  run bash -c "source ${LOG_SH}; _log_info setup env_regenerated"
+  assert_success
+  local ts
+  ts="$(printf '%s' "${output}" | grep -o '"timestamp":"[^"]*"')"
+  [[ "${ts}" =~ \"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}Z\" ]]
+}
+
+# ── Stream routing (LOG_FORMAT=text) ──────────────────────────────
 
 @test "_log_info and _log_debug route to stdout" {
-  run --separate-stderr bash -c "source ${LOG_SH}; _log_info setup msg1; _log_debug setup msg2"
+  run --separate-stderr bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_info setup env_regenerated; _log_debug setup dry_run_cmd"
   assert_success
   assert_equal "${stderr}" ""
-  [[ "${output}" == *"msg1"* ]]
-  [[ "${output}" == *"msg2"* ]]
+  [[ "${output}" == *"env_regenerated"* ]]
+  [[ "${output}" == *"dry_run_cmd"* ]]
 }
 
 @test "_log_warn _log_err _log_fatal route to stderr" {
   run --separate-stderr bash -c "
+    export LOG_FORMAT=text
     source ${LOG_SH}
-    _log_warn  setup w
-    _log_err   setup e
-    _log_fatal setup f
+    _log_warn  setup xauth_rewrite_failed
+    _log_err   setup conf_invalid_value
+    _log_fatal setup conf_unknown_subcmd
   "
   assert_success
   assert_equal "${output}" ""
@@ -97,121 +149,163 @@ setup() {
   [[ "${stderr}" == *"FATAL"* ]]
 }
 
-# ── JSON file output (LOG_JSON_FILE) ───────────────────────────────
+# ── Single-sink tty-detect dispatch (#438) ────────────────────────
 
-@test "LOG_JSON_FILE receives JSON when set" {
-  run bash -c "
-    export LOG_JSON_FILE='${JSON_FILE}'
-    source ${LOG_SH}
-    _log_info setup 'regen done' ws_path=/tmp
-  "
+@test "non-TTY stdout emits JSON by default (auto-detect)" {
+  run bash -c "source ${LOG_SH}; _log_info setup env_regenerated ws_path=/tmp"
   assert_success
-  [[ -f "${JSON_FILE}" ]]
-  local json
-  json="$(cat "${JSON_FILE}")"
-  [[ "${json}" == *'"severity_text":"INFO"'* ]]
-  [[ "${json}" == *'"body":"regen done"'* ]]
+  [[ "${output}" == *'"severity_text":"INFO"'* ]]
+  [[ "${output}" == *'"body":"env_regenerated"'* ]]
+  [[ "${output}" == *'"ws_path":"/tmp"'* ]]
 }
 
-@test "JSON file contains OTel fields" {
-  run bash -c "
-    export LOG_JSON_FILE='${JSON_FILE}'
-    source ${LOG_SH}
-    _log_info setup env_regenerated ws_path=/tmp
-  "
+@test "non-TTY stderr emits JSON for _log_err" {
+  run --separate-stderr bash -c "source ${LOG_SH}; _log_err build build_no_env"
   assert_success
-  local json
-  json="$(cat "${JSON_FILE}")"
-  [[ "${json}" == *'"timestamp":'* ]]
-  [[ "${json}" == *'"severity_text":"INFO"'* ]]
-  [[ "${json}" == *'"severity_number":9'* ]]
-  [[ "${json}" == *'"body":"env_regenerated"'* ]]
-  [[ "${json}" == *'"service.name":"setup"'* ]]
-  [[ "${json}" == *'"service.lang":"bash"'* ]]
-  [[ "${json}" == *'"code.filepath":'* ]]
-  [[ "${json}" == *'"code.lineno":'* ]]
-  [[ "${json}" == *'"thread.id":'* ]]
+  assert_equal "${output}" ""
+  [[ "${stderr}" == *'"severity_text":"ERROR"'* ]]
+  [[ "${stderr}" == *'"body":"build_no_env"'* ]]
 }
 
-@test "JSON file contains custom attributes" {
+@test "LOG_FORMAT=text forces text output on non-TTY" {
   run bash -c "
-    export LOG_JSON_FILE='${JSON_FILE}'
-    source ${LOG_SH}
-    _log_info setup env_regenerated ws_path=/tmp conf_hash=abc123
-  "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_info setup env_regenerated"
   assert_success
-  local json
-  json="$(cat "${JSON_FILE}")"
-  [[ "${json}" == *'"ws_path":"/tmp"'* ]]
-  [[ "${json}" == *'"conf_hash":"abc123"'* ]]
+  [[ "${output}" =~ 'INFO : env_regenerated'$ ]]
+  [[ "${output}" != *'"severity_text"'* ]]
+}
+
+@test "LOG_FORMAT=json forces JSON output" {
+  run bash -c "
+    export LOG_FORMAT=json
+    source ${LOG_SH}; _log_info setup env_regenerated"
+  assert_success
+  [[ "${output}" == *'"severity_text":"INFO"'* ]]
+  [[ "${output}" == *'"body":"env_regenerated"'* ]]
+}
+
+@test "LOG_FORMAT=auto is equivalent to unset (non-TTY -> JSON)" {
+  local out_auto out_unset
+  out_auto="$(bash -c "export LOG_FORMAT=auto; source ${LOG_SH}; _log_info setup env_regenerated" 2>/dev/null)"
+  out_unset="$(bash -c "unset LOG_FORMAT; source ${LOG_SH}; _log_info setup env_regenerated" 2>/dev/null)"
+  [[ "${out_auto}" == *'"severity_text":"INFO"'* ]]
+  [[ "${out_unset}" == *'"severity_text":"INFO"'* ]]
+}
+
+# ── JSON output format (non-TTY auto-detect) ─────────────────────
+
+@test "JSON output contains OTel fields" {
+  run bash -c "source ${LOG_SH}; _log_info setup env_regenerated ws_path=/tmp"
+  assert_success
+  [[ "${output}" == *'"timestamp":'* ]]
+  [[ "${output}" == *'"severity_text":"INFO"'* ]]
+  [[ "${output}" == *'"severity_number":9'* ]]
+  [[ "${output}" == *'"body":"env_regenerated"'* ]]
+  [[ "${output}" == *'"service.name":"setup"'* ]]
+  [[ "${output}" == *'"service.lang":"bash"'* ]]
+  [[ "${output}" == *'"code.filepath":'* ]]
+  [[ "${output}" == *'"code.lineno":'* ]]
+  [[ "${output}" == *'"thread.id":'* ]]
+}
+
+@test "JSON output contains custom attributes" {
+  run bash -c "source ${LOG_SH}; _log_info setup env_regenerated ws_path=/tmp conf_hash=abc123"
+  assert_success
+  [[ "${output}" == *'"ws_path":"/tmp"'* ]]
+  [[ "${output}" == *'"conf_hash":"abc123"'* ]]
 }
 
 @test "JSON severity_number: DEBUG=5 INFO=9 WARN=13 ERROR=17 FATAL=21" {
   run bash -c "
-    export LOG_JSON_FILE='${JSON_FILE}'
     source ${LOG_SH}
     _log_debug build dry_run_cmd
     _log_info  setup env_regenerated
+  "
+  assert_success
+  [[ "${output}" == *'"severity_number":5'* ]]
+  [[ "${output}" == *'"severity_number":9'* ]]
+
+  run bash -c "
+    source ${LOG_SH}
     _log_warn  setup xauth_rewrite_failed
     _log_err   setup conf_invalid_value
     _log_fatal init  init_missing_required_arg
   " 2>/dev/null
   assert_success
-  local json
-  json="$(cat "${JSON_FILE}")"
-  [[ "${json}" == *'"severity_number":5'* ]]
-  [[ "${json}" == *'"severity_number":9'* ]]
-  [[ "${json}" == *'"severity_number":13'* ]]
-  [[ "${json}" == *'"severity_number":17'* ]]
-  [[ "${json}" == *'"severity_number":21'* ]]
+  local combined="${output}${stderr}"
+  [[ "${combined}" == *'"severity_number":13'* ]]
+  [[ "${combined}" == *'"severity_number":17'* ]]
+  [[ "${combined}" == *'"severity_number":21'* ]]
 }
 
-@test "no JSON file written when LOG_JSON_FILE is unset" {
-  run bash -c "unset LOG_JSON_FILE; source ${LOG_SH}; _log_info setup msg"
-  assert_success
-  [[ ! -f "${JSON_FILE}" ]]
-}
-
-@test "JSON file appends multiple entries" {
+@test "JSON output is valid per-line (starts with { ends with })" {
   run bash -c "
-    export LOG_JSON_FILE='${JSON_FILE}'
     source ${LOG_SH}
     _log_info setup env_regenerated
-    _log_err  setup conf_invalid_value
-  " 2>/dev/null
+    _log_info setup env_drift_detected
+  "
   assert_success
-  local count
-  count="$(wc -l < "${JSON_FILE}")"
+  local count=0
+  local line
+  while IFS= read -r line; do
+    [[ "${line}" == "{"*"}" ]]
+    [[ "${line}" == *'"timestamp":'* ]]
+    [[ "${line}" == *'"body":'* ]]
+    count=$(( count + 1 ))
+  done <<< "${output}"
   [[ "${count}" -eq 2 ]]
 }
 
-# ── TRACEPARENT in JSON file ───────────────────────────────────────
+# ── TRACEPARENT in JSON ───────────────────────────────────────────
 
 @test "JSON includes trace_id and span_id when TRACEPARENT is set" {
   run bash -c "
     export TRACEPARENT='00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01'
-    export LOG_JSON_FILE='${JSON_FILE}'
     source ${LOG_SH}
     _log_info setup env_regenerated
   "
   assert_success
-  local json
-  json="$(cat "${JSON_FILE}")"
-  [[ "${json}" == *'"trace_id":"0af7651916cd43dd8448eb211c80319c"'* ]]
-  [[ "${json}" == *'"span_id":"b7ad6b7169203331"'* ]]
+  [[ "${output}" == *'"trace_id":"0af7651916cd43dd8448eb211c80319c"'* ]]
+  [[ "${output}" == *'"span_id":"b7ad6b7169203331"'* ]]
 }
 
 @test "JSON omits trace_id when TRACEPARENT is unset" {
   run bash -c "
     unset TRACEPARENT
-    export LOG_JSON_FILE='${JSON_FILE}'
     source ${LOG_SH}
     _log_info setup env_regenerated
   "
   assert_success
-  local json
-  json="$(cat "${JSON_FILE}")"
-  [[ "${json}" != *'"trace_id"'* ]]
+  [[ "${output}" != *'"trace_id"'* ]]
+}
+
+# ── Strict body enforcement (#438) ────────────────────────────────
+
+@test "unregistered body causes fatal exit" {
+  run bash -c "source ${LOG_SH}; _log_info setup not_a_real_event"
+  assert_failure
+  [[ "${output}${stderr}" == *'unregistered'* ]]
+  [[ "${output}${stderr}" == *'not_a_real_event'* ]]
+}
+
+@test "registered body succeeds normally" {
+  run bash -c "source ${LOG_SH}; _log_info setup env_regenerated"
+  assert_success
+}
+
+@test "empty body is allowed (no strict check)" {
+  run bash -c "
+    export LOG_FORMAT=text
+    source ${LOG_SH}; _log_info setup"
+  assert_success
+}
+
+@test "strict body error names the offending body and log-events.txt" {
+  run bash -c "source ${LOG_SH}; _log_info setup typo_event_name"
+  assert_failure
+  [[ "${output}${stderr}" == *'typo_event_name'* ]]
+  [[ "${output}${stderr}" == *'log-events.txt'* ]]
 }
 
 # ── Missing service is rejected ────────────────────────────────────
@@ -228,8 +322,9 @@ setup() {
 
 @test "_log_fatal does not exit; caller controls exit" {
   run --separate-stderr bash -c "
+    export LOG_FORMAT=text
     source ${LOG_SH}
-    _log_fatal init 'unrecoverable' arg=REPO_NAME
+    _log_fatal init init_missing_required_arg
     echo 'still running'
   "
   assert_success
@@ -280,23 +375,11 @@ setup() {
   [[ "${stderr}" == *"[trace started:"* ]]
 }
 
-# ── _log_plain backward compat ─────────────────────────────────────
+# ── _log_plain removed (#438) ─────────────────────────────────────
 
-@test "_log_plain writes tagged text to stdout (no style)" {
-  run --separate-stderr bash -c "source ${LOG_SH}; _log_plain build '' 'plain text'"
-  assert_success
-  assert_equal "${output}" "[build] plain text"
-  assert_equal "${stderr}" ""
-}
-
-@test "_log_plain with bold + FORCE_COLOR=1 wraps in ANSI bold" {
-  run --separate-stderr bash -c "FORCE_COLOR=1 source ${LOG_SH}; FORCE_COLOR=1 _log_plain build bold 'header'"
-  assert_success
-  assert_equal "${output}" $'[build] \033[1mheader\033[0m'
-}
-
-@test "_log_plain with no tag exits non-zero" {
-  run -127 bash -c "source ${LOG_SH}; _log_plain"
+@test "_log_plain is no longer defined" {
+  run bash -c "source ${LOG_SH}; declare -F _log_plain"
+  assert_failure
 }
 
 # ── _log_color_enabled ─────────────────────────────────────────────
@@ -319,25 +402,31 @@ setup() {
 # ── FORCE_COLOR text ───────────────────────────────────────────────
 
 @test "_log_err FORCE_COLOR=1 emits red bold ANSI in text" {
-  run --separate-stderr bash -c "FORCE_COLOR=1 source ${LOG_SH}; FORCE_COLOR=1 _log_err build msg"
+  run --separate-stderr bash -c "
+    export FORCE_COLOR=1 LOG_FORMAT=text
+    source ${LOG_SH}; _log_err build build_no_env"
   assert_success
   [[ "${stderr}" == *$'\033[1;31m'* ]]
   [[ "${stderr}" == *"ERROR"* ]]
-  [[ "${stderr}" == *"msg"* ]]
+  [[ "${stderr}" == *"build_no_env"* ]]
 }
 
 @test "_log_warn FORCE_COLOR=1 emits yellow ANSI in text" {
-  run --separate-stderr bash -c "FORCE_COLOR=1 source ${LOG_SH}; FORCE_COLOR=1 _log_warn run msg"
+  run --separate-stderr bash -c "
+    export FORCE_COLOR=1 LOG_FORMAT=text
+    source ${LOG_SH}; _log_warn run run_no_env"
   assert_success
   [[ "${stderr}" == *$'\033[33m'* ]]
   [[ "${stderr}" == *"WARN"* ]]
 }
 
 @test "NO_COLOR=1 text omits ANSI" {
-  run --separate-stderr bash -c "NO_COLOR=1 FORCE_COLOR=1 source ${LOG_SH}; NO_COLOR=1 FORCE_COLOR=1 _log_err build msg"
+  run --separate-stderr bash -c "
+    export NO_COLOR=1 FORCE_COLOR=1 LOG_FORMAT=text
+    source ${LOG_SH}; _log_err build build_no_env"
   assert_success
   [[ "${stderr}" != *$'\033['* ]]
-  [[ "${stderr}" == *"ERROR: msg"* ]]
+  [[ "${stderr}" == *"ERROR: build_no_env"* ]]
 }
 
 # ── Event registry ─────────────────────────────────────────────────

--- a/test/unit/prune_sh_spec.bats
+++ b/test/unit/prune_sh_spec.bats
@@ -11,6 +11,7 @@
 bats_require_minimum_version 1.5.0
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/test_helper"
 
   # shellcheck disable=SC2154
@@ -22,7 +23,7 @@ setup() {
 
   cp /source/script/docker/_lib.sh  "${SANDBOX}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh  "${SANDBOX}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${SANDBOX}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${SANDBOX}/.base/script/docker/lib/"
   ln -s /source/script/docker/prune.sh "${SANDBOX}/prune.sh"
 
   # prune.sh doesn't load .env, but a seed file keeps the sandbox layout
@@ -191,7 +192,7 @@ teardown() {
   mkdir -p "${ALT}/.base/script/docker/lib"
   cp /source/script/docker/_lib.sh "${ALT}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${ALT}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${ALT}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${ALT}/.base/script/docker/lib/"
   : > "${ALT}/.env"
   run bash "${SANDBOX}/prune.sh" -C "${ALT}" --networks --dry-run
   assert_success

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -8,6 +8,7 @@
 bats_require_minimum_version 1.5.0
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/test_helper"
 
   # shellcheck disable=SC2154
@@ -21,7 +22,7 @@ setup() {
   cp /source/script/docker/_lib.sh  "${SANDBOX}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh  "${SANDBOX}/.base/script/docker/i18n.sh"
   # _lib.sh post-#284 is an umbrella that sources lib/*.sh sub-libs.
-  cp /source/script/docker/lib/*.sh "${SANDBOX}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${SANDBOX}/.base/script/docker/lib/"
   # Symlink (not copy) so kcov attributes coverage to /source/script/docker/run.sh.
   ln -s /source/script/docker/run.sh "${SANDBOX}/run.sh"
 
@@ -418,7 +419,7 @@ EOS
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=zh_TW.UTF-8 run bash "${_tmp}/run.sh" -h
   assert_success
   assert_output --partial "用法"
@@ -432,7 +433,7 @@ EOS
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=zh_CN.UTF-8 run bash "${_tmp}/run.sh" -h
   assert_success
   assert_output --partial "用法"
@@ -446,7 +447,7 @@ EOS
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=ja_JP.UTF-8 run bash "${_tmp}/run.sh" -h
   assert_success
   assert_output --partial "使用法"
@@ -692,7 +693,7 @@ EOS
   mkdir -p "${ALT}/.base/script/docker/lib"
   cp /source/script/docker/_lib.sh "${ALT}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${ALT}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${ALT}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${ALT}/.base/script/docker/lib/"
   cp "${SANDBOX}/.base/script/docker/setup.sh" "${ALT}/.base/script/docker/setup.sh"
   chmod +x "${ALT}/.base/script/docker/setup.sh"
 
@@ -708,7 +709,7 @@ EOS
   mkdir -p "${ALT}/.base/script/docker/lib"
   cp /source/script/docker/_lib.sh "${ALT}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${ALT}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${ALT}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${ALT}/.base/script/docker/lib/"
   cp "${SANDBOX}/.base/script/docker/setup.sh" "${ALT}/.base/script/docker/setup.sh"
   chmod +x "${ALT}/.base/script/docker/setup.sh"
 

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -3,6 +3,7 @@
 bats_require_minimum_version 1.5.0
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/test_helper"
 
   # Source setup.sh functions only (main is guarded)
@@ -1395,7 +1396,7 @@ EOF
   # is an umbrella that sources lib/*.sh sub-libs post-#284.
   cp /source/script/docker/_lib.sh \
     "${TEMP_DIR}/sandbox_repo/.base/script/docker/_lib.sh"
-  cp /source/script/docker/lib/*.sh \
+  cp /source/script/docker/lib/* \
     "${TEMP_DIR}/sandbox_repo/.base/script/docker/lib/"
   cp /source/config/docker/setup.conf "${TEMP_DIR}/sandbox_repo/.base/config/docker/setup.conf"
 
@@ -1558,7 +1559,7 @@ EOF
   # setup.sh sources _lib.sh for the _log_* helpers (#290); _lib.sh
   # is an umbrella that sources lib/*.sh sub-libs post-#284.
   cp /source/script/docker/_lib.sh "${TEMP_DIR}/sandbox/.base/script/docker/_lib.sh"
-  cp /source/script/docker/lib/*.sh "${TEMP_DIR}/sandbox/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${TEMP_DIR}/sandbox/.base/script/docker/lib/"
   cp /source/config/docker/setup.conf "${TEMP_DIR}/sandbox/.base/config/docker/setup.conf"
 
   bash "${TEMP_DIR}/sandbox/.base/script/docker/setup.sh" apply \
@@ -1801,7 +1802,7 @@ EOF
   # setup.sh sources _lib.sh for the _log_* helpers (#290); _lib.sh
   # is an umbrella that sources lib/*.sh sub-libs post-#284.
   cp /source/script/docker/_lib.sh "${TEMP_DIR}/sandbox/.base/script/docker/_lib.sh"
-  cp /source/script/docker/lib/*.sh "${TEMP_DIR}/sandbox/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${TEMP_DIR}/sandbox/.base/script/docker/lib/"
   cp /source/config/docker/setup.conf "${TEMP_DIR}/sandbox/config/docker/setup.conf"
 
   run bash "${TEMP_DIR}/sandbox/.base/script/docker/setup.sh" \

--- a/test/unit/stop_sh_spec.bats
+++ b/test/unit/stop_sh_spec.bats
@@ -8,6 +8,7 @@
 bats_require_minimum_version 1.5.0
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/test_helper"
 
   # shellcheck disable=SC2154
@@ -20,7 +21,7 @@ setup() {
   cp /source/script/docker/_lib.sh  "${SANDBOX}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh  "${SANDBOX}/.base/script/docker/i18n.sh"
   # _lib.sh post-#284 is an umbrella that sources lib/*.sh sub-libs.
-  cp /source/script/docker/lib/*.sh "${SANDBOX}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${SANDBOX}/.base/script/docker/lib/"
   ln -s /source/script/docker/stop.sh "${SANDBOX}/stop.sh"
 
   # Seed .env so _load_env succeeds.
@@ -203,7 +204,7 @@ teardown() {
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=zh_TW.UTF-8 run bash "${_tmp}/stop.sh" -h
   assert_success
   assert_output --partial "用法"
@@ -217,7 +218,7 @@ teardown() {
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=zh_CN.UTF-8 run bash "${_tmp}/stop.sh" -h
   assert_success
   assert_output --partial "用法"
@@ -231,7 +232,7 @@ teardown() {
   cp /source/script/docker/_lib.sh "${_tmp}/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/i18n.sh"
   mkdir -p "${_tmp}/lib"
-  cp /source/script/docker/lib/*.sh "${_tmp}/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/lib/"
   LANG=ja_JP.UTF-8 run bash "${_tmp}/stop.sh" -h
   assert_success
   assert_output --partial "使用法"
@@ -247,7 +248,7 @@ teardown() {
   mkdir -p "${ALT}/.base/script/docker/lib"
   cp /source/script/docker/_lib.sh "${ALT}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${ALT}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${ALT}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${ALT}/.base/script/docker/lib/"
   {
     echo "USER_NAME=tester"
     echo "IMAGE_NAME=altimg"
@@ -267,7 +268,7 @@ teardown() {
   mkdir -p "${ALT}/.base/script/docker/lib"
   cp /source/script/docker/_lib.sh "${ALT}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${ALT}/.base/script/docker/i18n.sh"
-  cp /source/script/docker/lib/*.sh "${ALT}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${ALT}/.base/script/docker/lib/"
   {
     echo "USER_NAME=tester"
     echo "IMAGE_NAME=altimg2"

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
+  export LOG_FORMAT=text
   load "${BATS_TEST_DIRNAME}/test_helper"
 }
 
@@ -474,7 +475,7 @@ EOF
   cp /source/script/docker/_lib.sh "${_tmp}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/.base/script/docker/i18n.sh" 2>/dev/null || true
   # _lib.sh post-#284 is an umbrella that sources lib/*.sh sub-libs.
-  cp /source/script/docker/lib/*.sh "${_tmp}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/.base/script/docker/lib/"
   cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
 
   run bash "${_tmp}/exec.sh"
@@ -496,7 +497,7 @@ EOF
   cp /source/script/docker/_lib.sh "${_tmp}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${_tmp}/.base/script/docker/i18n.sh" 2>/dev/null || true
   # _lib.sh post-#284 is an umbrella that sources lib/*.sh sub-libs.
-  cp /source/script/docker/lib/*.sh "${_tmp}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${_tmp}/.base/script/docker/lib/"
   cp /source/script/docker/exec.sh "${_tmp}/exec.sh"
 
   run bash "${_tmp}/exec.sh" --dry-run
@@ -599,7 +600,7 @@ _stage_lint_layout() {
   cp /source/script/docker/_lib.sh   "${_dest}/_lib.sh"
   cp /source/script/docker/i18n.sh   "${_dest}/i18n.sh"
   mkdir -p "${_dest}/lib"
-  cp /source/script/docker/lib/*.sh  "${_dest}/lib/"
+  cp /source/script/docker/lib/*  "${_dest}/lib/"
 }
 
 @test "build.sh -h works in /lint/ layout (flat dir with _lib.sh + i18n.sh, issue #104)" {

--- a/test/unit/wrapper_lib_lookup_spec.bats
+++ b/test/unit/wrapper_lib_lookup_spec.bats
@@ -30,7 +30,7 @@ setup() {
   cp /source/script/docker/_lib.sh "${SANDBOX}/.base/script/docker/_lib.sh"
   cp /source/script/docker/i18n.sh "${SANDBOX}/.base/script/docker/i18n.sh"
   # _lib.sh post-#284 is an umbrella that sources lib/*.sh sub-libs.
-  cp /source/script/docker/lib/*.sh "${SANDBOX}/.base/script/docker/lib/"
+  cp /source/script/docker/lib/* "${SANDBOX}/.base/script/docker/lib/"
 
   for _w in build.sh run.sh exec.sh stop.sh; do
     ln -s "/source/script/docker/${_w}" "${SANDBOX}/${_w}"

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -32,8 +32,8 @@ source "${SCRIPT_DIR}/script/docker/_lib.sh"
 
 cd "${REPO_ROOT}"
 
-_log() { _log_info upgrade "$*"; }
-_error() { _log_err upgrade "$*"; exit 1; }
+_log() { _log_info upgrade upgrade_started "display=$*"; }
+_error() { _log_err upgrade upgrade_rollback "display=$*"; exit 1; }
 
 # ── Safety guards ────────────────────────────────────────────────────────────
 #
@@ -92,9 +92,9 @@ _verify_subtree_intact() {
   local _marker
   for _marker in "${_markers[@]}"; do
     if [[ ! -f "${_marker}" ]]; then
-      _log_err upgrade "post-pull integrity check failed — '${_marker}' missing."
-      _log_err upgrade "Likely cause: git-subtree fast-forwarded destructively."
-      _log_info upgrade "Rolling back to ${_pre_head:0:12} ..."
+      _log_err upgrade upgrade_subtree_pull_failed "display=post-pull integrity check failed -- '${_marker}' missing." "marker=${_marker}"
+      _log_err upgrade upgrade_rollback "display=Likely cause: git-subtree fast-forwarded destructively."
+      _log_info upgrade upgrade_rollback "display=Rolling back to ${_pre_head:0:12} ..." "commit=${_pre_head:0:12}"
       git reset --hard "${_pre_head}" >/dev/null 2>&1 || true
       _error "upgrade aborted; repo restored to pre-upgrade state"
     fi


### PR DESCRIPTION
## Summary

- Single-sink tty-detect dispatch: text on TTY, JSON on pipe/redirect; `LOG_FORMAT=auto|text|json` override; `LOG_JSON_FILE` dual-sink removed
- Strict body enforcement: unregistered body is fatal; all 80+ callers across 10 scripts migrated to registered event names with `display=` attribute for i18n text
- Microsecond UTC timestamps (`%6NZ`) in both text and JSON paths
- `_log_plain` removed; `config_summary.sh` uses local `_summary_print` helper
- `_log_is_registered` simplified to single `grep -Fxq` (avoids `pipefail` SIGPIPE race from the old pipe chain)
- Test sandboxes updated: `lib/*.sh` glob changed to `lib/*` to include `log-events.txt`

Breaking: `LOG_JSON_FILE` env dropped, `LOG_STRICT_BODY` env dropped (strict is default).

Closes #438

## Test plan

- [x] `_log_dispatch` tty-detect: non-TTY emits JSON, TTY emits text
- [x] `LOG_FORMAT=text` forces text on non-TTY
- [x] `LOG_FORMAT=json` forces JSON
- [x] Unregistered body causes fatal exit with body name + file hint
- [x] Registered body succeeds; empty body allowed
- [x] `display=` attribute overrides body in text output
- [x] `display=` included as JSON attribute
- [x] Timestamps match `YYYY-MM-DDTHH:MM:SS.xxxxxxZ` in both modes
- [x] `_log_plain` function no longer defined
- [x] All existing tests pass (1411 total, 0 failures)
- [x] Strict body gracefully skips when events file missing (destructive fast-forward test)
