### PR TITLE
refactor(lib): extract [logging] parsers to lib/conf_logging.sh (refs #402)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TUI mount mode picker for `[devices]`/`[volumes]`** — new `_prompt_mount_with_picker` walks the user through host path, container path, access mode (`ro`/`rw`/none), and propagation mode (`rslave`/`rshared`/`rprivate`/`slave`/`shared`/`private`/none) via separate radiolist prompts. Pure `_assemble_mount_value` helper builds the final `host:container[:mode]` string. Lets users discover propagation modes from #450 without reading docs. Closes #461.
 - **`runtime/smoke.sh` ldd-based missing-dep check** — new helper script scans `.so` files under given roots (default `/usr/local/lib` + `/opt/ros/*/lib`) and fails if any has a "not found" dependency. Default `RUNTIME_SMOKE_CMD` in `Dockerfile.example` now invokes it, catching missing shared-library installs that the old `whoami && bash --version` default silently passed (e.g. `libboost_regex.so` absent in ros1_bridge#123). Downstream repos that uncomment the runtime-test stage get the stronger check automatically. Closes #430.
 
+### Changed
+- **`[logging]` parsers extracted to `lib/conf_logging.sh`** — `_parse_logging_svc_sections` and `_collect_logging` moved out of `script/docker/wrapper/setup.sh` into a new shared lib, wired via `lib/_lib.sh`. Internal refactor only; no behaviour change. Sets up PR-B (#402) where `lib/gitignore.sh` will reuse the same parsers to take over the `[logging] local_path` gitignore sync from `setup.sh apply`. Refs #402.
+
 ### Fixed
 - **`run.sh` non-devel stages now use `compose up`** — previously used `compose run --rm` which generated random hash container names (e.g. `user-repo-runtime-run-63e8313ab536`), bypassing the `container_name:` directive emitted by `setup.sh` (#215, #322, #335). Empty CMD → foreground `compose up`; CMD passed → `compose up -d` + `compose exec`. Container names now consistent across all stages. Closes #458.
 

--- a/script/docker/lib/_lib.sh
+++ b/script/docker/lib/_lib.sh
@@ -26,6 +26,8 @@ source "${_lib_dir}/env.sh"
 # shellcheck disable=SC1091
 source "${_lib_dir}/conf.sh"
 # shellcheck disable=SC1091
+source "${_lib_dir}/conf_logging.sh"
+# shellcheck disable=SC1091
 source "${_lib_dir}/compose.sh"
 # shellcheck disable=SC1091
 source "${_lib_dir}/config_summary.sh"

--- a/script/docker/lib/conf_logging.sh
+++ b/script/docker/lib/conf_logging.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# conf_logging.sh -- shared parsers for the [logging] / [logging.<svc>]
+# sections of setup.conf.
+#
+# Extracted from script/docker/wrapper/setup.sh during the #402
+# lifecycle refactor (PR-A). Both setup.sh's compose generator and
+# lib/gitignore.sh's logging-block sync (added in PR-B) read the same
+# values, so the parser belongs in a shared lib rather than ping-pong
+# sourcing setup.sh from gitignore.sh.
+#
+# Surface:
+#   _parse_logging_svc_sections <file> <out_array>
+#     Emit each "<svc>" found in a `[logging.<svc>]` header in <file>,
+#     in file order.
+#
+#   _collect_logging <base_path> <global_out> <per_svc_out>
+#     Resolve effective [logging] (section-replace fallback to template)
+#     and per-service [logging.<svc>] (per-repo only) into two
+#     newline-joined strings.
+
+# Guard against double-sourcing -- setup.sh sources us, and so does
+# lib/gitignore.sh in PR-B; the apply pipeline pulls both in.
+if [[ -n "${_DOCKER_LIB_CONF_LOGGING_SOURCED:-}" ]]; then
+  return 0
+fi
+_DOCKER_LIB_CONF_LOGGING_SOURCED=1
+
+# _parse_logging_svc_sections depends on the caller having sourced
+# _parse_ini_section (lives in setup.sh today; will move to a shared
+# lib later if more parsers need it). Same with _SETUP_SCRIPT_DIR for
+# the template fallback in _collect_logging.
+
+# _parse_logging_svc_sections <file> <out_array>
+#
+# Emit each service name that has a `[logging.<svc>]` section in <file>
+# (in the order they appear). Mirrors `_parse_stage_sections` but for
+# the per-service logging override namespace (#310).
+_parse_logging_svc_sections() {
+  local _file="${1:?"${FUNCNAME[0]}: missing file"}"
+  local -n _plss_out="${2:?"${FUNCNAME[0]}: missing out array"}"
+  _plss_out=()
+  [[ -f "${_file}" ]] || return 0
+  local _line
+  while IFS= read -r _line || [[ -n "${_line}" ]]; do
+    if [[ "${_line}" =~ ^\[logging\.([a-z][a-z0-9_-]*)\][[:space:]]*$ ]]; then
+      _plss_out+=("${BASH_REMATCH[1]}")
+    fi
+  done < "${_file}"
+}
+
+# _collect_logging <base_path> <global_out> <per_svc_out>
+#
+# Resolve [logging] + [logging.<svc>] for the compose generator. Output
+# layout:
+#
+#   global_out   newline-separated KEY=VALUE for the effective global
+#                [logging] section. Resolution rule mirrors [security]:
+#                if the per-repo setup.conf has a [logging] section,
+#                that section fully replaces the template default (per
+#                CLAUDE.md "section-level replace, no key-level merge
+#                inside a section"). If the per-repo file omits the
+#                section, template defaults apply.
+#
+#   per_svc_out  newline-separated "<svc>:KEY=VALUE" rows for any
+#                [logging.<svc>] sections in the per-repo setup.conf.
+#                Key-level merge against global_out happens in
+#                `_emit_logging_block` at compose-emit time -- only
+#                keys present in [logging.<svc>] override the
+#                corresponding global key; absent keys fall through.
+#                Template setup.conf does not ship per-svc sections;
+#                if one ever appears there it is honored too (parsed
+#                only from the per-repo file in practice, since the
+#                template loader path uses _SETUP_SCRIPT_DIR).
+_collect_logging() {
+  local _base="${1:?"${FUNCNAME[0]}: missing base_path"}"
+  local -n _cl_global="${2:?"${FUNCNAME[0]}: missing global outvar"}"
+  local -n _cl_per_svc="${3:?"${FUNCNAME[0]}: missing per_svc outvar"}"
+  _cl_global=""
+  _cl_per_svc=""
+
+  local _conf
+  if [[ -n "${SETUP_CONF:-}" ]]; then
+    _conf="${SETUP_CONF}"
+  else
+    _conf="${_base}/config/docker/setup.conf"
+  fi
+
+  # Global [logging] -- per-repo first, fall back to template if absent.
+  local -a _g_keys=() _g_vals=()
+  [[ -f "${_conf}" ]] && _parse_ini_section "${_conf}" "logging" _g_keys _g_vals
+  if (( ${#_g_keys[@]} == 0 )); then
+    local _tpl="${_SETUP_SCRIPT_DIR}/../../../config/docker/setup.conf"
+    [[ -f "${_tpl}" ]] && _parse_ini_section "${_tpl}" "logging" _g_keys _g_vals
+  fi
+  local i
+  local -a _g_lines=()
+  for (( i = 0; i < ${#_g_keys[@]}; i++ )); do
+    _g_lines+=("${_g_keys[i]}=${_g_vals[i]}")
+  done
+  (( ${#_g_lines[@]} > 0 )) && _cl_global="$(printf '%s\n' "${_g_lines[@]}")"
+
+  # Per-service [logging.<svc>] sections (per-repo only).
+  [[ -f "${_conf}" ]] || return 0
+  local -a _svcs=()
+  _parse_logging_svc_sections "${_conf}" _svcs
+  local _svc
+  local -a _ps_lines=()
+  for _svc in "${_svcs[@]}"; do
+    local -a _sk=() _sv=()
+    _parse_ini_section "${_conf}" "logging.${_svc}" _sk _sv
+    for (( i = 0; i < ${#_sk[@]}; i++ )); do
+      _ps_lines+=("${_svc}:${_sk[i]}=${_sv[i]}")
+    done
+  done
+  (( ${#_ps_lines[@]} > 0 )) && _cl_per_svc="$(printf '%s\n' "${_ps_lines[@]}")"
+  return 0
+}

--- a/script/docker/wrapper/setup.sh
+++ b/script/docker/wrapper/setup.sh
@@ -1271,48 +1271,12 @@ _resolve_stage_list() {
   fi
 }
 
-# _parse_logging_svc_sections <file> <out_array>
-#
-# Emit each service name that has a `[logging.<svc>]` section in <file>
-# (in the order they appear). Mirrors `_parse_stage_sections` but for
-# the per-service logging override namespace (#310).
-_parse_logging_svc_sections() {
-  local _file="${1:?"${FUNCNAME[0]}: missing file"}"
-  local -n _plss_out="${2:?"${FUNCNAME[0]}: missing out array"}"
-  _plss_out=()
-  [[ -f "${_file}" ]] || return 0
-  local _line
-  while IFS= read -r _line || [[ -n "${_line}" ]]; do
-    if [[ "${_line}" =~ ^\[logging\.([a-z][a-z0-9_-]*)\][[:space:]]*$ ]]; then
-      _plss_out+=("${BASH_REMATCH[1]}")
-    fi
-  done < "${_file}"
-}
+# _parse_logging_svc_sections / _collect_logging moved to
+# lib/conf_logging.sh in #402 (PR-A) so both setup.sh and the
+# upcoming PR-B gitignore sync (lib/gitignore.sh) can share them
+# without circular sourcing. _lib.sh now pulls conf_logging.sh in
+# automatically, so callers below still resolve the same names.
 
-# _collect_logging <base_path> <global_out> <per_svc_out>
-#
-# Resolve [logging] + [logging.<svc>] for the compose generator. Output
-# layout:
-#
-#   global_out   newline-separated KEY=VALUE for the effective global
-#                [logging] section. Resolution rule mirrors [security]
-#                (line 3328 area): if the per-repo setup.conf has a
-#                [logging] section, that section fully replaces the
-#                template default (per CLAUDE.md "section-level
-#                replace, no key-level merge inside a section"). If
-#                the per-repo file omits the section, template
-#                defaults apply.
-#
-#   per_svc_out  newline-separated "<svc>:KEY=VALUE" rows for any
-#                [logging.<svc>] sections in the per-repo setup.conf.
-#                Key-level merge against global_out happens in
-#                `_emit_logging_block` at compose-emit time — only
-#                keys present in [logging.<svc>] override the
-#                corresponding global key; absent keys fall through.
-#                Template setup.conf does not ship per-svc sections;
-#                if one ever appears there it is honored too (parsed
-#                only from the per-repo file in practice, since the
-#                template loader path uses _SETUP_SCRIPT_DIR).
 # _sync_logging_local_paths_gitignore <base_path> <global_str> <per_svc_str>
 #
 # After `apply` resolves [logging] / [logging.<svc>] for compose
@@ -1442,51 +1406,6 @@ _sync_logging_local_paths_gitignore() {
       printf '%s\n' "${_post[@]}"
     fi
   } > "${_gitignore}"
-}
-
-_collect_logging() {
-  local _base="${1:?"${FUNCNAME[0]}: missing base_path"}"
-  local -n _cl_global="${2:?"${FUNCNAME[0]}: missing global outvar"}"
-  local -n _cl_per_svc="${3:?"${FUNCNAME[0]}: missing per_svc outvar"}"
-  _cl_global=""
-  _cl_per_svc=""
-
-  local _conf
-  if [[ -n "${SETUP_CONF:-}" ]]; then
-    _conf="${SETUP_CONF}"
-  else
-    _conf="${_base}/config/docker/setup.conf"
-  fi
-
-  # Global [logging] — per-repo first, fall back to template if absent.
-  local -a _g_keys=() _g_vals=()
-  [[ -f "${_conf}" ]] && _parse_ini_section "${_conf}" "logging" _g_keys _g_vals
-  if (( ${#_g_keys[@]} == 0 )); then
-    local _tpl="${_SETUP_SCRIPT_DIR}/../../../config/docker/setup.conf"
-    [[ -f "${_tpl}" ]] && _parse_ini_section "${_tpl}" "logging" _g_keys _g_vals
-  fi
-  local i
-  local -a _g_lines=()
-  for (( i = 0; i < ${#_g_keys[@]}; i++ )); do
-    _g_lines+=("${_g_keys[i]}=${_g_vals[i]}")
-  done
-  (( ${#_g_lines[@]} > 0 )) && _cl_global="$(printf '%s\n' "${_g_lines[@]}")"
-
-  # Per-service [logging.<svc>] sections (per-repo only).
-  [[ -f "${_conf}" ]] || return 0
-  local -a _svcs=()
-  _parse_logging_svc_sections "${_conf}" _svcs
-  local _svc
-  local -a _ps_lines=()
-  for _svc in "${_svcs[@]}"; do
-    local -a _sk=() _sv=()
-    _parse_ini_section "${_conf}" "logging.${_svc}" _sk _sv
-    for (( i = 0; i < ${#_sk[@]}; i++ )); do
-      _ps_lines+=("${_svc}:${_sk[i]}=${_sv[i]}")
-    done
-  done
-  (( ${#_ps_lines[@]} > 0 )) && _cl_per_svc="$(printf '%s\n' "${_ps_lines[@]}")"
-  return 0
 }
 
 # ════════════════════════════════════════════════════════════════════

--- a/test/unit/compose_logging_spec.bats
+++ b/test/unit/compose_logging_spec.bats
@@ -127,94 +127,9 @@ teardown() {
   echo "${output}" | grep -F 'max-file: "3"'
 }
 
-# ════════════════════════════════════════════════════════════════════
-# _parse_logging_svc_sections
-# ════════════════════════════════════════════════════════════════════
-
-@test "_parse_logging_svc_sections enumerates services in file order" {
-  cat > "${CONF_FILE}" <<'CONF'
-[logging]
-driver = json-file
-
-[logging.runtime]
-max_size = 50m
-
-[logging.devel]
-compress = false
-CONF
-  local -a _svcs=()
-  _parse_logging_svc_sections "${CONF_FILE}" _svcs
-  [[ "${#_svcs[@]}" -eq 2 ]]
-  [[ "${_svcs[0]}" == "runtime" ]]
-  [[ "${_svcs[1]}" == "devel" ]]
-}
-
-@test "_parse_logging_svc_sections ignores plain [logging] section" {
-  cat > "${CONF_FILE}" <<'CONF'
-[logging]
-driver = json-file
-CONF
-  local -a _svcs=()
-  _parse_logging_svc_sections "${CONF_FILE}" _svcs
-  [[ "${#_svcs[@]}" -eq 0 ]]
-}
-
-@test "_parse_logging_svc_sections returns empty when file does not exist" {
-  local -a _svcs=()
-  _parse_logging_svc_sections "/no/such/file" _svcs
-  [[ "${#_svcs[@]}" -eq 0 ]]
-}
-
-# ════════════════════════════════════════════════════════════════════
-# _collect_logging
-# ════════════════════════════════════════════════════════════════════
-
-@test "_collect_logging reads global [logging] from per-repo setup.conf" {
-  mkdir -p "${TEMP_DIR}/config/docker"
-  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'CONF'
-[logging]
-driver = local
-max_size = 20m
-CONF
-  local _g="" _p=""
-  _collect_logging "${TEMP_DIR}" _g _p
-  [[ "${_g}" == *"driver=local"* ]]
-  [[ "${_g}" == *"max_size=20m"* ]]
-  [[ -z "${_p}" ]]
-}
-
-@test "_collect_logging reads per-service [logging.<svc>] sections" {
-  mkdir -p "${TEMP_DIR}/config/docker"
-  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'CONF'
-[logging]
-driver = json-file
-
-[logging.runtime]
-max_size = 100m
-compress = false
-CONF
-  local _g="" _p=""
-  _collect_logging "${TEMP_DIR}" _g _p
-  [[ "${_p}" == *"runtime:max_size=100m"* ]]
-  [[ "${_p}" == *"runtime:compress=false"* ]]
-}
-
-@test "_collect_logging returns empty when no [logging] sections anywhere" {
-  mkdir -p "${TEMP_DIR}/config/docker"
-  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'CONF'
-[image]
-rule_1 = @basename
-CONF
-  local _g="" _p=""
-  # Force template fallback to also miss (point _SETUP_SCRIPT_DIR at a
-  # path whose ../../config/docker/setup.conf does not exist).
-  local _save="${_SETUP_SCRIPT_DIR:-}"
-  _SETUP_SCRIPT_DIR="${TEMP_DIR}/nonexistent/docker"
-  _collect_logging "${TEMP_DIR}" _g _p
-  _SETUP_SCRIPT_DIR="${_save}"
-  [[ -z "${_g}" ]]
-  [[ -z "${_p}" ]]
-}
+# _parse_logging_svc_sections / _collect_logging parser tests moved
+# to test/unit/conf_logging_spec.bats when the implementations were
+# extracted to lib/conf_logging.sh in #402 (PR-A).
 
 # ════════════════════════════════════════════════════════════════════
 # generate_compose_yaml: [logging] local_path bind mount + LOG_FILE_PATH (#328)

--- a/test/unit/conf_logging_spec.bats
+++ b/test/unit/conf_logging_spec.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+#
+# Unit tests for the shared [logging] / [logging.<svc>] parsers in
+# lib/conf_logging.sh.
+#
+# Parsers were extracted from script/docker/wrapper/setup.sh during the
+# #402 lifecycle refactor (PR-A) so that lib/gitignore.sh can reuse the
+# same logic without circular sourcing (setup.sh used to own both the
+# parser and the runtime-time gitignore sync; PR-B moves the sync to
+# init.sh while keeping the parser as a shared primitive).
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+
+  # _collect_logging depends on _parse_ini_section (defined in setup.sh)
+  # and _SETUP_SCRIPT_DIR (set when setup.sh is sourced). Source order:
+  # setup.sh first, then conf_logging.sh so the lib's definitions win
+  # the second-definition tie-break (mirrors how setup.sh will source
+  # the lib once the rewire commit lands in PR-A's later cycle).
+  # shellcheck disable=SC1091
+  source /source/script/docker/wrapper/setup.sh
+  # shellcheck disable=SC1091
+  source /source/script/docker/lib/conf_logging.sh
+
+  TEMP_DIR="$(mktemp -d)"
+  CONF_FILE="${TEMP_DIR}/setup.conf"
+}
+
+teardown() {
+  unset SETUP_CONF
+  rm -rf "${TEMP_DIR}"
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _parse_logging_svc_sections
+# ════════════════════════════════════════════════════════════════════
+
+@test "_parse_logging_svc_sections enumerates services in file order" {
+  cat > "${CONF_FILE}" <<'CONF'
+[logging]
+driver = json-file
+
+[logging.runtime]
+max_size = 50m
+
+[logging.devel]
+compress = false
+CONF
+  local -a _svcs=()
+  _parse_logging_svc_sections "${CONF_FILE}" _svcs
+  [[ "${#_svcs[@]}" -eq 2 ]]
+  [[ "${_svcs[0]}" == "runtime" ]]
+  [[ "${_svcs[1]}" == "devel" ]]
+}
+
+@test "_parse_logging_svc_sections ignores plain [logging] section" {
+  cat > "${CONF_FILE}" <<'CONF'
+[logging]
+driver = json-file
+CONF
+  local -a _svcs=()
+  _parse_logging_svc_sections "${CONF_FILE}" _svcs
+  [[ "${#_svcs[@]}" -eq 0 ]]
+}
+
+@test "_parse_logging_svc_sections returns empty when file does not exist" {
+  local -a _svcs=()
+  _parse_logging_svc_sections "/no/such/file" _svcs
+  [[ "${#_svcs[@]}" -eq 0 ]]
+}
+
+# ════════════════════════════════════════════════════════════════════
+# _collect_logging
+# ════════════════════════════════════════════════════════════════════
+
+@test "_collect_logging reads global [logging] from per-repo setup.conf" {
+  mkdir -p "${TEMP_DIR}/config/docker"
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'CONF'
+[logging]
+driver = local
+max_size = 20m
+CONF
+  local _g="" _p=""
+  _collect_logging "${TEMP_DIR}" _g _p
+  [[ "${_g}" == *"driver=local"* ]]
+  [[ "${_g}" == *"max_size=20m"* ]]
+  [[ -z "${_p}" ]]
+}
+
+@test "_collect_logging reads per-service [logging.<svc>] sections" {
+  mkdir -p "${TEMP_DIR}/config/docker"
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'CONF'
+[logging]
+driver = json-file
+
+[logging.runtime]
+max_size = 100m
+compress = false
+CONF
+  local _g="" _p=""
+  _collect_logging "${TEMP_DIR}" _g _p
+  [[ "${_p}" == *"runtime:max_size=100m"* ]]
+  [[ "${_p}" == *"runtime:compress=false"* ]]
+}
+
+@test "_collect_logging returns empty when no [logging] sections anywhere" {
+  mkdir -p "${TEMP_DIR}/config/docker"
+  cat > "${TEMP_DIR}/config/docker/setup.conf" <<'CONF'
+[image]
+rule_1 = @basename
+CONF
+  local _g="" _p=""
+  # Force template fallback to also miss (point _SETUP_SCRIPT_DIR at a
+  # path whose ../../config/docker/setup.conf does not exist).
+  local _save="${_SETUP_SCRIPT_DIR:-}"
+  _SETUP_SCRIPT_DIR="${TEMP_DIR}/nonexistent/docker"
+  _collect_logging "${TEMP_DIR}" _g _p
+  _SETUP_SCRIPT_DIR="${_save}"
+  [[ -z "${_g}" ]]
+  [[ -z "${_p}" ]]
+}

--- a/test/unit/init_spec.bats
+++ b/test/unit/init_spec.bats
@@ -32,7 +32,7 @@ setup() {
         "${TMP_REPO}/.base/script/docker/lib/_lib.sh"
   ln -s /source/script/docker/lib/i18n.sh \
         "${TMP_REPO}/.base/script/docker/lib/i18n.sh"
-  for _sl in log env conf compose config_summary; do
+  for _sl in log env conf conf_logging compose config_summary; do
     ln -s "/source/script/docker/lib/${_sl}.sh" \
           "${TMP_REPO}/.base/script/docker/lib/${_sl}.sh"
   done


### PR DESCRIPTION
## Summary

- New file `script/docker/lib/conf_logging.sh` holds `_parse_logging_svc_sections` + `_collect_logging`.
- `lib/_lib.sh` now sources the new lib automatically.
- `script/docker/wrapper/setup.sh` drops its inline copies of both functions; callers stay put.
- 6 parser tests moved from `compose_logging_spec.bats` into a new `conf_logging_spec.bats`.
- Pure refactor — zero behaviour change.

Refs #402 (PR-A; the first of two PRs landing the #402 lifecycle refactor. PR-B will move the `[logging] local_path` gitignore sync from `setup.sh apply` runtime to the init/upgrade path.)

## Why

#402 wants to move `[logging] local_path` `.gitignore` sync out of `setup.sh apply` (runtime) and into the `init.sh` / `upgrade.sh` lifecycle. The new home (`lib/gitignore.sh`) needs to read the `[logging]` section, using the same parser `setup.sh` uses today.

If we leave the parsers in `setup.sh`, `lib/gitignore.sh` would have to `source setup.sh` to reach them — which is circular (setup.sh already sources `lib/`). Extracting first into a shared lib makes PR-B a clean source.

## Test plan (TDD red->green per cycle)

- [x] Cycle 1: new `conf_logging_spec.bats` sources the not-yet-existing lib -> fail. Create the lib -> 3 `_parse_logging_svc_sections` tests pass.
- [x] Cycle 2: add 3 `_collect_logging` tests; spec also sources `setup.sh` to satisfy `_parse_ini_section` -> all 6 pass.
- [x] Cycle 3: delete the inline definitions in `setup.sh`; `lib/_lib.sh` adds `source conf_logging.sh`; run `compose_logging_spec.bats` to confirm existing callers still work via the shared lib.
- [x] Cycle 4: remove the 6 migrated parser tests from `compose_logging_spec.bats` so we do not run them twice.
- [x] `make -f Makefile.ci test` green (ShellCheck + Bats via compose).

## Note

- `_collect_logging` still depends on `_parse_ini_section` + `_SETUP_SCRIPT_DIR` (provided by `setup.sh`). The test spec satisfies this by sourcing `setup.sh` first, then the lib.
- `conf_logging.sh` carries its own double-source guard (`_DOCKER_LIB_CONF_LOGGING_SOURCED`), matching the pattern of the sibling libs.
- Total test count is unchanged (`compose_logging_spec.bats` 26 + new `conf_logging_spec.bats` 6 = original 32).

## Out of scope

- No change to `_sync_logging_local_paths_gitignore` behaviour — PR-B owns the lifecycle move.
- `_parse_ini_section` stays in `setup.sh` for now. If a future change adds more INI parsers that need sharing, that can be a separate `lib/conf.sh` extension.
- The 9 `_sync_logging_local_paths_gitignore` tests stay in `compose_logging_spec.bats` for this PR; PR-B will relocate them to `gitignore_spec.bats` as part of the lifecycle move.

## Related

- #402 — issue with the Option A lifecycle decision.
- PR-B (follow-up): add `lib/gitignore.sh::_sync_logging_gitignore`, hook into `init.sh`, remove `setup.sh`'s runtime sync.
