### PR TITLE
feat(conf): opaque read-accessor layer for conf.sh (#564)

### DIFF
--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`conf.sh` opaque accessor interface (#564, architecture deepening)** — new read-side accessor verbs hide `conf.sh`'s internal parallel-array representation and the `<section>.<key>` namespacing rule so callers query setup.conf without knowing the data model: `_conf_load <file> <handle>` tokenizes a file once into a named handle; `_conf_get <handle> <section> <key> [default]` returns a value (last occurrence wins) or the default; `_conf_sections <handle>` lists section names in first-appearance order; `_conf_list <handle> <section>` lists a section's keys in file order (for iterating list sections like `volumes mount_*` / `environment env_*`). The existing `_ini_tokenize` / `_parse_ini_section` / `_load_setup_conf_full` readers are unchanged (the accessors are a thin opaque layer over the tokenizer). Caller adoption lands incrementally starting with the resolved-config seam (#563), which restructures the prime adoption site (`_resolve_deploy_context`) — migrating those call sites now would be churn #563 immediately rewrites. Unit-tested in `test/unit/conf_accessor_spec.bats`. Refs #564, #563.
+
 ## [v0.41.0] - 2026-06-10
 
 ### Added

--- a/doc/test/TEST.md
+++ b/doc/test/TEST.md
@@ -791,7 +791,7 @@ skipped, ipc `private` skipped) and the deliberate omissions
 | `_setup_deploy: --stage selects the target stage` | stage select |
 | `main deploy routes to _setup_deploy` | dispatch wiring |
 
-### test/unit/compose_logging_spec.bats (32)
+### test/unit/compose_logging_spec.bats (17)
 
 Covers `[logging]` + `[logging.<svc>]` support in
 `generate_compose_yaml` (#310). Tests the global emission on every
@@ -1224,7 +1224,15 @@ must not be reported as "needing downgrade").
 | `_get_latest_version: empty result feeds _check's 'Could not fetch' guard` | Empty result still surfaces real fetch failures |
 | `_upgrade refuses to downgrade from a newer local version` | Implicit-downgrade guard |
 
-### test/unit/gitignore_spec.bats (16)
+### test/unit/conf_accessor_spec.bats (3)
+
+Unit tests for the `conf.sh` opaque accessor interface (#564): `_conf_load`
+loads a file into a named handle, `_conf_get` reads a value by (section, key)
+with an optional default, `_conf_sections` lists section names, and `_conf_list`
+lists a section's keys -- all without callers touching the internal
+parallel-array representation or the `<section>.<key>` namespacing rule.
+
+### test/unit/gitignore_spec.bats (26)
 
 Unit tests for `template/script/docker/lib/gitignore.sh` — the canonical
 `.gitignore` set + sync/untrack helpers introduced for issue #172.

--- a/script/docker/lib/conf.sh
+++ b/script/docker/lib/conf.sh
@@ -239,6 +239,22 @@ _conf_sections() {
   done
 }
 
+# _conf_list <handle> <section>
+#
+# Echo the keys present in <section> from <handle>, one per line, in file
+# order (duplicates preserved). Empty output for an absent section. Use to
+# iterate list-style sections (e.g. volumes `mount_*`, environment `env_*`).
+_conf_list() {
+  local _h="${1:?"${FUNCNAME[0]}: missing handle"}"
+  local _sec="${2:?"${FUNCNAME[0]}: missing section"}"
+  local -n _ls_es="${_h}__es" _ls_k="${_h}__keys"
+  local _ls_i
+  for (( _ls_i = 0; _ls_i < ${#_ls_k[@]}; _ls_i++ )); do
+    [[ "${_ls_es[_ls_i]}" == "${_sec}" ]] && printf '%s\n' "${_ls_k[_ls_i]}"
+  done
+  return 0
+}
+
 # ════════════════════════════════════════════════════════════════════
 # INI writer (comment-preserving)
 # ════════════════════════════════════════════════════════════════════

--- a/script/docker/lib/conf.sh
+++ b/script/docker/lib/conf.sh
@@ -185,6 +185,48 @@ _parse_ini_section() {
 }
 
 # ════════════════════════════════════════════════════════════════════
+# Opaque accessor interface (#564)
+# ════════════════════════════════════════════════════════════════════
+#
+# Callers load a file once into a named handle and query it by
+# (section, key) via the accessor verbs below, without touching the
+# parallel-array representation or the `<section>.<key>` namespacing rule.
+# A "handle" is just a name prefix; _conf_load creates the backing global
+# arrays (`<handle>__es` / `<handle>__keys` / `<handle>__vals` +
+# `<handle>__sects`) so the accessors can find them by prefix.
+
+# _conf_load <file> <handle>
+#
+# Tokenize <file> once into the global arrays backing <handle>. Safe to
+# call on a missing file (yields an empty handle).
+_conf_load() {
+  local _file="${1:?"${FUNCNAME[0]}: missing file"}"
+  local _h="${2:?"${FUNCNAME[0]}: missing handle"}"
+  declare -g -a "${_h}__sects=()" "${_h}__es=()" "${_h}__keys=()" "${_h}__vals=()"
+  local -n _cl_s="${_h}__sects" _cl_es="${_h}__es" _cl_k="${_h}__keys" _cl_v="${_h}__vals"
+  _ini_tokenize "${_file}" _cl_s _cl_es _cl_k _cl_v
+}
+
+# _conf_get <handle> <section> <key> [default]
+#
+# Echo the value for <section>.<key> from <handle>, or [default] (empty
+# if omitted) when absent. Last occurrence wins (override semantics).
+_conf_get() {
+  local _h="${1:?"${FUNCNAME[0]}: missing handle"}"
+  local _sec="${2:?"${FUNCNAME[0]}: missing section"}"
+  local _key="${3:?"${FUNCNAME[0]}: missing key"}"
+  local _def="${4-}"
+  local -n _cg_es="${_h}__es" _cg_k="${_h}__keys" _cg_v="${_h}__vals"
+  local _cg_i _cg_val="${_def}"
+  for (( _cg_i = 0; _cg_i < ${#_cg_k[@]}; _cg_i++ )); do
+    if [[ "${_cg_es[_cg_i]}" == "${_sec}" && "${_cg_k[_cg_i]}" == "${_key}" ]]; then
+      _cg_val="${_cg_v[_cg_i]}"
+    fi
+  done
+  printf '%s\n' "${_cg_val}"
+}
+
+# ════════════════════════════════════════════════════════════════════
 # INI writer (comment-preserving)
 # ════════════════════════════════════════════════════════════════════
 

--- a/script/docker/lib/conf.sh
+++ b/script/docker/lib/conf.sh
@@ -226,6 +226,19 @@ _conf_get() {
   printf '%s\n' "${_cg_val}"
 }
 
+# _conf_sections <handle>
+#
+# Echo the handle's section names (deduped, first-appearance order), one
+# per line.
+_conf_sections() {
+  local _h="${1:?"${FUNCNAME[0]}: missing handle"}"
+  local -n _cs_s="${_h}__sects"
+  local _cs_i
+  for (( _cs_i = 0; _cs_i < ${#_cs_s[@]}; _cs_i++ )); do
+    printf '%s\n' "${_cs_s[_cs_i]}"
+  done
+}
+
 # ════════════════════════════════════════════════════════════════════
 # INI writer (comment-preserving)
 # ════════════════════════════════════════════════════════════════════

--- a/test/unit/conf_accessor_spec.bats
+++ b/test/unit/conf_accessor_spec.bats
@@ -32,3 +32,11 @@ teardown() {
   assert_success
   assert_output "auto"
 }
+
+@test "_conf_sections lists section names in first-appearance order" {
+  _conf_load "${FIX}" H
+  run _conf_sections H
+  assert_success
+  assert_line --index 0 "deploy"
+  assert_line --index 1 "network"
+}

--- a/test/unit/conf_accessor_spec.bats
+++ b/test/unit/conf_accessor_spec.bats
@@ -40,3 +40,11 @@ teardown() {
   assert_line --index 0 "deploy"
   assert_line --index 1 "network"
 }
+
+@test "_conf_list lists a section's keys in file order" {
+  _conf_load "${FIX}" H
+  run _conf_list H deploy
+  assert_success
+  assert_line --index 0 "gpu_runtime"
+  assert_line --index 1 "gpu_count"
+}

--- a/test/unit/conf_accessor_spec.bats
+++ b/test/unit/conf_accessor_spec.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+#
+# Unit tests for the conf.sh opaque accessor interface (#564).
+#
+# The accessor verbs (_conf_load / _conf_get / _conf_list / _conf_sections)
+# hide conf.sh's internal parallel-array + namespacing representation: callers
+# load a handle once and query it by (section, key) without touching arrays.
+
+setup() {
+  load "${BATS_TEST_DIRNAME}/test_helper"
+  # shellcheck source=script/docker/lib/conf.sh
+  # shellcheck disable=SC1091
+  source /source/script/docker/lib/conf.sh
+  FIX="$(mktemp)"
+  cat > "${FIX}" <<'EOF'
+[deploy]
+gpu_runtime = auto
+gpu_count = 2
+
+[network]
+net = host
+EOF
+}
+
+teardown() {
+  rm -f "${FIX}"
+}
+
+@test "_conf_get returns a value by section and key" {
+  _conf_load "${FIX}" H
+  run _conf_get H deploy gpu_runtime
+  assert_success
+  assert_output "auto"
+}


### PR DESCRIPTION
## Summary

Introduces the opaque **read-accessor layer** for `conf.sh` (#564, architecture
deepening) so callers can query `setup.conf` without touching the internal
parallel-array representation or the `<section>.<key>` namespacing rule.

## What landed

New accessor verbs in `script/docker/lib/conf.sh` (a thin opaque layer over the
existing `_ini_tokenize`; readers/writers unchanged):

- `_conf_load <file> <handle>` — tokenize once into a named handle.
- `_conf_get <handle> <section> <key> [default]` — value (last occurrence wins) or default.
- `_conf_sections <handle>` — section names, first-appearance order.
- `_conf_list <handle> <section>` — a section's keys, file order.

Strict TDD: each verb is a RED→GREEN pair (`test/unit/conf_accessor_spec.bats`,
3 tests). Full gate (`make -f Makefile.ci test`) green; conf.sh ShellCheck clean.

## Decision / scope (why this is layer-only, not the full caller migration)

#564's end state is "callers stop knowing the representation". The prime
adopters are the ~12 `_load_setup_conf` + value-lookup sites in
`_resolve_deploy_context` — which is **exactly the code the resolved-config seam
(#563) restructures** (resolve once into a canonical array). Migrating those
call sites now and having #563 rewrite them immediately would be wasted churn.

So this PR delivers the **deep module** (the accessor interface + tests); caller
adoption lands incrementally, starting with #563 (which will consume these
accessors internally), making the seam real. **Refs #564 (not Closes)** — #564
stays open tracking the migration, folded into #563.

## Doc-sync

- `TEST.md`: new `conf_accessor_spec.bats (3)` section; fixed two pre-existing
  stale counts surfaced by the drift check (`compose_logging` 32→17,
  `gitignore` 16→26).
- `CHANGELOG.md` `[Unreleased]`.

Refs #564, #563.
