### PR TITLE
feat(build-worker): add submodules input for checkout (closes #444)

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -159,6 +159,24 @@ on:
             ros1_bridge-humble -> ros1_bridge-humble-x86_64-cache
             ros2_distro + cache_variant=humble-desktop-full
                               -> ros2_distro-humble-desktop-full-x86_64-cache
+      submodules:
+        required: false
+        type: string
+        default: ""
+        description: |
+          Submodule checkout mode passed to `actions/checkout` in the
+          build job. Empty string (default) = submodules disabled,
+          preserving existing behavior. Set to `true` for top-level
+          submodules or `recursive` for nested submodules.
+
+          Only the `build` job checkout is affected — the `path-filter`
+          job (which only runs `git diff`) does not need submodule
+          content and keeps `submodules: false` unconditionally.
+
+          Example (repo with source as a submodule):
+            with:
+              image_name: omniverse_web_viewer
+              submodules: recursive
 
 jobs:
   # ────────────────────────────────────────────────────────────────
@@ -295,6 +313,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          submodules: ${{ inputs.submodules }}
 
       - name: Check template version
         run: |

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`build-worker.yaml` `submodules` input** — optional checkout mode (`true` / `recursive`) for repos whose Dockerfile source lives in a git submodule. Default empty string preserves existing behavior (no submodule checkout). Only the `build` job checkout is affected; `path-filter` stays `submodules: false`. Closes #444.
+
 ## [v0.37.0] - 2026-05-27
 
 ### Added


### PR DESCRIPTION
## Summary

- Add optional `submodules` input to `build-worker.yaml` checkout step
- Default empty string = no submodule checkout (zero diff for existing callers)
- Callers opt in with `submodules: recursive` (or `true` for top-level only)

## Detail

`actions/checkout@v6` defaults to `submodules: false`. Repos whose Dockerfile source lives in a git submodule (e.g. `omniverse_web_viewer` with `src/` pointing to NVIDIA's `web-viewer-sample`) get empty directories and fail:

```
COPY src/package.json src/.npmrc /app/
ERROR: "/src/package.json": not found
```

Only the `build` job checkout gets the new input — `path-filter` only runs `git diff` and does not need submodule content.

## Caller usage

```yaml
uses: ycpss91255-docker/base/.github/workflows/build-worker.yaml@<tag>
with:
  image_name: omniverse_web_viewer
  submodules: recursive
```

## Test plan

- [x] Existing callers (no `submodules` input) see no behavior change (default empty = `false`)
- [ ] `omniverse_web_viewer` CI passes after updating `main.yaml` to use this version with `submodules: recursive` (integration test after merge + tag)
