### PR TITLE
test(setup): fill coverage gaps for device propagation (refs #450)

### DIFF
--- a/test/unit/compose_gen_spec.bats
+++ b/test/unit/compose_gen_spec.bats
@@ -174,6 +174,22 @@ teardown() {
   assert_success
 }
 
+@test "generate_compose_yaml: propagation-only device creates volumes: header even without extras (#450)" {
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "/dev:/dev:rslave"
+  run grep -E '^    volumes:$' "${COMPOSE_OUT}"
+  assert_success
+}
+
+@test "generate_compose_yaml: all devices have propagation → no devices: section (#450)" {
+  local _extras=()
+  generate_compose_yaml "${COMPOSE_OUT}" "myrepo" \
+    "false" "false" "0" "gpu" _extras "" "/dev:/dev:rslave"
+  run grep -E '^    devices:$' "${COMPOSE_OUT}"
+  assert_failure
+}
+
 @test "generate_compose_yaml emits environment block from env_ list" {
   local _extras=()
   local _env

--- a/test/unit/setup_spec.bats
+++ b/test/unit/setup_spec.bats
@@ -4385,3 +4385,19 @@ EOC
   assert_success
   assert_output --partial "duplicate"
 }
+
+@test "apply does NOT warn duplicate when device and volume targets differ (#450 P4)" {
+  mkdir -p "${TEMP_DIR}/config/docker"
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'EOC'
+[devices]
+device_1 = /dev:/dev:rslave
+[volumes]
+mount_5 = /data:/data
+EOC
+  run bash -c "
+    source /source/script/docker/wrapper/setup.sh
+    main apply --base-path '${TEMP_DIR}' --print-resolved 2>&1
+  "
+  assert_success
+  refute_output --partial "duplicate"
+}

--- a/test/unit/tui_spec.bats
+++ b/test/unit/tui_spec.bats
@@ -92,6 +92,10 @@ teardown() {
   _validate_mount "/dev:/dev:private"
 }
 
+@test "_validate_mount accepts combined rw,slave non-recursive (#450)" {
+  _validate_mount "/dev:/dev:rw,slave"
+}
+
 @test "_validate_mount rejects invalid propagation mode (#450)" {
   run _validate_mount "/dev:/dev:bogus"
   [ "${status}" -ne 0 ]


### PR DESCRIPTION
## Summary

- Fill 4 coverage gaps identified in #450 device propagation tests
- Validator: `rw,slave` non-recursive combo
- Emit: propagation-only device creates `volumes:` header even without extras
- Emit: all-propagation devices produce no `devices:` section
- P4: no-duplicate negative case (different targets produce no warning)

refs #450

## Test plan

- [x] All 4 new tests pass
- [x] All existing tests pass (0 failures)
