### PR TITLE
fix(upgrade.sh): R1+ marker check (structural invariant + target match) (closes #477, refs #492)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`upgrade.sh` post-pull integrity check rewritten as R1+ (structural invariant + target match)** — `_verify_subtree_intact` no longer asserts specific files exist at hard-coded paths (the v0.39.0 reorg of `script/docker/setup.sh` -> `wrapper/setup.sh` tripped the legacy marker list and broke `make upgrade v0.39.0+` from any pre-v0.39.0 release; tested v0.34.1 reproducer rolled back at Step 2/5). The new check is path-agnostic: it verifies `${TEMPLATE_REL}/` is a non-empty directory, `${TEMPLATE_REL}/.version` exists and parses as semver, and the pulled version matches the caller's target (catches wrong-tag / wrong-remote pulls that pass the structural check but deliver the wrong thing). Sibling path-coupling regions in upgrade.sh (`init.sh` invocation, `config/` drift detection, Dockerfile lib auto-patch) are intentionally not covered here -- tracked in #492. Pre-v0.39.0 downstream repos still need a manual one-shot patch of their stale `.base/upgrade.sh` before they can reach a version carrying this fix. Closes #477.
+
 ## [v0.40.0] - 2026-05-30
 
 ### Added

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1043,7 +1043,7 @@ Exercises the runtime assertion helpers shipped in
 | `main copies tmux.conf to config directory` | Config copy |
 | `script runs entry_point when executed directly` | Direct-run guard |
 
-### test/unit/upgrade_spec.bats (35)
+### test/unit/upgrade_spec.bats (38)
 
 Unit tests for `upgrade.sh` helpers. Uses the sed-range pattern to extract
 one function at a time into a minimal harness (with `_log` / `_error`
@@ -1057,7 +1057,11 @@ the three safety guards added after the v0.9.7 Jetson incident
 `_verify_subtree_intact` with rollback), structural invariants that
 pin call-ordering in `_upgrade` (identity check runs before subtree
 pull, integrity verification runs after, pre-pull HEAD is snapshotted
-for rollback), and the SemVer §11-aware `_semver_cmp` + `_check`
+for rollback), the R1+ rewrite of `_verify_subtree_intact` (#477)
+that replaces the hard-coded marker list with a path-agnostic
+structural invariant + target-version match (catches destructive
+fast-forward, empty subtree, malformed `.version`, and wrong-tag
+pulls), and the SemVer §11-aware `_semver_cmp` + `_check`
 behavior added for issue #156 (prerelease ahead of latest stable
 must not be reported as "needing downgrade").
 
@@ -1075,11 +1079,14 @@ must not be reported as "needing downgrade").
 | `_require_clean_merge_state succeeds in clean repo` | Happy path |
 | `_require_clean_merge_state fails when MERGE_HEAD exists` | Mid-merge guard |
 | `_require_clean_merge_state fails when rebase-merge dir exists` | Mid-rebase guard |
-| `_verify_subtree_intact succeeds when all markers present` | Happy path |
+| `_verify_subtree_intact succeeds when subtree dir + version match target (#477 happy path)` | R1+ happy path |
 | `_verify_subtree_intact rolls back when template/.version is missing` | Destructive-FF rollback |
-| `_verify_subtree_intact rolls back when template/script/docker/setup.sh is missing` | Marker rollback |
+| `_verify_subtree_intact rolls back when template/ dir is missing (#477 destructive-FF detector)` | R1+ dir-missing rollback |
+| `_verify_subtree_intact rolls back when template/ dir is empty (#477)` | R1+ empty-dir rollback |
+| `_verify_subtree_intact rolls back when .version content is not semver (#477)` | R1+ semver-shape guard |
+| `_verify_subtree_intact rolls back when .version does not match target (#477 wrong-tag detector)` | R1+ wrong-tag detector |
 | `upgrade.sh calls _require_git_identity before subtree pull` | Pre-flight ordering |
-| `upgrade.sh calls _verify_subtree_intact after subtree pull` | Post-flight ordering |
+| `upgrade.sh calls _verify_subtree_intact after subtree pull with target version (#477)` | Post-flight ordering + R1+ caller integration |
 | `upgrade.sh snapshots pre-pull HEAD for rollback` | Rollback anchor |
 | `_semver_cmp: equal versions return 0` | Equality |
 | `_semver_cmp: lower core returns 1` | Behind core |

--- a/script/docker/lib/log-events.txt
+++ b/script/docker/lib/log-events.txt
@@ -90,6 +90,7 @@ upgrade_started
 upgrade_completed
 upgrade_subtree_pull_failed
 upgrade_version_bumped
+upgrade_version_mismatch
 upgrade_rollback
 
 # init.sh

--- a/test/integration/upgrade_spec.bats
+++ b/test/integration/upgrade_spec.bats
@@ -399,7 +399,10 @@ STUB
 
   assert_failure
   assert_output --partial "integrity check failed"
-  assert_output --partial ".base/.version"
+  # R1+ (#477) detects destructive FF via subtree dir missing, ahead of the
+  # later .version / version-mismatch checks. The legacy assertion against
+  # ".base/.version" missing was specific to the pre-R1+ marker list.
+  assert_output --partial "subtree dir missing"
   assert_output --partial "Rolling back"
   assert_output --partial "upgrade aborted"
 

--- a/test/unit/upgrade_spec.bats
+++ b/test/unit/upgrade_spec.bats
@@ -38,6 +38,7 @@ EOS
   sed -n '/^_require_git_identity() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
   sed -n '/^_require_clean_merge_state() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
   sed -n '/^_verify_subtree_intact() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
+  sed -n '/^_rollback_subtree_pull() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
   sed -n '/^_semver_cmp() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
   sed -n '/^_check() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
   sed -n '/^_get_latest_version() {$/,/^}$/p' "${UPGRADE}" >> "${HARNESS}"
@@ -215,14 +216,14 @@ _mk_subtree_repo() {
   git -C "${_dir}" commit -q -m "initial"
 }
 
-@test "_verify_subtree_intact succeeds when all markers present" {
+@test "_verify_subtree_intact succeeds when subtree dir + version match target (#477 happy path)" {
   local _git_dir="${TEMP_DIR}/intact_ok"
-  _mk_subtree_repo "${_git_dir}"
+  _mk_subtree_repo "${_git_dir}"  # writes .version=v0.9.5
   run bash -c "
     cd '${_git_dir}'
     _pre=\$(git rev-parse HEAD)
     source '${HARNESS}'
-    _verify_subtree_intact \"\${_pre}\"
+    _verify_subtree_intact \"\${_pre}\" 'v0.9.5'
   "
   assert_success
 }
@@ -238,7 +239,7 @@ _mk_subtree_repo() {
   run bash -c "
     cd '${_git_dir}'
     source '${HARNESS}'
-    _verify_subtree_intact '${_pre}'
+    _verify_subtree_intact '${_pre}' 'v0.9.5'
   "
   assert_failure
   assert_output --partial "integrity check failed"
@@ -247,21 +248,78 @@ _mk_subtree_repo() {
   [ -f "${_git_dir}/.base/.version" ]
 }
 
-@test "_verify_subtree_intact rolls back when .base/script/docker/wrapper/setup.sh is missing" {
-  local _git_dir="${TEMP_DIR}/intact_nosetup"
+@test "_verify_subtree_intact rolls back when .base/ dir is missing (#477 destructive-FF detector)" {
+  local _git_dir="${TEMP_DIR}/intact_nodir"
   _mk_subtree_repo "${_git_dir}"
   local _pre
   _pre="$(git -C "${_git_dir}" rev-parse HEAD)"
-  rm "${_git_dir}/.base/script/docker/wrapper/setup.sh"
+  rm -rf "${_git_dir}/.base"
 
   run bash -c "
     cd '${_git_dir}'
     source '${HARNESS}'
-    _verify_subtree_intact '${_pre}'
+    _verify_subtree_intact '${_pre}' 'v0.9.5'
   "
   assert_failure
-  assert_output --partial ".base/script/docker/wrapper/setup.sh"
-  [ -f "${_git_dir}/.base/script/docker/wrapper/setup.sh" ]
+  assert_output --partial "subtree dir missing"
+  # Post-condition: rollback restored the dir.
+  [ -d "${_git_dir}/.base" ]
+}
+
+@test "_verify_subtree_intact rolls back when .base/ dir is empty (#477)" {
+  local _git_dir="${TEMP_DIR}/intact_emptydir"
+  _mk_subtree_repo "${_git_dir}"
+  local _pre
+  _pre="$(git -C "${_git_dir}" rev-parse HEAD)"
+  # Empty the dir but keep it as a directory.
+  rm -rf "${_git_dir}/.base"/* "${_git_dir}/.base"/.[!.]*
+
+  run bash -c "
+    cd '${_git_dir}'
+    source '${HARNESS}'
+    _verify_subtree_intact '${_pre}' 'v0.9.5'
+  "
+  assert_failure
+  assert_output --partial "subtree dir is empty"
+  # Post-condition: contents restored.
+  [ -f "${_git_dir}/.base/.version" ]
+}
+
+@test "_verify_subtree_intact rolls back when .version content is not semver (#477)" {
+  local _git_dir="${TEMP_DIR}/intact_notsemver"
+  _mk_subtree_repo "${_git_dir}"
+  local _pre
+  _pre="$(git -C "${_git_dir}" rev-parse HEAD)"
+  # Corrupt .version with non-semver content.
+  echo "garbage-not-a-version" > "${_git_dir}/.base/.version"
+
+  run bash -c "
+    cd '${_git_dir}'
+    source '${HARNESS}'
+    _verify_subtree_intact '${_pre}' 'v0.9.5'
+  "
+  assert_failure
+  assert_output --partial "not semver"
+  assert_output --partial "garbage-not-a-version"
+  # Post-condition: original .version content restored.
+  run cat "${_git_dir}/.base/.version"
+  assert_output "v0.9.5"
+}
+
+@test "_verify_subtree_intact rolls back when .version does not match target (#477 wrong-tag detector)" {
+  local _git_dir="${TEMP_DIR}/intact_wrongtag"
+  _mk_subtree_repo "${_git_dir}"  # writes v0.9.5
+  local _pre
+  _pre="$(git -C "${_git_dir}" rev-parse HEAD)"
+
+  run bash -c "
+    cd '${_git_dir}'
+    source '${HARNESS}'
+    _verify_subtree_intact '${_pre}' 'v0.8.0'
+  "
+  assert_failure
+  assert_output --partial "v0.9.5"
+  assert_output --partial "v0.8.0"
 }
 
 # ── upgrade.sh structural invariants (safety guards) ───────────────────────
@@ -276,10 +334,12 @@ _mk_subtree_repo() {
   (( _id_line < _pull_line ))
 }
 
-@test "upgrade.sh calls _verify_subtree_intact after subtree pull" {
+@test "upgrade.sh calls _verify_subtree_intact after subtree pull with target version (#477)" {
   local _pull_line _verify_line
   _pull_line="$(grep -n 'git subtree pull' "${UPGRADE}" | head -1 | cut -d: -f1)"
-  _verify_line="$(grep -n '_verify_subtree_intact "\${_pre_head}"' "${UPGRADE}" | head -1 | cut -d: -f1)"
+  # Caller must pass both _pre_head AND target_ver so the wrong-tag
+  # detector (#477 R1+) is armed in production, not just in tests.
+  _verify_line="$(grep -n '_verify_subtree_intact "\${_pre_head}" "\${target_ver}"' "${UPGRADE}" | head -1 | cut -d: -f1)"
   [ -n "${_pull_line}" ]
   [ -n "${_verify_line}" ]
   (( _verify_line > _pull_line ))

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -84,21 +84,49 @@ _require_clean_merge_state() {
 #   markers, and hard-reset back to <pre_head_sha> if integrity is lost.
 _verify_subtree_intact() {
   local _pre_head="$1"
-  local _markers=(
-    "${TEMPLATE_REL}/.version"
-    "${TEMPLATE_REL}/init.sh"
-    "${TEMPLATE_REL}/script/docker/wrapper/setup.sh"
-  )
-  local _marker
-  for _marker in "${_markers[@]}"; do
-    if [[ ! -f "${_marker}" ]]; then
-      _log_err upgrade upgrade_subtree_pull_failed "display=post-pull integrity check failed -- '${_marker}' missing." "marker=${_marker}"
-      _log_err upgrade upgrade_rollback "display=Likely cause: git-subtree fast-forwarded destructively."
-      _log_info upgrade upgrade_rollback "display=Rolling back to ${_pre_head:0:12} ..." "commit=${_pre_head:0:12}"
-      git reset --hard "${_pre_head}" >/dev/null 2>&1 || true
-      _error "upgrade aborted; repo restored to pre-upgrade state"
-    fi
-  done
+  local _target_ver="${2:-}"
+
+  # R1+ structural invariant (#477): instead of asserting specific
+  # files exist at hard-coded paths (which broke on the v0.39.0
+  # `script/docker/setup.sh` -> `wrapper/setup.sh` reorg), check that
+  # the subtree directory exists, is non-empty, and carries a
+  # well-formed `.version`. Then verify the pulled version matches
+  # the target the caller asked for (catches wrong-tag / wrong-remote
+  # cases that pass the structural check but deliver the wrong thing).
+  # Sibling path-coupling regions in upgrade.sh are intentionally not
+  # covered here -- tracked in #492.
+  if [[ ! -d "${TEMPLATE_REL}" ]]; then
+    _log_err upgrade upgrade_subtree_pull_failed "display=post-pull integrity check failed -- '${TEMPLATE_REL}/' subtree dir missing." "marker=${TEMPLATE_REL}"
+    _rollback_subtree_pull "${_pre_head}"
+  fi
+  if [[ -z "$(ls -A "${TEMPLATE_REL}" 2>/dev/null)" ]]; then
+    _log_err upgrade upgrade_subtree_pull_failed "display=post-pull integrity check failed -- '${TEMPLATE_REL}/' subtree dir is empty." "marker=${TEMPLATE_REL}"
+    _rollback_subtree_pull "${_pre_head}"
+  fi
+  if [[ ! -f "${TEMPLATE_REL}/.version" ]]; then
+    _log_err upgrade upgrade_subtree_pull_failed "display=post-pull integrity check failed -- '${TEMPLATE_REL}/.version' missing." "marker=${TEMPLATE_REL}/.version"
+    _rollback_subtree_pull "${_pre_head}"
+  fi
+
+  local _pulled_ver
+  _pulled_ver="$(tr -d '[:space:]' < "${TEMPLATE_REL}/.version")"
+  if [[ ! "${_pulled_ver}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$ ]]; then
+    _log_err upgrade upgrade_subtree_pull_failed "display=post-pull integrity check failed -- '${TEMPLATE_REL}/.version' content is not semver: '${_pulled_ver}'." "pulled=${_pulled_ver}"
+    _rollback_subtree_pull "${_pre_head}"
+  fi
+
+  if [[ -n "${_target_ver}" ]] && [[ "${_pulled_ver#v}" != "${_target_ver#v}" ]]; then
+    _log_err upgrade upgrade_version_mismatch "display=pulled ${_pulled_ver}, expected ${_target_ver}" "pulled=${_pulled_ver}" "expected=${_target_ver}"
+    _rollback_subtree_pull "${_pre_head}"
+  fi
+}
+
+_rollback_subtree_pull() {
+  local _pre_head="$1"
+  _log_err upgrade upgrade_rollback "display=Likely cause: git-subtree fast-forwarded destructively or pulled wrong tag."
+  _log_info upgrade upgrade_rollback "display=Rolling back to ${_pre_head:0:12} ..." "commit=${_pre_head:0:12}"
+  git reset --hard "${_pre_head}" >/dev/null 2>&1 || true
+  _error "upgrade aborted; repo restored to pre-upgrade state"
 }
 
 # ── Get versions ─────────────────────────────────────────────────────────────
@@ -265,7 +293,7 @@ _upgrade() {
 
   # Step 2: post-pull integrity check (rolls back on corruption)
   _log "Step 2/5: verify ${TEMPLATE_REL}/ subtree integrity"
-  _verify_subtree_intact "${_pre_head}"
+  _verify_subtree_intact "${_pre_head}" "${target_ver}"
 
   # Step 3: re-run init.sh to sync symlinks (in case template structure changed)
   _log "Step 3/5: re-run init.sh to sync symlinks"


### PR DESCRIPTION
## Summary

`upgrade.sh::_verify_subtree_intact` is rewritten from a hard-coded marker list to the R1+ design (structural invariant + target match). Fixes #477 — the v0.39.0 reorg that moved `script/docker/setup.sh` to `wrapper/setup.sh` made every pre-v0.39.0 → v0.39.0+ upgrade roll back at the integrity check.

## R1+ design

The new check has 5 conditions, all path-agnostic:

1. `${TEMPLATE_REL}/` is a directory
2. `${TEMPLATE_REL}/` is non-empty
3. `${TEMPLATE_REL}/.version` exists
4. `${TEMPLATE_REL}/.version` content is valid semver (`^v?\d+\.\d+\.\d+(-rc\d+)?$`)
5. parsed version equals the caller's `target_ver` (v-prefix normalized on both sides)

Any failing step calls `_rollback_subtree_pull` → `git reset --hard ${_pre_head}` → exit non-zero.

The new `_rollback_subtree_pull` helper extracts the rollback-log + reset boilerplate that the three legacy branches duplicated.

The caller (`_upgrade()`) now invokes `_verify_subtree_intact "${_pre_head}" "${target_ver}"` so the wrong-tag detector is armed in production, not just in tests.

## Why this design (grill outcome)

| Alternative | Why not |
|---|---|
| R0 (status quo hard-coded markers) | Every reorg requires a marker-list update — exactly the root cause of this bug |
| R2 manifest file (marker list moved to `.subtree-manifest.txt`) | Doesn't solve the root cause; just relocates it. The actual R0 problem is "maintainer forgets to update marker list on reorg" — moving the list to another file doesn't help |
| R3 blacklist (detect disaster shape instead of normal shape) | The sentinel list still needs maintenance; false-positive risk |
| R4 git tree-hash compare | Most precise, but squash mode does not guarantee bit-identical tree hash; over-engineered |

**R1+ is the minimum viable design in the "no path coupling" direction** — there is no hard-coded path anywhere, so any future internal reorg of `.base/` will not trip this check.

## Scope (intentional exclusions)

`upgrade.sh` has three other hard-coded `.base/...` path regions that the audit surfaced — direct `init.sh` invocation, `config/` drift detection, and Dockerfile `lib/` auto-patch — but they are **out of scope** for this PR. Reasoning:

1. None of the three paths has any short-term relocation plan
2. Each has its own design questions to grill (discovery vs manifest vs ADR fix)
3. No active pain point

Tracked as **#492** (label `enhancement, backlog`). Any future reorg touching those three paths must cross-reference #492 and address as part of that work.

## Zero immediate effect on downstream

All 13 downstream repos in the org currently sit at `.base/.version < v0.39.0` (v0.29.2 .. v0.35.0). They run their own stale `upgrade.sh`, so **they will never get this fix automatically**. The next time we attempt a batch fanout, `/batch-base-upgrade` must first patch each repo's stale marker via `sed`. This is a known follow-up, deferred until that actual fanout is needed.

This PR exclusively delivers robustness for "any future upgrade once already on ≥ v0.39.0".

## Changes

| File | Change |
|------|--------|
| `upgrade.sh` | `_verify_subtree_intact` rewritten as R1+; new `_rollback_subtree_pull` helper; caller passes `target_ver` |
| `script/docker/lib/log-events.txt` | New `upgrade_version_mismatch` body |
| `test/unit/upgrade_spec.bats` | +5 R1+ tests, -1 R0-only test, 2 existing tests updated for the new signature; harness sources `_rollback_subtree_pull` |
| `test/integration/upgrade_spec.bats` | Rollback test's message assertion changed from `.base/.version` to `subtree dir missing` (R1+ catches the dir-gone case earlier in the chain) |
| `doc/changelog/CHANGELOG.md` | `[Unreleased]/Fixed` entry |
| `doc/test/TEST.md` | `upgrade_spec.bats` count 35→38; test rows + section description synced |

## Test plan

- [x] `make -f Makefile.ci test` 1568/1568 pass (ShellCheck + bats unit + integration all green)
- [x] All 7 `_verify_subtree_intact`-related tests pass (5 rollback + 1 happy + 1 caller integration)
- [x] Integration test `upgrade.sh rolls back when git-subtree does a destructive fast-forward` still rolls back correctly under the R1+ message
- [ ] CI green (verify after push)
- [ ] No downstream fanout needed (base PR but downstream won't auto-upgrade — see "Zero immediate effect on downstream" above)

## Related

- Closes #477 (the bug)
- Refs #492 (sibling path fragility recorded as backlog; out of this PR's scope)
