### PR TITLE
feat(runtime): ldd-based smoke check catches missing .so deps (closes #430)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **TUI mount mode picker for `[devices]`/`[volumes]`** — new `_prompt_mount_with_picker` walks the user through host path, container path, access mode (`ro`/`rw`/none), and propagation mode (`rslave`/`rshared`/`rprivate`/`slave`/`shared`/`private`/none) via separate radiolist prompts. Pure `_assemble_mount_value` helper builds the final `host:container[:mode]` string. Lets users discover propagation modes from #450 without reading docs. Closes #461.
+- **`runtime/smoke.sh` ldd-based missing-dep check** — new helper script scans `.so` files under given roots (default `/usr/local/lib` + `/opt/ros/*/lib`) and fails if any has a "not found" dependency. Default `RUNTIME_SMOKE_CMD` in `Dockerfile.example` now invokes it, catching missing shared-library installs that the old `whoami && bash --version` default silently passed (e.g. `libboost_regex.so` absent in ros1_bridge#123). Downstream repos that uncomment the runtime-test stage get the stronger check automatically. Closes #430.
 
 ### Fixed
 - **`run.sh` non-devel stages now use `compose up`** — previously used `compose run --rm` which generated random hash container names (e.g. `user-repo-runtime-run-63e8313ab536`), bypassing the `container_name:` directive emitted by `setup.sh` (#215, #322, #335). Empty CMD → foreground `compose up`; CMD passed → `compose up -d` + `compose exec`. Container names now consistent across all stages. Closes #458.

--- a/dockerfile/Dockerfile.example
+++ b/dockerfile/Dockerfile.example
@@ -406,7 +406,12 @@ RUN bats /smoke_test/
 #
 # FROM runtime AS runtime-test
 #
-# ARG RUNTIME_SMOKE_CMD='whoami && bash --version'
+# # #430: default smoke check now includes an ldd-based missing-dep scan
+# # via runtime/smoke.sh (catches missing .so installs that the old
+# # 'whoami && bash --version' default silently passed -- e.g.
+# # libboost_regex.so absent in ros1_bridge#123).
+# COPY .base/script/docker/runtime/smoke.sh /usr/local/lib/base/smoke.sh
+# ARG RUNTIME_SMOKE_CMD='whoami && bash --version && bash /usr/local/lib/base/smoke.sh'
 # # Inherit USER from runtime (non-root). install-check doesn't need
 # # privilege; if downstream override needs root, prefix with sudo.
 # RUN bash -c "${RUNTIME_SMOKE_CMD}"

--- a/script/docker/runtime/smoke.sh
+++ b/script/docker/runtime/smoke.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# smoke.sh -- runtime image install-check (#430).
+#
+# Scans a directory for .so files and runs `ldd` on each. Fails if any
+# library has a "not found" dependency, which catches missing runtime
+# shared-library installs that the old bash-only smoke check missed
+# (ros1_bridge#123: libboost_regex.so absent, runtime-test still passed).
+#
+# Usage: smoke.sh [SCAN_ROOT...]
+#   SCAN_ROOT  Directory to scan recursively for .so files. Defaults to
+#              /usr/local/lib and /opt/ros/*/lib when no args given.
+#
+# Exit: 0 = all libs link cleanly. 1 = at least one MISSING dep found.
+
+set -uo pipefail
+
+main() {
+  local -a _roots=()
+  if (( $# > 0 )); then
+    _roots=("$@")
+  else
+    _roots=(/usr/local/lib /opt/ros/*/lib)
+  fi
+
+  local _exit=0 _root _so _ldd_out
+  for _root in "${_roots[@]}"; do
+    [[ -d "${_root}" ]] || continue
+    while IFS= read -r -d '' _so; do
+      _ldd_out="$(ldd "${_so}" 2>&1)" || continue
+      if grep -q 'not found' <<< "${_ldd_out}"; then
+        printf 'MISSING DEP: %s\n' "${_so}" >&2
+        grep 'not found' <<< "${_ldd_out}" >&2
+        _exit=1
+      fi
+    done < <(find "${_root}" -name '*.so*' -type f -print0 2>/dev/null)
+  done
+  return "${_exit}"
+}
+
+main "$@"

--- a/test/unit/runtime_smoke_spec.bats
+++ b/test/unit/runtime_smoke_spec.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+#
+# Unit tests for script/docker/runtime/smoke.sh -- the runtime-test
+# smoke check that catches missing shared library dependencies (#430).
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  SMOKE_SH="/source/script/docker/runtime/smoke.sh"
+  SCAN_ROOT="$(mktemp -d)"
+  export SCAN_ROOT
+}
+
+teardown() {
+  rm -rf "${SCAN_ROOT}"
+}
+
+# ── #430: ldd-based missing-dep detection ──────────────────────────
+
+@test "smoke.sh exits non-zero when a .so has 'not found' dep (#430)" {
+  # Create a fake .so file and a stub `ldd` that reports a missing dep.
+  mkdir -p "${SCAN_ROOT}/lib"
+  : > "${SCAN_ROOT}/lib/libbroken.so"
+  local _stub_dir
+  _stub_dir="$(mktemp -d)"
+  cat > "${_stub_dir}/ldd" <<'EOS'
+#!/usr/bin/env bash
+# Simulate a missing shared lib for any input.
+echo "    libmissing.so.1 => not found"
+EOS
+  chmod +x "${_stub_dir}/ldd"
+  PATH="${_stub_dir}:${PATH}" run bash "${SMOKE_SH}" "${SCAN_ROOT}"
+  rm -rf "${_stub_dir}"
+  assert_failure
+  assert_output --partial "MISSING"
+}
+
+@test "smoke.sh exits 0 when scan root has no .so files (#430)" {
+  # Empty directory — nothing to check, no failure.
+  run bash "${SMOKE_SH}" "${SCAN_ROOT}"
+  assert_success
+}
+
+@test "smoke.sh exits 0 when scan root does not exist (#430)" {
+  # Missing dir — non-fatal, just skipped (default has multiple roots).
+  run bash "${SMOKE_SH}" "${SCAN_ROOT}/nonexistent"
+  assert_success
+}
+
+@test "Dockerfile.example runtime-test default RUNTIME_SMOKE_CMD calls smoke.sh (#430)" {
+  # Default should invoke the helper script, not just the old
+  # 'whoami && bash --version' that missed libboost_regex (ros1_bridge#123).
+  run grep -E '^# ARG RUNTIME_SMOKE_CMD=.*smoke\.sh' /source/dockerfile/Dockerfile.example
+  assert_success
+}
+
+@test "Dockerfile.example commented runtime-test COPY brings smoke.sh into image (#430)" {
+  run grep -F 'COPY' /source/dockerfile/Dockerfile.example
+  # Find the runtime/smoke.sh COPY (commented in template; downstream uncomments)
+  run grep -F '.base/script/docker/runtime/smoke.sh' /source/dockerfile/Dockerfile.example
+  assert_success
+}
+
+@test "smoke.sh exits 0 when all .so files link cleanly (#430)" {
+  mkdir -p "${SCAN_ROOT}/lib"
+  : > "${SCAN_ROOT}/lib/libgood.so"
+  local _stub_dir
+  _stub_dir="$(mktemp -d)"
+  cat > "${_stub_dir}/ldd" <<'EOS'
+#!/usr/bin/env bash
+echo "    libfoo.so => /usr/lib/libfoo.so (0x00007fff)"
+EOS
+  chmod +x "${_stub_dir}/ldd"
+  PATH="${_stub_dir}:${PATH}" run bash "${SMOKE_SH}" "${SCAN_ROOT}"
+  rm -rf "${_stub_dir}"
+  assert_success
+}


### PR DESCRIPTION
## Summary

- New `script/docker/runtime/smoke.sh` scans `.so` files under common library install roots (`/usr/local/lib`, `/opt/ros/*/lib` by default) and runs `ldd` on each; fails if any has a "not found" dependency
- `Dockerfile.example` runtime-test stage default `RUNTIME_SMOKE_CMD` now invokes it
- Downstream repos that uncomment the runtime-test stage get the stronger check automatically -- no per-repo `RUNTIME_SMOKE_CMD` override needed

Catches the class of bug from ros1_bridge#123 where `libboost_regex.so` was absent from the runtime apt install list. The old `whoami && bash --version` default passed CI; the user hit exit 127 at runtime.

Closes #430

## Test plan (TDD)

- [x] Cycle 1: smoke.sh fails when a .so has "not found" dep (RED → GREEN)
- [x] Cycle 2: smoke.sh exits 0 when all .so files link cleanly
- [x] Cycle 3: smoke.sh exits 0 when scan root has no .so files / doesn't exist
- [x] Cycle 4: Dockerfile.example default RUNTIME_SMOKE_CMD invokes smoke.sh + COPYs the script into the image
- [x] All CI tests pass (0 failures)
