### PR TITLE
test(wrapper): behavioural dry-run compose-dispatch spec, drop name-coupled greps (closes #490)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Wrapper -> compose dispatch is now asserted behaviourally** — new `test/integration/wrapper_compose_dispatch_spec.bats` runs each wrapper (`build` / `run` / `exec` / `stop`) with `--dry-run` and checks the planned `docker compose -p <project> <verb>` (including the `-p` flag), replacing the name-coupled `_compose_project` / `_app_cleanup` greps in `template_spec.bats`. The behavioural assertions are immune to internal renames (which broke the old greps twice during the v0.40.0 cycle: #480's `_compose_dispatch` shim, #484's `_app_cleanup` rename) and additionally catch a raw-`docker compose` bypass (a missing `-p`) that a grep could not. Closes #490.
+
 ### Fixed
 - **`upgrade.sh` post-pull integrity check rewritten as R1+ (structural invariant + target match)** — `_verify_subtree_intact` no longer asserts specific files exist at hard-coded paths (the v0.39.0 reorg of `script/docker/setup.sh` -> `wrapper/setup.sh` tripped the legacy marker list and broke `make upgrade v0.39.0+` from any pre-v0.39.0 release; tested v0.34.1 reproducer rolled back at Step 2/5). The new check is path-agnostic: it verifies `${TEMPLATE_REL}/` is a non-empty directory, `${TEMPLATE_REL}/.version` exists and parses as semver, and the pulled version matches the caller's target (catches wrong-tag / wrong-remote pulls that pass the structural check but deliver the wrong thing). Sibling path-coupling regions in upgrade.sh (`init.sh` invocation, `config/` drift detection, Dockerfile lib auto-patch) are intentionally not covered here -- tracked in #492. Pre-v0.39.0 downstream repos still need a manual one-shot patch of their stale `.base/upgrade.sh` before they can reach a version carrying this fix. Closes #477.
 

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -1,6 +1,6 @@
 # TEST.md
 
-Template self-tests: **1466 tests** total (1398 unit + 68 integration).
+Template self-tests: **1465 tests** total (1391 unit + 74 integration).
 
 > Counted scope is the `make -f Makefile.ci test` self-test suite —
 > what runs in the `Self Test` CI job. The 36 shared smoke tests under
@@ -762,7 +762,7 @@ the host file content and the inherited stdout (preserving
 | `entrypoint_logging warns + continues when target is a directory (#328)` | Failure-mode fallback |
 | `entrypoint_logging captures stderr along with stdout (#328)` | 2>&1 redirect |
 
-### test/unit/template_spec.bats (147)
+### test/unit/template_spec.bats (145)
 
 | Test | Description |
 |------|-------------|
@@ -1197,6 +1197,27 @@ invocation — `build.sh --dry-run`).
 |------|-------------|
 | `fresh clone with stale absolute mount_1: build.sh auto-migrates + generates local .env` | Stale-path auto-migrate |
 | `fresh clone with portable ${WS_PATH} mount_1: no warning, .env gets local path` | Happy path round-trip |
+
+### test/integration/wrapper_compose_dispatch_spec.bats (6)
+
+Behavioural assertion (#490) that every wrapper routes its `docker compose`
+calls through the `-p`-injecting dispatcher. Reuses the
+`fresh_clone_portability_spec.bats` fixture pattern (cp `/source` -> `.base/`,
+symlink the wrappers from the repo root, materialize `.env` + `compose.yaml`
+via `build.sh --dry-run`), then runs each wrapper with `--dry-run` and
+inspects the planned `[dry-run] docker compose -p <project> <verb>` line.
+Immune to internal renames (replaces the old name-coupled `_compose_project` /
+`_app_cleanup` greps in `template_spec.bats`) and catches a raw-`docker
+compose` bypass (a missing `-p`). **Level 1** (no Docker invocation).
+
+| Test | Description |
+|------|-------------|
+| `build.sh --dry-run dispatches compose build with -p project flag` | build dispatch |
+| `run.sh --dry-run (default devel) dispatches compose up + exec with -p` | run devel up+exec |
+| `exec.sh --dry-run dispatches compose exec with -p` | exec dispatch |
+| `stop.sh --dry-run dispatches compose down with -p` | stop dispatch |
+| `run.sh foreground --dry-run installs cleanup that downs with --remove-orphans` | EXIT-trap cleanup |
+| `no wrapper dispatches compose without -p (bypass regression)` | bypass catcher |
 
 ### test/integration/upgrade_spec.bats (16)
 

--- a/test/integration/wrapper_compose_dispatch_spec.bats
+++ b/test/integration/wrapper_compose_dispatch_spec.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+#
+# Integration test: wrapper -> compose dispatch, asserted behaviourally
+# via --dry-run output rather than by grepping for the dispatcher's
+# identifier name in the wrapper source (#490).
+#
+# Why behavioural: the old template_spec.bats greps asserted that the
+# literal string `_compose_project` appeared in each wrapper. Every
+# internal rename (#480 `_compose_dispatch` shim, #484 `_app_cleanup`)
+# forced those greps to be updated in lockstep or CI failed -- and a
+# grep cannot catch a *bypass* (a raw `docker compose ...` added without
+# `-p`, which would silently use the directory basename as the project
+# name). These tests instead run each wrapper with --dry-run and assert
+# the planned command is `docker compose -p <project> <verb>`, including
+# the `-p` flag. They are immune to internal renames and DO catch a
+# bypass (a missing `-p`).
+#
+# Level-1 (file generation + dry-run only) -- docker is never invoked;
+# --dry-run makes every wrapper print its compose command and stop.
+
+setup() {
+  export LOG_FORMAT=text
+  load "${BATS_TEST_DIRNAME}/../unit/test_helper"
+
+  REPO_NAME="myapp_test"
+  TMP_ROOT="$(mktemp -d)"
+  REPO_DIR="${TMP_ROOT}/${REPO_NAME}"
+  mkdir -p "${REPO_DIR}/.base"
+  cp -a /source/. "${REPO_DIR}/.base/"
+
+  # Look like a committed downstream consumer: Dockerfile present and the
+  # wrappers symlinked from the repo root exactly as init.sh produces.
+  touch "${REPO_DIR}/Dockerfile"
+  local _w
+  for _w in build run exec stop; do
+    ln -s ".base/script/docker/wrapper/${_w}.sh" "${REPO_DIR}/${_w}.sh"
+  done
+
+  # Seed a per-repo setup.conf from the template so apply renders .env +
+  # compose.yaml deterministically.
+  mkdir -p "${REPO_DIR}/config/docker"
+  cp "${REPO_DIR}/.base/config/docker/setup.conf" \
+     "${REPO_DIR}/config/docker/setup.conf"
+
+  cd "${REPO_DIR}"
+
+  # Materialize .env + compose.yaml once. build.sh / run.sh self-regen on
+  # drift, but stop.sh / exec.sh expect the derived artifacts to already
+  # exist (as in a real repo after its first build). --dry-run keeps docker
+  # uninvoked while setup.sh runs end-to-end.
+  bash "${REPO_DIR}/build.sh" --dry-run >/dev/null 2>&1 || true
+}
+
+teardown() {
+  rm -rf "${TMP_ROOT}"
+}
+
+# ── compose dispatch (behavioural) ──────────────────────────────────────────
+
+@test "build.sh --dry-run dispatches compose build with -p project flag" {
+  run bash "${REPO_DIR}/build.sh" --dry-run
+  assert_success
+  # -p must be present (catches a raw `docker compose` bypass) and the
+  # project name is the wrapper's PROJECT_NAME rule, not the dir basename.
+  assert_output --regexp '\[dry-run\] docker compose -p [a-zA-Z0-9._-]+'
+  assert_output --partial ' build'
+}
+
+@test "run.sh --dry-run (default devel) dispatches compose up + exec with -p" {
+  run bash "${REPO_DIR}/run.sh" --dry-run
+  assert_success
+  assert_output --regexp '\[dry-run\] docker compose -p [a-zA-Z0-9._-]+ .* up '
+  assert_output --regexp '\[dry-run\] docker compose -p [a-zA-Z0-9._-]+ .* exec '
+}
+
+@test "exec.sh --dry-run dispatches compose exec with -p" {
+  run bash "${REPO_DIR}/exec.sh" --dry-run
+  assert_success
+  assert_output --regexp '\[dry-run\] docker compose -p [a-zA-Z0-9._-]+ .* exec '
+}
+
+@test "stop.sh --dry-run dispatches compose down with -p" {
+  run bash "${REPO_DIR}/stop.sh" --dry-run
+  assert_success
+  assert_output --regexp '\[dry-run\] docker compose -p [a-zA-Z0-9._-]+ .* down'
+}
+
+@test "run.sh foreground --dry-run installs cleanup that downs with --remove-orphans" {
+  run bash "${REPO_DIR}/run.sh" --dry-run
+  assert_success
+  # The EXIT-trap cleanup is visible in dry-run output (#386/#440): it
+  # tears the project down through the same -p dispatcher.
+  assert_output --regexp '\[dry-run\] docker compose -p [a-zA-Z0-9._-]+ .* down --remove-orphans -t'
+}
+
+@test "no wrapper dispatches compose without -p (bypass regression)" {
+  # Every `docker compose` invocation must go through the -p-injecting
+  # dispatcher. A raw `docker compose ...` (wrong project name) is the
+  # exact failure this guards against -- grep-based tests could not.
+  local _w _line
+  for _w in build run exec stop; do
+    run bash "${REPO_DIR}/${_w}.sh" --dry-run
+    assert_success
+    while IFS= read -r _line; do
+      [[ "${_line}" == *"docker compose"* ]] || continue
+      [[ "${_line}" == *"docker compose -p "* ]] \
+        || fail "${_w}.sh dispatched compose without -p: ${_line}"
+    done <<< "${output}"
+  done
+}

--- a/test/unit/template_spec.bats
+++ b/test/unit/template_spec.bats
@@ -228,30 +228,13 @@ setup() {
   assert_success
 }
 
-@test "lib/compose.sh _compose_project wraps -p with PROJECT_NAME" {
-  run grep -E '\-p .*PROJECT_NAME' /source/script/docker/lib/compose.sh
-  assert_success
-}
-
-@test "build.sh routes compose call through _compose_project" {
-  run grep -E '_compose_project ' /source/script/docker/wrapper/build.sh
-  assert_success
-}
-
-@test "run.sh routes compose calls through _compose_project" {
-  run grep -E '_compose_project ' /source/script/docker/wrapper/run.sh
-  assert_success
-}
-
-@test "exec.sh routes compose call through _compose_project" {
-  run grep -E '_compose_project ' /source/script/docker/wrapper/exec.sh
-  assert_success
-}
-
-@test "stop.sh routes compose call through _compose_project" {
-  run grep -E '_compose_project ' /source/script/docker/wrapper/stop.sh
-  assert_success
-}
+# Wrapper -> compose dispatch is asserted behaviourally in
+# test/integration/wrapper_compose_dispatch_spec.bats (#490): each wrapper
+# is run with --dry-run and the planned `docker compose -p <project> <verb>`
+# is checked (incl. the -p flag, catching a raw-`docker compose` bypass).
+# The old name-coupled greps for `_compose_project` here were removed —
+# they broke on every internal rename (#480 shim, #484 rename) and could
+# not catch a bypass.
 
 @test "exec.sh loads .env via _load_env helper" {
   run grep -E '_load_env .*\.env' /source/script/docker/wrapper/exec.sh
@@ -300,27 +283,10 @@ setup() {
   assert_success
 }
 
-@test "run.sh foreground installs trap to auto-down on exit (#440 renamed _app_cleanup)" {
-  # #386: trap installed centrally before the dispatch block so both devel
-  # and non-devel foreground paths get the cleanup; -d / --no-rm opt out.
-  # #440: renamed from _compose_cleanup to _app_cleanup since the handler
-  # now also runs the post-run hook before compose down.
-  run grep -E 'trap _app_cleanup EXIT' /source/script/docker/wrapper/run.sh
-  assert_success
-  run grep -E '_app_cleanup\(\)' /source/script/docker/wrapper/run.sh
-  assert_success
-}
-
-@test "run.sh _app_cleanup uses --remove-orphans + short timeout (#440)" {
-  # #386: aligned with stop.sh's _down_one so worktree-removed-before-stop
-  # network leaks get caught. -t 0 skips the default 10s SIGTERM grace
-  # period (user already exited the foreground shell — nothing to drain).
-  # #440: function renamed; behaviour unchanged.
-  run grep -E '_app_cleanup\(\)' /source/script/docker/wrapper/run.sh
-  assert_success
-  run grep -E 'down --remove-orphans -t 0|down -t 0 --remove-orphans' /source/script/docker/wrapper/run.sh
-  assert_success
-}
+# run.sh foreground EXIT-trap cleanup (auto compose-down with
+# --remove-orphans -t 0) is asserted behaviourally in
+# wrapper_compose_dispatch_spec.bats (#490) via the dry-run output, instead
+# of grepping the `_app_cleanup` identifier (renamed in #440).
 
 @test "run.sh non-devel TARGET uses compose up (#458)" {
   # #458: non-devel stages unified to `compose up` so container_name takes


### PR DESCRIPTION
## Summary

Replace the name-coupled `_compose_project` / `_app_cleanup` greps in `template_spec.bats` with behavioural assertions in a new integration spec. Closes #490.

## Why

The old greps asserted that a literal identifier appeared in each wrapper's source. Every internal rename forced them to be updated in lockstep or CI failed — this bit us twice during the v0.40.0 cycle (#480's `_compose_dispatch` shim, #484's `_app_cleanup` rename). A grep also cannot catch a *bypass*: a raw `docker compose ...` added without `-p` would silently use the directory basename as the project name, and the grep would still pass because `_compose_project` appears elsewhere.

## What

New `test/integration/wrapper_compose_dispatch_spec.bats` (6 cases): runs each wrapper (`build` / `run` / `exec` / `stop`) with `--dry-run` and asserts the planned `docker compose -p <project> <verb>`, **including the `-p` flag**. It:

- is immune to internal renames (tests behaviour, not identifiers)
- catches a raw-`docker compose` bypass (the dedicated `no wrapper dispatches compose without -p` case)

Reuses the `fresh_clone_portability_spec.bats` fixture pattern (cp `/source` -> `.base/`, symlink wrappers from the repo root, materialize `.env` + `compose.yaml` via `build.sh --dry-run`). Level-1: docker is never invoked.

`template_spec.bats` drops 7 greps (5 `_compose_project` routing + 2 `_app_cleanup`); the `_load_env` and #458 up-vs-run assertions are out of scope and kept.

This lands first in the queue intentionally: being rename-proof, it protects the later #408 wrapper renames.

## Test plan
- [x] `make -f Makefile.ci test` — 0 failures (ShellCheck + bats unit + integration)
- [x] new spec 6/6 pass; `template_spec.bats` 152 -> 145
- [x] TEST.md + CHANGELOG updated

Closes #490.
