### PR TITLE
feat(run): stop flag parsing at first positional + document -- CMD separator (closes #448)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`run.sh` CMD separator `--` + positional stop** — first positional arg now stops run.sh flag parsing so CMD flags like `--target` no longer collide with run.sh's own `-t/--target`. Explicit `--` separator documented in usage (4 languages). Closes #448.
+
 ## [v0.38.0] - 2026-05-27
 
 ### Added

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -497,7 +497,7 @@ opt-out (no inspect calls + no rmi even when ids would have moved),
 if displaced>` visible + zero real rmi), and `--help` mentions the
 `--no-prune` flag.
 
-### test/unit/run_sh_spec.bats (54)
+### test/unit/run_sh_spec.bats (57)
 
 Unit tests for `run.sh`. Mirrors the build_sh_spec.bats harness;
 `docker ps` reads from a controllable stub file so tests can simulate
@@ -523,7 +523,10 @@ trace pattern as build.sh, parity across wrappers), and **#386
 foreground exit auto compose-down** (default-on for devel + one-shot
 non-devel targets, `--no-rm` opts out, `-d` suppresses the trap; the
 trap fires `down --remove-orphans` to mirror stop.sh and close the
-worktree-removed-before-stop network leak).
+worktree-removed-before-stop network leak), and **#448 `--` CMD
+separator** (`--` stops flag parsing so CMD flags like `--target`
+don't collide; positional CMD also stops parsing; usage documents
+`--`).
 
 ### test/unit/exec_sh_spec.bats (53)
 

--- a/script/docker/run.sh
+++ b/script/docker/run.sh
@@ -172,6 +172,9 @@ usage() {
 CMD: 啟動容器後要執行的指令，對齊 `docker run <image> [cmd]` 語意：
   無 CMD  → 跑 Dockerfile 的 CMD（例: devel=bash, runtime=auto-run service）
   有 CMD  → 覆蓋 Dockerfile CMD（例: ./run.sh -t runtime bash 進 runtime shell）
+  --      → 分隔 run.sh 旗標與 CMD；-- 之後的全部參數視為 CMD，不再由 run.sh 解析。
+            當 CMD 本身有 --target 等與 run.sh 衝突的旗標時必須使用。
+            例: ./run.sh -t cli -- sdkmanager --target JETSON --flash
 EOF
       ;;
     zh-CN)
@@ -209,6 +212,9 @@ EOF
 CMD: 启动容器后要执行的指令，对齐 `docker run <image> [cmd]` 语义:
   无 CMD  → 跑 Dockerfile 的 CMD（例: devel=bash, runtime=auto-run service）
   有 CMD  → 覆盖 Dockerfile CMD（例: ./run.sh -t runtime bash 进 runtime shell）
+  --      → 分隔 run.sh 旗标与 CMD；-- 之后的全部参数视为 CMD，不再由 run.sh 解析。
+            当 CMD 本身有 --target 等与 run.sh 冲突的旗标时必须使用。
+            例: ./run.sh -t cli -- sdkmanager --target JETSON --flash
 EOF
       ;;
     ja)
@@ -252,6 +258,9 @@ EOF
 CMD: コンテナ起動後に実行するコマンド。`docker run <image> [cmd]` セマンティクス:
   CMD 無し → Dockerfile の CMD を実行（例: devel=bash, runtime=auto-run service）
   CMD あり → Dockerfile CMD を上書き（例: ./run.sh -t runtime bash で runtime shell）
+  --      → run.sh フラグと CMD を分離。-- 以降の全引数は CMD として扱い、run.sh は
+            解析しません。CMD 自体に --target 等 run.sh と衝突するフラグがある場合に
+            使用。例: ./run.sh -t cli -- sdkmanager --target JETSON --flash
 EOF
       ;;
     *)
@@ -295,6 +304,10 @@ Options:
 CMD: Command to run after the container starts; mirrors `docker run <image> [cmd]`:
   no CMD  → run the Dockerfile CMD (e.g. devel=bash, runtime=auto-run service)
   with CMD → override the Dockerfile CMD (e.g. ./run.sh -t runtime bash to shell in)
+  --      → separates run.sh flags from CMD; everything after -- is passed as CMD
+            without further parsing by run.sh. Required when CMD has flags that
+            collide with run.sh (e.g. --target).
+            Example: ./run.sh -t cli -- sdkmanager --target JETSON --flash
 EOF
       ;;
   esac
@@ -443,11 +456,8 @@ main() {
         break
         ;;
       *)
-        # Positional from here on is the CMD to run inside the container,
-        # mirroring `docker run <image> [cmd...]` semantics. Empty CMD_ARGS
-        # means "use the Dockerfile CMD".
-        CMD_ARGS+=("$1")
-        shift
+        CMD_ARGS+=("$@")
+        break
         ;;
     esac
   done

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -306,6 +306,30 @@ EOS
   assert_output --partial "bash"
 }
 
+# ── #448: -- CMD separator ────────────────────────────────────────────────
+
+@test "run.sh -- separates CMD from run.sh flags (#448)" {
+  run bash "${SANDBOX}/run.sh" --dry-run -t cli -- sdkmanager --target JETSON
+  assert_success
+  assert_output --partial "sdkmanager"
+  assert_output --partial "--target"
+  assert_output --partial "JETSON"
+  refute_output --partial "service name"
+}
+
+@test "run.sh positional CMD stops flag parsing — --target in CMD is not consumed (#448)" {
+  run bash "${SANDBOX}/run.sh" --dry-run -t cli sdkmanager --target JETSON
+  assert_success
+  assert_output --partial "sdkmanager"
+  assert_output --partial "--target"
+  assert_output --partial "JETSON"
+}
+
+@test "run.sh --help mentions -- CMD separator (#448)" {
+  run bash "${SANDBOX}/run.sh" --help
+  assert_output --partial "--"
+}
+
 # ── #386: foreground exit auto compose-down ────────────────────────────────
 # trap _compose_cleanup EXIT is installed for any foreground invocation
 # (devel + one-shot stages). It fires on normal exit, Ctrl-C, and signal.


### PR DESCRIPTION
## Summary

- First positional arg now stops run.sh flag parsing -- CMD flags like `--target` no longer collide with run.sh's own `-t/--target`
- Existing `--` separator documented in usage text (zh-TW, zh-CN, ja, en)
- Fixes the `jetson_sdk_manager` use case: `make run -- -t cli -- sdkmanager --target JETSON --flash`

Closes #448

## Test plan

- [x] `--` separates CMD from run.sh flags: `--target JETSON` stays in CMD_ARGS
- [x] Positional CMD stops flag parsing: `sdkmanager --target JETSON` without `--` also works
- [x] `--help` mentions `--` CMD separator
- [x] All existing tests pass (1414 total, 0 failures)
- [x] `-d` + CMD rejection still works (exit 2)
