### PR TITLE
docs(readme): add just prerequisite + install guide (4 locales)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Shared template for Docker container repos in the [ycpss91255-docker](https://gi
 ## Table of Contents
 
 - [TL;DR](#tldr)
+- [Prerequisites](#prerequisites)
 - [Overview](#overview)
 - [Quick Start](#quick-start)
 - [CI Reusable Workflows](#ci-reusable-workflows)
@@ -46,6 +47,30 @@ just upgrade         # pull + update version + workflow tag
 make -f Makefile.ci test   # ShellCheck + Bats + Kcov
 just                       # show all recipes
 ```
+
+## Prerequisites
+
+Container operations run through [`just`](https://github.com/casey/just) (the
+command runner) layered on Docker. Install both on the host before using the
+`just <verb>` entry point:
+
+- **Docker** + Docker Compose v2 (`docker compose`).
+- **just** -- any recent release works (the recipes use only variadic
+  parameters, supported since early versions). Install via a package manager
+  or the official installer:
+
+  ```bash
+  apt install just         # Debian 13+ / Ubuntu 24.04+
+  brew install just        # macOS / Linuxbrew
+  cargo install just       # from crates.io
+  # or the official prebuilt-binary installer:
+  curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+      | bash -s -- --to ~/.local/bin
+  ```
+
+  See the [official install guide](https://github.com/casey/just#installation)
+  for every method. If `just` is unavailable each recipe has a raw fallback
+  (`./script/<verb>.sh`, `./.base/upgrade.sh`) -- see [Quick Start](#quick-start).
 
 ## Overview
 

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -18,6 +18,7 @@
 ## 目次
 
 - [TL;DR](#tldr)
+- [前提条件](#前提条件)
 - [概要](#概要)
 - [クイックスタート](#クイックスタート)
 - [CI Reusable Workflows](#ci-reusable-workflows)
@@ -43,9 +44,33 @@ just upgrade-check   # 確認
 just upgrade         # pull + バージョンファイル + workflow tag 更新
 
 # CI 実行
-just test            # ShellCheck + Bats + Kcov
-just                 # 全コマンド表示
+make -f Makefile.ci test   # ShellCheck + Bats + Kcov
+just                       # 全 recipe 表示
 ```
+
+## 前提条件
+
+コンテナ操作は Docker 上で [`just`](https://github.com/casey/just)（command
+runner）を介して実行します。`just <verb>` エントリポイントを使う前に、host へ
+両方をインストールしてください:
+
+- **Docker** + Docker Compose v2（`docker compose`）。
+- **just** -- 近年のどのリリースでも動作します（recipe は variadic
+  パラメータのみ使用、初期バージョンから対応）。パッケージマネージャまたは
+  公式インストーラで導入します:
+
+  ```bash
+  apt install just         # Debian 13+ / Ubuntu 24.04+
+  brew install just        # macOS / Linuxbrew
+  cargo install just       # crates.io から
+  # または公式のビルド済みバイナリインストーラ:
+  curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+      | bash -s -- --to ~/.local/bin
+  ```
+
+  全方式は[公式インストールガイド](https://github.com/casey/just#installation)を
+  参照。`just` が使えない場合、各 recipe には raw fallback
+  （`./script/<verb>.sh`、`./.base/upgrade.sh`）があります -- [クイックスタート](#クイックスタート)参照。
 
 ## 概要
 

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -18,6 +18,7 @@
 ## 目录
 
 - [TL;DR](#tldr)
+- [必要条件](#必要条件)
 - [概述](#概述)
 - [快速开始](#快速开始)
 - [CI Reusable Workflows](#ci-reusable-workflows)
@@ -43,9 +44,31 @@ just upgrade-check   # 检查
 just upgrade         # pull + 更新版本文件 + workflow tag
 
 # 运行 CI
-make test            # ShellCheck + Bats + Kcov
-make help            # 显示所有命令
+make -f Makefile.ci test   # ShellCheck + Bats + Kcov
+just                       # 列出所有 recipe
 ```
+
+## 必要条件
+
+容器操作透过 [`just`](https://github.com/casey/just)（command runner）搭配
+Docker 执行。使用 `just <verb>` 入口前，请先在 host 安装两者：
+
+- **Docker** + Docker Compose v2（`docker compose`）。
+- **just** -- 任何近期版本皆可（recipe 仅用到 variadic 参数，早期版本即支持）。
+  通过包管理器或官方安装程序安装：
+
+  ```bash
+  apt install just         # Debian 13+ / Ubuntu 24.04+
+  brew install just        # macOS / Linuxbrew
+  cargo install just       # 从 crates.io
+  # 或官方预编译 binary 安装程序：
+  curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+      | bash -s -- --to ~/.local/bin
+  ```
+
+  完整方式见[官方安装指南](https://github.com/casey/just#installation)。若
+  `just` 不可用，每个 recipe 都有 raw fallback（`./script/<verb>.sh`、
+  `./.base/upgrade.sh`）-- 见[快速开始](#快速开始)。
 
 ## 概述
 

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -18,6 +18,7 @@
 ## 目錄
 
 - [TL;DR](#tldr)
+- [必要條件](#必要條件)
 - [概述](#概述)
 - [快速開始](#快速開始)
 - [CI Reusable Workflows](#ci-reusable-workflows)
@@ -46,6 +47,28 @@ just upgrade         # pull + 更新版本檔 + workflow tag
 make -f Makefile.ci test   # ShellCheck + Bats + Kcov
 just                       # 列出所有 recipe
 ```
+
+## 必要條件
+
+容器操作透過 [`just`](https://github.com/casey/just)（command runner）搭配
+Docker 執行。使用 `just <verb>` 入口前，請先在 host 安裝兩者：
+
+- **Docker** + Docker Compose v2（`docker compose`）。
+- **just** -- 任何近期版本皆可（recipe 僅用到 variadic 參數，早期版本即支援）。
+  透過套件管理器或官方安裝程式安裝：
+
+  ```bash
+  apt install just         # Debian 13+ / Ubuntu 24.04+
+  brew install just        # macOS / Linuxbrew
+  cargo install just       # 從 crates.io
+  # 或官方預編譯 binary 安裝程式：
+  curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh \
+      | bash -s -- --to ~/.local/bin
+  ```
+
+  完整方式見[官方安裝指南](https://github.com/casey/just#installation)。若
+  `just` 不可用，每個 recipe 都有 raw fallback（`./script/<verb>.sh`、
+  `./.base/upgrade.sh`）-- 見[快速開始](#快速開始)。
 
 ## 概述
 


### PR DESCRIPTION
## Summary

`just` became base's second host-side runtime dependency (after Docker) when
ADR-00000005 replaced the GNU make wrapper in v0.41.0. The READMEs use
`just <verb>` throughout but never told a reader how to obtain `just`. This
adds a short **Prerequisites** section to all four locales pointing at the
official install methods and the upstream guide, and notes the raw-script
fallback for hosts without `just`.

## Changes

- New `## Prerequisites` section (+ TOC entry) in `README.md` and the three
  i18n READMEs (zh-TW / zh-CN / ja): Docker + Docker Compose v2, and `just`
  via `apt` / `brew` / `cargo` / the official `install.sh`, linking
  https://github.com/casey/just#installation. States that any recent `just`
  works (recipes use only variadic params) and that every recipe has a raw
  fallback (`./script/<verb>.sh`, `./.base/upgrade.sh`).
- Aligned two stale TL;DR CI-invocation lines found while editing: zh-CN used
  the retired `make test` / `make help`; ja used a non-existent `just test`
  recipe. Both now match the canonical `make -f Makefile.ci test` + `just`.

## Verification

Usage was checked empirically against `just 1.37.0` (the version baked into
`test-tools:latest`): `*args` variadic + `{{args}}` interpolation, bare `just`
listing recipes, and dash-prefixed passthrough without a `--` separator
(`just build --no-cache test`, `just exec -t cli --/app/k=v`) all behave as the
READMEs document. Doc-only change: CI classifies it as doc-only and skips the
build/test jobs.
