### PR TITLE
feat(setup): device mount propagation with auto-redirect to volumes (closes #450)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`[devices]` mount propagation support** — device entries like `device_1 = /dev:/dev:rslave` are auto-redirected from compose `devices:` to `volumes:` long-form bind mount (compose `devices:` does not support propagation). Plain devices without propagation emit to `devices:` as before. Validator (`_validate_mount`) extended to accept `rslave|rshared|rprivate|slave|shared|private` modes, combinable with `ro|rw` (e.g. `rw,rslave`). Warns when propagation is used without `[security] privileged = true` (P2, #453). Warns on duplicate target paths between `[devices]` and `[volumes]` (P4, #455). Per-stage emit supports propagation (P3, #454). Closes #450, closes #453, closes #454, closes #455.
+
 ### Changed
 - **`run.sh` CMD separator `--` + positional stop** — first positional arg now stops run.sh flag parsing so CMD flags like `--target` no longer collide with run.sh's own `-t/--target`. Explicit `--` separator documented in usage (4 languages). Closes #448.
 - **`script/docker/` reorganized into role-based subdirectories** — wrappers move to `wrapper/`, all libs consolidate into `lib/`, container-side helpers move to `runtime/`. `_entrypoint_logging.sh` renamed to `runtime/logging.sh` (container path `/usr/local/lib/base/logging.sh`). New `runtime/entrypoint.sh` template replaces init.sh heredoc. Breaking: downstream symlink paths change; `make upgrade` handles migration automatically. Closes #406.

--- a/script/docker/lib/_tui_conf.sh
+++ b/script/docker/lib/_tui_conf.sh
@@ -20,10 +20,10 @@ _DOCKER_TUI_CONF_SOURCED=1
 #
 # Valid forms:
 #   <host>:<container>
-#   <host>:<container>:ro
-#   <host>:<container>:rw
-# Both parts must be non-empty. Exactly 1 or 2 ':' separators (env-var
-# forms like ${FOO} count as host path, not separators).
+#   <host>:<container>:<mode>
+# where <mode> is one or more of: ro, rw, rslave, rshared, rprivate,
+# slave, shared, private — comma-separated (e.g. rw,rslave).
+# Both path parts must be non-empty. Exactly 1 or 2 ':' separators.
 _validate_mount() {
   local _v="${1-}"
   [[ -z "${_v}" ]] && return 1
@@ -36,7 +36,15 @@ _validate_mount() {
       ;;
     3)
       [[ -n "${_parts[0]}" && -n "${_parts[1]}" ]] || return 1
-      [[ "${_parts[2]}" == "ro" || "${_parts[2]}" == "rw" ]] || return 1
+      local _mode
+      IFS=',' read -ra _mode <<< "${_parts[2]}"
+      local _m
+      for _m in "${_mode[@]}"; do
+        case "${_m}" in
+          ro|rw|rslave|rshared|rprivate|slave|shared|private) ;;
+          *) return 1 ;;
+        esac
+      done
       ;;
     *)
       return 1

--- a/script/docker/wrapper/setup.sh
+++ b/script/docker/wrapper/setup.sh
@@ -1546,6 +1546,37 @@ _expand_env_cross_refs() {
   done <<< "${_input}"
 }
 
+_device_has_propagation() {
+  local _entry="${1}"
+  local -a _parts=()
+  IFS=':' read -ra _parts <<< "${_entry}"
+  (( ${#_parts[@]} == 3 )) || return 1
+  [[ "${_parts[2]}" =~ (rslave|rshared|rprivate|slave|shared|private) ]]
+}
+
+_emit_device_as_volume() {
+  local _entry="${1}" _indent="${2:-    }"
+  local -a _parts=()
+  IFS=':' read -ra _parts <<< "${_entry}"
+  local _src="${_parts[0]}" _tgt="${_parts[1]}" _opts="${_parts[2]}"
+  local _propagation="" _read_only=""
+  local _o
+  IFS=',' read -ra _oarr <<< "${_opts}"
+  for _o in "${_oarr[@]}"; do
+    case "${_o}" in
+      ro) _read_only="true" ;;
+      rw) _read_only="false" ;;
+      rslave|rshared|rprivate|slave|shared|private) _propagation="${_o}" ;;
+    esac
+  done
+  echo "${_indent}  - type: bind"
+  echo "${_indent}    source: ${_src}"
+  echo "${_indent}    target: ${_tgt}"
+  [[ -n "${_read_only}" ]] && echo "${_indent}    read_only: ${_read_only}"
+  echo "${_indent}    bind:"
+  echo "${_indent}      propagation: ${_propagation}"
+}
+
 generate_compose_yaml() {
   local _out="${1:?}"
   local _name="${2:?}"
@@ -1982,7 +2013,15 @@ YAML
     # the [logging] local_path bind mount when the per-service
     # resolution yields a non-empty host path -- _devel_llp was resolved
     # earlier (above the env block) so it could share with LOG_FILE_PATH.
-    if [[ "${_gui}" == "true" ]] || (( ${#_gcy_extras[@]} > 0 )) || [[ -n "${_devel_llp}" ]]; then
+    local _any_prop_device=false
+    if [[ -n "${_devices_str}" ]]; then
+      local _chk
+      while IFS= read -r _chk; do
+        [[ -z "${_chk}" ]] && continue
+        if _device_has_propagation "${_chk}"; then _any_prop_device=true; break; fi
+      done <<< "${_devices_str}"
+    fi
+    if [[ "${_gui}" == "true" ]] || (( ${#_gcy_extras[@]} > 0 )) || [[ -n "${_devel_llp}" ]] || [[ "${_any_prop_device}" == true ]]; then
       echo "    volumes:"
       if [[ "${_gui}" == "true" ]]; then
         cat <<'YAML'
@@ -1996,13 +2035,25 @@ YAML
         echo "      - ${_m}"
       done
       [[ -n "${_devel_llp}" ]] && echo "      - ${_devel_llp}"
+      # #450: device entries with propagation redirect to volumes: long-form
+      if [[ -n "${_devices_str}" ]]; then
+        local _d
+        while IFS= read -r _d; do
+          [[ -z "${_d}" ]] && continue
+          _device_has_propagation "${_d}" && _emit_device_as_volume "${_d}" "    "
+        done <<< "${_devices_str}"
+      fi
     fi
-    # devices: + device_cgroup_rules: from [devices] section
+    # devices: from [devices] section (plain entries only, no propagation)
     if [[ -n "${_devices_str}" ]]; then
-      echo "    devices:"
-      local _d
+      local _has_plain=false _d
       while IFS= read -r _d; do
         [[ -z "${_d}" ]] && continue
+        _device_has_propagation "${_d}" && continue
+        if [[ "${_has_plain}" != true ]]; then
+          echo "    devices:"
+          _has_plain=true
+        fi
         echo "      - ${_d}"
       done <<< "${_devices_str}"
     fi
@@ -2332,7 +2383,7 @@ YAML
       # volumes: GUI baseline (effective gui) + effective volume list
       # + #328 [logging] local_path per-stage bind mount. _stage_llp
       # was resolved above the env block; reuse it here.
-      if [[ "${_eff_gui}" == "true" ]] || [[ -n "${_eff_volumes}" ]] || [[ -n "${_stage_llp}" ]]; then
+      if [[ "${_eff_gui}" == "true" ]] || [[ -n "${_eff_volumes}" ]] || [[ -n "${_stage_llp}" ]] || [[ "${_any_prop_device}" == true ]]; then
         echo "    volumes:"
         if [[ "${_eff_gui}" == "true" ]]; then
           cat <<'YAML'
@@ -2349,13 +2400,25 @@ YAML
           done <<< "${_eff_volumes}"
         fi
         [[ -n "${_stage_llp}" ]] && echo "      - ${_stage_llp}"
+        # #450: device entries with propagation redirect to volumes: long-form
+        if [[ -n "${_devices_str}" ]]; then
+          local _sd
+          while IFS= read -r _sd; do
+            [[ -z "${_sd}" ]] && continue
+            _device_has_propagation "${_sd}" && _emit_device_as_volume "${_sd}" "    "
+          done <<< "${_devices_str}"
+        fi
       fi
-      # devices: + cgroup_rules: from top-level (not yet per-stage).
+      # devices: from top-level (plain entries only, no propagation).
       if [[ -n "${_devices_str}" ]]; then
-        echo "    devices:"
-        local _sd
+        local _has_plain_sd=false _sd
         while IFS= read -r _sd; do
           [[ -z "${_sd}" ]] && continue
+          _device_has_propagation "${_sd}" && continue
+          if [[ "${_has_plain_sd}" != true ]]; then
+            echo "    devices:"
+            _has_plain_sd=true
+          fi
           echo "      - ${_sd}"
         done <<< "${_devices_str}"
       fi
@@ -3953,6 +4016,48 @@ _setup_apply() {
   local _cgroup_rule_str=""
   if (( ${#_cgroup_rule_arr[@]} > 0 )); then
     _cgroup_rule_str="$(printf '%s\n' "${_cgroup_rule_arr[@]}")"
+  fi
+
+  # ── #450 P2: propagation + privileged guard ──
+  if [[ -n "${_devices_str}" ]]; then
+    local _has_prop=false _d_check
+    while IFS= read -r _d_check; do
+      [[ -z "${_d_check}" ]] && continue
+      if _device_has_propagation "${_d_check}"; then
+        _has_prop=true
+        break
+      fi
+    done <<< "${_devices_str}"
+    if [[ "${_has_prop}" == true ]]; then
+      local _priv_val=""
+      _get_conf_value _sec_k _sec_v "privileged" "" _priv_val
+      if [[ "${_priv_val}" != "true" ]]; then
+        _log_warn setup conf_invalid_value \
+          "display=device entry uses mount propagation but [security] privileged is not true. Device I/O may be blocked by cgroup."
+      fi
+    fi
+  fi
+
+  # ── #450 P4: duplicate device/volume target path detection ──
+  if [[ -n "${_devices_str}" ]]; then
+    local _d_dup
+    while IFS= read -r _d_dup; do
+      [[ -z "${_d_dup}" ]] && continue
+      _device_has_propagation "${_d_dup}" || continue
+      local -a _dup_parts=()
+      IFS=':' read -ra _dup_parts <<< "${_d_dup}"
+      local _dup_target="${_dup_parts[1]}"
+      local _ev
+      for _ev in "${extra_volumes[@]}"; do
+        local -a _ev_parts=()
+        IFS=':' read -ra _ev_parts <<< "${_ev}"
+        if [[ "${_ev_parts[1]}" == "${_dup_target}" ]]; then
+          _log_warn setup conf_invalid_value \
+            "display=duplicate target path '${_dup_target}': appears in both [devices] (with propagation) and [volumes]. The [devices] entry with propagation takes precedence."
+          break
+        fi
+      done
+    done <<< "${_devices_str}"
   fi
 
   # ── Collect [environment] env_*, [tmpfs] tmpfs_*, [network] port_* ──

--- a/test/unit/compose_gen_spec.bats
+++ b/test/unit/compose_gen_spec.bats
@@ -116,6 +116,64 @@ teardown() {
   assert_success
 }
 
+# ── #450 device propagation → volumes long-form ──────────────────────
+
+@test "generate_compose_yaml: device with propagation emits to volumes long-form (#450 P1)" {
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "/dev:/dev:rslave"
+  run grep -F 'propagation: rslave' "${COMPOSE_OUT}"
+  assert_success
+  run grep -F 'source: /dev' "${COMPOSE_OUT}"
+  assert_success
+  run grep -F 'target: /dev' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "generate_compose_yaml: device without propagation stays in devices: (#450 P1)" {
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "/dev/video0:/dev/video0"
+  run grep -E '^    devices:$' "${COMPOSE_OUT}"
+  assert_success
+  run grep -F -- '- /dev/video0:/dev/video0' "${COMPOSE_OUT}"
+  assert_success
+  run grep -F 'propagation:' "${COMPOSE_OUT}"
+  assert_failure
+}
+
+@test "generate_compose_yaml: mixed devices split correctly (#450 P1)" {
+  local _extras=()
+  local _devices
+  printf -v _devices '%s\n%s' "/dev/video0:/dev/video0" "/dev:/dev:rslave"
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "${_devices}"
+  run grep -F -- '- /dev/video0:/dev/video0' "${COMPOSE_OUT}"
+  assert_success
+  run grep -F 'propagation: rslave' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "generate_compose_yaml: device rw,rslave emits combined propagation (#450 P1)" {
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "/dev:/dev:rw,rslave"
+  run grep -F 'propagation: rslave' "${COMPOSE_OUT}"
+  assert_success
+  run grep -F 'read_only: false' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "generate_compose_yaml: device ro,rshared emits read_only + propagation (#450 P1)" {
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "/data:/data:ro,rshared"
+  run grep -F 'propagation: rshared' "${COMPOSE_OUT}"
+  assert_success
+  run grep -F 'read_only: true' "${COMPOSE_OUT}"
+  assert_success
+}
+
 @test "generate_compose_yaml emits environment block from env_ list" {
   local _extras=()
   local _env
@@ -720,4 +778,23 @@ DOCK
   # "runtime-base" doesn't count as the runtime stage (strict match).
   run grep -cE '^  runtime:' "${COMPOSE_OUT}"
   assert_output "0"
+}
+
+# ── #450 P3: per-stage device propagation redirect ───────────────
+
+@test "generate_compose_yaml: runtime stage inherits device propagation from devel (#450 P3)" {
+  cat > "${TEMP_DIR}/Dockerfile" <<'DOCK'
+FROM ubuntu:24.04 AS devel
+CMD ["bash"]
+
+FROM devel AS runtime
+CMD ["/app"]
+DOCK
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "/dev:/dev:rslave"
+  run grep -c 'propagation: rslave' "${COMPOSE_OUT}"
+  [[ "${output}" -ge 1 ]]
+  run grep -E '^  runtime:' "${COMPOSE_OUT}"
+  assert_success
 }

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -4328,3 +4328,60 @@ EOC
   # CLI --gui force wins
   assert_output --partial "GUI_MODE=force"
 }
+
+# ════════════════════════════════════════════════════════════════════
+# #450 P2: propagation + non-privileged guard
+# ════════════════════════════════════════════════════════════════════
+
+@test "apply warns when device propagation used without privileged (#450 P2)" {
+  mkdir -p "${TEMP_DIR}/config/docker"
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'EOC'
+[security]
+privileged = false
+[devices]
+device_1 = /dev:/dev:rslave
+EOC
+  run bash -c "
+    source /source/script/docker/wrapper/setup.sh
+    main apply --base-path '${TEMP_DIR}' --print-resolved 2>&1
+  "
+  assert_success
+  assert_output --partial "propagation"
+  assert_output --partial "privileged"
+}
+
+@test "apply suppresses propagation warning when privileged is true (#450 P2)" {
+  mkdir -p "${TEMP_DIR}/config/docker"
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'EOC'
+[security]
+privileged = true
+[devices]
+device_1 = /dev:/dev:rslave
+EOC
+  run bash -c "
+    source /source/script/docker/wrapper/setup.sh
+    main apply --base-path '${TEMP_DIR}' --print-resolved 2>&1
+  "
+  assert_success
+  refute_output --partial "propagation"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# #450 P4: duplicate device/volume target path detection
+# ════════════════════════════════════════════════════════════════════
+
+@test "apply warns when device and volume have same target path (#450 P4)" {
+  mkdir -p "${TEMP_DIR}/config/docker"
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'EOC'
+[devices]
+device_1 = /dev:/dev:rslave
+[volumes]
+mount_5 = /dev:/dev
+EOC
+  run bash -c "
+    source /source/script/docker/wrapper/setup.sh
+    main apply --base-path '${TEMP_DIR}' --print-resolved 2>&1
+  "
+  assert_success
+  assert_output --partial "duplicate"
+}

--- a/test/unit/tui_spec.bats
+++ b/test/unit/tui_spec.bats
@@ -64,6 +64,44 @@ teardown() {
   [ "${status}" -ne 0 ]
 }
 
+# ── #450 mount propagation modes ──────────────────────────────────
+
+@test "_validate_mount accepts propagation mode rslave (#450)" {
+  _validate_mount "/dev:/dev:rslave"
+}
+
+@test "_validate_mount accepts propagation mode rshared (#450)" {
+  _validate_mount "/mnt:/mnt:rshared"
+}
+
+@test "_validate_mount accepts propagation mode rprivate (#450)" {
+  _validate_mount "/data:/data:rprivate"
+}
+
+@test "_validate_mount accepts combined rw,rslave (#450)" {
+  _validate_mount "/dev:/dev:rw,rslave"
+}
+
+@test "_validate_mount accepts combined ro,rshared (#450)" {
+  _validate_mount "/data:/data:ro,rshared"
+}
+
+@test "_validate_mount accepts non-recursive variants (#450)" {
+  _validate_mount "/dev:/dev:slave"
+  _validate_mount "/dev:/dev:shared"
+  _validate_mount "/dev:/dev:private"
+}
+
+@test "_validate_mount rejects invalid propagation mode (#450)" {
+  run _validate_mount "/dev:/dev:bogus"
+  [ "${status}" -ne 0 ]
+}
+
+@test "_validate_mount rejects rw,bogus combo (#450)" {
+  run _validate_mount "/dev:/dev:rw,bogus"
+  [ "${status}" -ne 0 ]
+}
+
 # ════════════════════════════════════════════════════════════════════
 # _validate_shm_size
 # ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- `[devices]` entries with mount propagation modes (`rslave`, `rshared`, etc.) auto-redirect from compose `devices:` to `volumes:` long-form bind mount -- compose `devices:` does not support propagation
- Plain device entries without propagation emit to `devices:` unchanged (no breaking change)
- `_validate_mount` extended to accept propagation modes, combinable with `ro|rw` (e.g. `rw,rslave`)
- Warns when propagation used without `[security] privileged = true` (P2, #453)
- Warns on duplicate target paths between redirected `[devices]` and `[volumes]` (P4, #455)
- Per-stage emit supports propagation split (P3, #454)

Closes #450, closes #453, closes #454, closes #455

## Test plan

- [x] `_validate_mount` accepts rslave, rshared, rprivate, slave, shared, private
- [x] `_validate_mount` accepts combined `rw,rslave` and `ro,rshared`
- [x] `_validate_mount` rejects invalid modes (`bogus`, `rw,bogus`)
- [x] Device with propagation emits to compose volumes: long-form (source/target/bind/propagation)
- [x] Device without propagation stays in compose devices: (unchanged)
- [x] Mixed devices split correctly (plain → devices:, propagation → volumes:)
- [x] Combined `rw,rslave` emits `read_only: false` + `propagation: rslave`
- [x] Combined `ro,rshared` emits `read_only: true` + `propagation: rshared`
- [x] Runtime stage inherits device propagation from devel
- [x] Warns when propagation + non-privileged
- [x] Suppresses warning when privileged = true
- [x] Warns on duplicate device/volume target path
- [x] All existing tests pass (0 failures)
