### PR TITLE
fix(run): non-devel stages use compose up to preserve container_name (closes #458)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`run.sh` non-devel stages now use `compose up`** — previously used `compose run --rm` which generated random hash container names (e.g. `user-repo-runtime-run-63e8313ab536`), bypassing the `container_name:` directive emitted by `setup.sh` (#215, #322, #335). Empty CMD → foreground `compose up`; CMD passed → `compose up -d` + `compose exec`. Container names now consistent across all stages. Closes #458.
+
 ## [v0.39.0] - 2026-05-28
 
 ### Added

--- a/script/docker/wrapper/run.sh
+++ b/script/docker/wrapper/run.sh
@@ -639,14 +639,15 @@ ${_parallel}"
       _compose_project exec "${TARGET}" bash
     fi
   else
-    # Other one-shot stages (runtime, test, ...): `compose run --rm` with
-    # CMD passthrough. Empty CMD_ARGS → service's Dockerfile CMD runs
-    # (e.g. runtime auto-boots parameter_bridge). Non-empty overrides
-    # (e.g. `./run.sh -t runtime bash` to debug interactively).
+    # Other one-shot stages (runtime, test, ...): unified to `compose up`
+    # so the container_name: directive (#215, #322, #335) takes effect.
+    # Empty CMD_ARGS → foreground `up`, Dockerfile CMD runs. Non-empty
+    # CMD_ARGS → `up -d` + `exec` for interactive override. Closes #458.
     if (( ${#CMD_ARGS[@]} > 0 )); then
-      _compose_project run --rm "${TARGET}" "${CMD_ARGS[@]}"
+      _compose_project up -d "${TARGET}"
+      _compose_project exec "${TARGET}" "${CMD_ARGS[@]}"
     else
-      _compose_project run --rm "${TARGET}"
+      _compose_project up "${TARGET}"
     fi
   fi
 }

--- a/test/unit/run_sh_spec.bats
+++ b/test/unit/run_sh_spec.bats
@@ -281,12 +281,27 @@ EOS
   assert_output --partial "exec"
 }
 
-@test "run.sh non-devel target routes to 'compose run --rm'" {
-  # -t is now the explicit target flag; positional would be treated as CMD.
+@test "run.sh non-devel target without CMD uses 'compose up' foreground (#458)" {
+  # #458: non-devel stages used to use 'compose run --rm' which bypassed
+  # container_name. Now unified to 'compose up' so container_name from
+  # #322 / #335 takes effect.
   run bash "${SANDBOX}/run.sh" --dry-run -t test
   assert_success
-  assert_output --partial "run"
-  assert_output --partial "--rm"
+  refute_output --partial "run --rm test"
+  refute_output --partial "run --rm 'test'"
+  # foreground compose up for the target (no -d, no run --rm)
+  assert_output --partial "compose"
+  assert_output --partial "up test"
+}
+
+@test "run.sh non-devel target WITH CMD uses 'up -d' + 'exec' (#458)" {
+  # #458: when CMD passed, use up -d + exec so container_name is preserved
+  # AND the user's CMD overrides Dockerfile CMD.
+  run bash "${SANDBOX}/run.sh" --dry-run -t test bash
+  assert_success
+  refute_output --partial "run --rm"
+  assert_output --partial "up -d test"
+  assert_output --partial "exec test bash"
 }
 
 @test "run.sh positional args after options become CMD passthrough (devel)" {
@@ -298,13 +313,14 @@ EOS
   assert_output --partial "ls /tmp"
 }
 
-@test "run.sh -t runtime with CMD overrides Dockerfile runtime CMD" {
+@test "run.sh -t runtime with CMD overrides Dockerfile runtime CMD (#458 up -d + exec)" {
+  # #458: non-devel + CMD now uses `up -d` + `exec` instead of `run --rm`
+  # so container_name is preserved.
   run bash "${SANDBOX}/run.sh" --dry-run -t runtime bash
   assert_success
-  assert_output --partial "run"
-  assert_output --partial "--rm"
-  assert_output --partial "runtime"
-  assert_output --partial "bash"
+  refute_output --partial "run --rm"
+  assert_output --partial "up -d runtime"
+  assert_output --partial "exec runtime bash"
 }
 
 # ── #448: -- CMD separator ────────────────────────────────────────────────

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -319,9 +319,12 @@ setup() {
   assert_success
 }
 
-@test "run.sh non-devel TARGET still uses compose run --rm" {
-  # test/runtime/etc one-shots stay on compose run --rm (no exec needed)
-  run grep -E 'run --rm' /source/script/docker/wrapper/run.sh
+@test "run.sh non-devel TARGET uses compose up (#458)" {
+  # #458: non-devel stages unified to `compose up` so container_name takes
+  # effect. Previously `run --rm` bypassed it with random hash names.
+  run grep -E 'compose run --rm' /source/script/docker/wrapper/run.sh
+  assert_failure
+  run grep -E 'up "?\$\{TARGET\}"?' /source/script/docker/wrapper/run.sh
   assert_success
 }
 


### PR DESCRIPTION
## Summary

- Non-devel stages (runtime, test, gui, headless, etc.) switched from `compose run --rm` to `compose up` so the `container_name:` directive (#215, #322, #335) takes effect
- Empty CMD → foreground `compose up <target>` (Dockerfile CMD runs, Ctrl-C → auto-down trap from #386 cleans up)
- CMD passed → `compose up -d <target>` + `compose exec <target> <CMD>` (interactive debug pattern)
- Existing tests updated to assert new behavior

Closes #458

## Test plan

- [x] TDD vertical slicing: cycle 1 (no-CMD path) → cycle 2 (with-CMD path)
- [x] `run.sh --dry-run -t test` uses compose up (no run --rm)
- [x] `run.sh --dry-run -t runtime bash` uses up -d + exec
- [x] Existing test 508 / 1020 updated for new behavior
- [x] All CI tests pass (0 failures)
