### PR TITLE
docs(readme): refresh all 4 locales for the namespace command model + downstream layout (#656)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Shared template for Docker container repos in the [ycpss91255-docker](https://gi
 ## TL;DR
 
 ```bash
-# New repo from scratch: init + first commit + subtree + init.sh
+# New repo from scratch: first commit + subtree + one-time bootstrap
 mkdir <repo_name> && cd <repo_name>
 git init
 git commit --allow-empty -m "chore: initial commit"
@@ -70,7 +70,8 @@ command runner) layered on Docker. Install both on the host before using the
 
   See the [official install guide](https://github.com/casey/just#installation)
   for every method. If `just` is unavailable each recipe has a raw fallback
-  (`./script/<verb>.sh`, `./.base/upgrade.sh`) -- see [Quick Start](#quick-start).
+  (`./script/<verb>.sh`, `./.base/downstream/script/base/upgrade.sh`) -- see
+  [Quick Start](#quick-start).
 
 ## Overview
 
@@ -81,22 +82,22 @@ This repo consolidates shared scripts, tests, and CI workflows used across all D
 ```mermaid
 graph TB
     subgraph base["base (shared repo)"]
-        scripts[".hadolint.yaml / script/test/justfile.test / compose.yaml"]
-        smoke["test/smoke/<br/>script_help.bats<br/>display_env.bats"]
-        config["config/<br/>bashrc / tmux / terminator / pip"]
-        mgmt["script/docker/<br/>build.sh / run.sh / exec.sh / stop.sh / setup.sh"]
+        scripts["downstream/.hadolint.yaml<br/>downstream/script/justfile (consumer entry)<br/>downstream/script/docker|base|template/"]
+        smoke["downstream/test/smoke/<br/>script_help.bats<br/>display_env.bats"]
+        config["downstream/config/<br/>bashrc / tmux / terminator"]
+        mgmt["downstream/script/docker/wrapper/<br/>build.sh / run.sh / exec.sh / stop.sh / setup.sh"]
         workflows["Reusable Workflows<br/>build-worker.yaml<br/>release-worker.yaml<br/>publish-worker.yaml (opt-in)"]
     end
 
     subgraph consumer["Docker Repo (e.g. ros_noetic)"]
-        symlinks["justfile → .base/script/docker/justfile<br/>build.sh → .base/downstream/script/docker/wrapper/build.sh<br/>run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
-        dockerfile["Dockerfile<br/>compose.yaml<br/>script/entrypoint.sh"]
+        symlinks["justfile → script/justfile → .base/downstream/script/justfile<br/>script/docker|base|template/ → .base/downstream/script/.../ (per-sub symlinks)<br/>script/build.sh → .base/downstream/script/docker/wrapper/build.sh<br/>run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
+        dockerfile["Dockerfile<br/>compose.yaml<br/>script/entrypoint.sh<br/>script/local/justfile.local (repo-owned)"]
         repo_test["test/smoke/<br/>app_env.bats (repo-specific)"]
         main_yaml["main.yaml<br/>→ calls reusable workflows"]
     end
 
     base -- "git subtree" --> consumer
-    scripts -. symlink .-> symlinks
+    scripts -. "per-sub symlink" .-> symlinks
     smoke -. "Dockerfile COPY" .-> repo_test
     workflows -. "@tag reference" .-> main_yaml
 ```
@@ -106,14 +107,14 @@ graph TB
 ```mermaid
 flowchart LR
     subgraph local["Local"]
-        build_test["./build.sh test"]
-        make_test["just docker build test"]
+        just_test["just test"]
+        just_build["just docker build --stage test-tools"]
     end
 
     subgraph ci_container["CI Container (ghcr.io/ycpss91255-docker/test-tools:latest)"]
         shellcheck["ShellCheck"]
-        hadolint["Hadolint"]
-        bats["Bats smoke tests"]
+        hadolint["Hadolint (just test lint)"]
+        bats["Bats specs"]
     end
 
     subgraph github["GitHub Actions"]
@@ -121,12 +122,12 @@ flowchart LR
         release_worker["release-worker.yaml<br/>(from template)"]
     end
 
-    build_test --> ci_container
-    make_test -->|"script/test/test.sh"| ci_container
+    just_build --> ci_container
+    just_test -->|"script/test/test.sh"| ci_container
     shellcheck --> hadolint --> bats
 
     push["git push / PR"] --> build_worker
-    build_worker -->|"docker build test"| ci_container
+    build_worker -->|"docker build (devel-test stage)"| ci_container
     tag["git tag v*"] --> release_worker
     release_worker -->|"tar.gz + zip"| release["GitHub Release"]
 ```
@@ -158,25 +159,31 @@ flowchart LR
 | `downstream/script/docker/runtime/logging.sh` | Host-side log tee helper |
 | `downstream/script/docker/runtime/smoke.sh` | Runtime install-check smoke |
 | `downstream/script/docker/runtime/entrypoint.sh` | Template entrypoint helper |
-| `script/test/test.sh` | CI orchestration (local + remote) |
+| `script/test/test.sh` | base self-test dispatcher (local + in-container) |
+| `script/test/drivers/` | One driver per tool — `bats.sh` / `shellcheck.sh` / `hadolint.sh` |
 | `script/test/lint_bare_stderr.sh` | Bare stderr lint checker |
-| `script/test/lint_mixed_test_layout.sh` | Mixed-tool test layout validator |
 | `config/` | Container-internal shell configs (bashrc, tmux, terminator) |
 | `setup.conf` | Single per-repo runtime configuration (image / build / deploy / gui / network / volumes) |
-| `test/smoke/` | Shared smoke tests + runtime assertion helpers (see below) |
-| `test/unit/` | Template self-tests (bats + kcov) |
-| `test/integration/` | Level-1 `init.sh` end-to-end tests |
+| `downstream/test/smoke/` | Shared smoke tests + runtime assertion helpers (see below) |
+| `test/bats/unit/` | base self-tests, unit (bats + kcov) |
+| `test/bats/integration/` | base self-tests, init/upgrade end-to-end |
+| `test/bats/behavioural/` | base self-tests, runtime behaviour (opt-in) |
 
-Multi-tool downstream repos (e.g. `.bats` + `pytest` in one category)
-segregate by a `<tool>` subdir -- `test/<category>/<tool>/` (e.g.
-`test/smoke/bats/`, `test/smoke/pytest/`). Single-tool repos stay flat.
-See [ADR-00000004](doc/adr/00000004-test-category-tool-subdir-layout.md).
+Test content is laid out **tool-first** -- `test/<tool>/<category>/`
+for specs (e.g. `test/bats/unit/`) and `test/lint/<tool>/` for linters --
+so adding a tool is a new folder, not a new command surface. See
+[ADR-00000012](doc/adr/00000012-tool-first-test-layout.md) (supersedes the
+category-first ADR-00000004). A consumer ships its own `test/smoke/`; base
+ships its own `test/bats/{unit,integration,behavioural}/`.
 
 | `.hadolint.yaml` | Shared Hadolint rules |
-| `justfile` | Repo entry — `just <verb>` recipes (`just docker build`, `just docker run`, `just docker stop`, etc.). Sub-cmds and flags pass straight through as `{{args}}` (`just docker build --no-cache test`); `just` with no recipe lists all recipes. |
-| `script/test/justfile.test` | Template CI entry (`just test`, `just test lint`, etc.). The user-facing vs CI-facing split is intentional. |
-| `init.sh` | First-time symlink setup + new-repo scaffolding |
-| `upgrade.sh` | Subtree version upgrade |
+| `justfile` (→ `script/justfile`) | Repo entry — layered namespaced recipes (`just docker build`, `just docker run`, `just test`, `just base upgrade`, etc.). Sub-cmds and flags pass straight through as `{{args}}` (`just docker build --no-cache --stage test-tools`); bare `just` lists all namespaces. |
+| `downstream/script/docker/justfile.docker` | `docker` namespace — container ops (`just docker build/run/exec/stop/prune/setup/setup-tui`). |
+| `downstream/script/base/justfile.base` | `base` namespace — manage the `.base` subtree (`just base init/update/upgrade/completions`). |
+| `downstream/script/base/init.sh` | First-time symlink setup + new-repo scaffolding (bootstrap: `./.base/downstream/script/base/init.sh`; thereafter `just base init`). |
+| `downstream/script/base/upgrade.sh` | Subtree version upgrade (`just base upgrade [vX.Y.Z]`). |
+| `script/test/justfile.test` | base self-test entry (`just test`, `just test lint`, `just test coverage`, …). |
+| `script/release/justfile.release` | base `release` namespace (release / publish tooling). |
 | `downstream/dockerfile/Dockerfile` | Multi-stage Dockerfile template for new repos |
 | `dockerfile/Dockerfile.test-tools` | Pre-built lint/test tools image (shellcheck, hadolint, bats, bats-mock) |
 | `.github/workflows/` | Reusable CI workflows (build + release) |
@@ -828,8 +835,9 @@ git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=.base \
     https://github.com/ycpss91255-docker/base.git vX.Y.Z --squash
 
-# 3. Initialize symlinks (one command; runs setup.sh under the hood)
-./.base/init.sh
+# 3. Initialize symlinks (one-time bootstrap; runs setup.sh under the hood).
+#    Thereafter use `just base init` (the symlinked entry).
+./.base/downstream/script/base/init.sh
 ```
 
 > `git subtree add` requires `HEAD` to exist. On a freshly `git init`-ed repo with no commits, it fails with `ambiguous argument 'HEAD'` and `working tree has modifications`. The empty commit creates `HEAD` so subtree can merge into it.
@@ -854,7 +862,7 @@ just base upgrade v0.3.0
 # per SemVer §11. Edit .base/.version manually if intentional.
 
 # Fallback if just is unavailable
-./.base/upgrade.sh v0.3.0
+./.base/downstream/script/base/upgrade.sh v0.3.0
 ```
 
 `upgrade.sh` handles the full cycle in one go:
@@ -1022,145 +1030,80 @@ See [TEST.md](doc/test/TEST.md) for details.
 ## Directory Structure
 
 ```
-.base/
-├── init.sh                           # Initialize repo (new or existing)
-├── upgrade.sh                        # Upgrade template subtree version
-├── script/
-│   ├── docker/                       # Docker operation scripts
-│   │   ├── wrapper/                  # User-facing wrapper scripts
-│   │   │   ├── build.sh
-│   │   │   ├── run.sh
-│   │   │   ├── exec.sh
-│   │   │   ├── stop.sh
-│   │   │   ├── prune.sh
-│   │   │   ├── setup.sh              # .env generator
-│   │   │   └── setup_tui.sh          # Interactive setup editor
-│   │   ├── lib/                      # Shared helper modules
-│   │   │   ├── _lib.sh               # Core wrappers library
-│   │   │   ├── bootstrap.sh          # Wrapper initialization
-│   │   │   ├── compose.sh            # Compose generation
-│   │   │   ├── conf.sh               # INI parser
-│   │   │   ├── conf_logging.sh       # Logging config
-│   │   │   ├── env.sh                # Environment setup
-│   │   │   ├── gitignore.sh          # Gitignore management
-│   │   │   ├── hook.sh               # Per-wrapper hooks
-│   │   │   ├── i18n.sh               # Language detection
-│   │   │   ├── log.sh                # Logging utilities
-│   │   │   ├── config_summary.sh     # Config summary
-│   │   │   ├── _tui_backend.sh       # TUI dialog/whiptail wrapper
-│   │   │   ├── _tui_conf.sh          # TUI INI validators
-│   │   │   ├── log-events.txt        # Log event catalog
-│   │   │   ├── log.lnav-format.json  # Lnav format (JSON *.jsonl)
-│   │   │   ├── transcript.sh         # Wrapper transcript capture
-│   │   │   └── transcript.lnav-format.json  # Lnav format (transcript)
-│   │   ├── runtime/                  # Runtime in-container scripts
-│   │   │   ├── entrypoint.sh         # Template entrypoint helper
-│   │   │   ├── logging.sh            # Host-side log tee helper
-│   │   │   └── smoke.sh              # Runtime install-check smoke
-│   │   ├── justfile                  # Docker operations entry (just)
-│   │   └── setup.conf                # Template runtime config defaults
-│   └── ci/                           # CI pipeline scripts
-│       ├── test.sh                     # CI orchestration (local + remote)
-│       ├── lint_bare_stderr.sh       # Bare stderr lint checker
-│       └── lint_mixed_test_layout.sh # Mixed-tool test layout validator
-├── dockerfile/
-│   ├── Dockerfile            # Multi-stage template (sys / devel-base / devel / devel-test / [runtime-base / runtime / runtime-test])
-│   └── Dockerfile.test-tools         # Pre-built lint/test tools image
-├── config/                           # Container-internal shell/tool configs
-│   ├── docker/
-│   │   └── setup.conf                # Runtime config (per-repo override mirror: <repo>/config/docker/setup.conf)
-│   └── shell/
-│       ├── bashrc
-│       ├── bashrc.d/                 # Interactive shell bootstrap drop-ins
-│       │   └── .gitkeep
-│       ├── terminator/
-│       │   ├── setup.sh
-│       │   └── config
-│       └── tmux/
-│           ├── setup.sh
-│           ├── README.adoc
-│           └── tmux.conf
-├── test/
-│   ├── smoke/                        # Shared smoke tests + runtime assertion helpers
-│   │   ├── test_helper.bash          # assert_cmd_installed / _runs / file / dir / owned_by / pip_pkg
-│   │   ├── script_help.bats
-│   │   └── display_env.bats
-│   ├── unit/                         # Template self-tests (bats + kcov)
-│   │   ├── test_helper.bash
-│   │   ├── bashrc_spec.bats
-│   │   ├── build_sh_spec.bats
-│   │   ├── build_sh_prune_spec.bats
-│   │   ├── build_worker_yaml_spec.bats
-│   │   ├── ci_spec.bats
-│   │   ├── compose_gen_spec.bats
-│   │   ├── compose_logging_spec.bats
-│   │   ├── compose_overlay_spec.bats
-│   │   ├── conf_logging_spec.bats
-│   │   ├── deploy_spec.bats
-│   │   ├── entrypoint_logging_spec.bats
-│   │   ├── exec_sh_spec.bats
-│   │   ├── gitignore_spec.bats
-│   │   ├── hook_spec.bats
-│   │   ├── init_spec.bats
-│   │   ├── lib_spec.bats
-│   │   ├── lint_mixed_test_layout_spec.bats
-│   │   ├── log_spec.bats
-│   │   ├── makefile_user_spec.bats
-│   │   ├── multi_distro_build_worker_yaml_spec.bats
-│   │   ├── prune_sh_spec.bats
-│   │   ├── release_test_tools_yaml_spec.bats
-│   │   ├── run_sh_spec.bats
-│   │   ├── runtime_smoke_spec.bats
-│   │   ├── self_test_yaml_spec.bats
-│   │   ├── setup_spec.bats
-│   │   ├── smoke_helper_spec.bats
-│   │   ├── stop_sh_spec.bats
-│   │   ├── template_spec.bats
-│   │   ├── terminator_config_spec.bats
-│   │   ├── terminator_setup_spec.bats
-│   │   ├── tmux_conf_spec.bats
-│   │   ├── tmux_setup_spec.bats
-│   │   ├── tui_backend_spec.bats
-│   │   ├── tui_flow.bats
-│   │   ├── tui_mount_assembler_spec.bats
-│   │   ├── tui_spec.bats
-│   │   ├── upgrade_spec.bats
-│   │   └── wrapper_lib_lookup_spec.bats
-│   ├── integration/                  # Level-1 init.sh end-to-end tests
-│   │   ├── init_new_repo_spec.bats
-│   │   ├── upgrade_spec.bats
-│   │   ├── fresh_clone_portability_spec.bats
-│   │   ├── gitignore_sync_spec.bats
-│   │   └── wrapper_compose_dispatch_spec.bats
-│   └── behavioural/                  # Runtime integration tests
-│       └── runtime_test_smoke_spec.bats
-├── script/test/justfile.test                       # Template CI entry (just test/lint/...)
-├── compose.yaml                      # Docker CI runner
-├── .hadolint.yaml                    # Shared Hadolint rules
-├── .dockerignore
-├── codecov.yml
-├── .github/workflows/
-│   ├── self-test.yaml                # Template CI
-│   ├── build-worker.yaml             # Reusable build + smoke-test workflow
-│   ├── release-worker.yaml           # Reusable release (source archive) workflow
-│   ├── publish-worker.yaml           # Reusable image publish workflow (opt-in)
-│   ├── multi-distro-build-worker.yaml # Multi-distro build workflow
-│   └── release-test-tools.yaml       # Template's own test-tools image release
-├── doc/
-│   ├── readme/                       # README translations
-│   │   ├── README.zh-TW.md
-│   │   ├── README.zh-CN.md
-│   │   └── README.ja.md
-│   ├── adr/                          # Architecture Decision Records
-│   │   ├── 00000001-setup-conf-vs-compose.md
-│   │   ├── 00000002-no-latest-tag.md
-│   │   ├── 00000003-env-vs-workload-param-boundary.md
-│   │   └── 00000004-test-category-tool-subdir-layout.md
+.base/                                  # subtree pinned in a consumer at <repo>/.base/
+├── .version                            # Pinned base release tag
+├── justfile                            # base's OWN self-test/release entry (mods test + release)
+├── compose.yaml                        # base CI runner (test-tools services)
+├── .dockerignore                       # Canonical ignore set (synced into consumers)
+├── .codecov.yaml                       # Coverage upload config
+├── downstream/                         # SHIPPED tooling + content (single source of truth)
+│   ├── .hadolint.yaml                  # Shared Hadolint rules (symlinked into consumers)
+│   ├── dockerfile/
+│   │   └── Dockerfile                  # Multi-stage Dockerfile template for new repos
+│   ├── config/                         # Container-internal shell/tool configs
+│   │   ├── docker/
+│   │   │   └── setup.conf              # Template runtime-config default
+│   │   └── shell/
+│   │       ├── bashrc
+│   │       ├── bashrc.d/               # Interactive shell bootstrap drop-ins
+│   │       ├── terminator/             # setup.sh + config
+│   │       └── tmux/                   # setup.sh + tmux.conf + README.adoc
+│   ├── script/                         # Generic tooling (consumers symlink per-sub)
+│   │   ├── justfile                    # Consumer container-ops entry (mods docker/base/template)
+│   │   ├── docker/                     # `docker` namespace
+│   │   │   ├── justfile.docker         # just docker build/run/exec/stop/prune/setup/setup-tui
+│   │   │   ├── wrapper/                # build.sh / run.sh / exec.sh / stop.sh / prune.sh
+│   │   │   │                           #   / setup.sh / setup_tui.sh
+│   │   │   ├── lib/                    # Shared helper modules (_lib / compose / conf / log
+│   │   │   │                           #   / i18n / hook / wrapper / schema / transcript / ...)
+│   │   │   └── runtime/                # In-container: entrypoint.sh / logging.sh / smoke.sh
+│   │   ├── base/                       # `base` namespace (manage the .base subtree)
+│   │   │   ├── justfile.base           # just base init/update/upgrade/completions
+│   │   │   ├── init.sh                 # First-time bootstrap + symlink/.gitignore resync
+│   │   │   ├── upgrade.sh              # Subtree version upgrade (walks up to .base root)
+│   │   │   └── completions.sh          # Opt-in shell tab-completion installer
+│   │   └── template/                   # `template` namespace (scaffold repo-local groups)
+│   │       ├── justfile.template       # just template new <name>
+│   │       ├── new.sh
+│   │       └── skel/                   # justfile.skel + skel.sh
+│   └── test/
+│       └── smoke/                      # Shared smoke tests + runtime assertion helpers
+│           ├── test_helper.bash        #   assert_cmd_installed / _runs / file / dir / ...
+│           ├── script_help.bats
+│           └── display_env.bats
+├── script/                             # base's OWN self-test/release tooling (not symlinked)
 │   ├── test/
-│   │   └── TEST.md                   # Test catalog and spec tables
+│   │   ├── justfile.test               # just test / lint / coverage / behavioural
+│   │   ├── test.sh                     # Dispatcher (local + in-container)
+│   │   ├── lint_bare_stderr.sh
+│   │   └── drivers/                    # One driver per tool: bats.sh / shellcheck.sh / hadolint.sh
+│   └── release/
+│       └── justfile.release            # just release <recipe>
+├── dockerfile/
+│   └── Dockerfile.test-tools           # Pre-built lint/test tools image (shellcheck/hadolint/bats)
+├── test/                               # base's OWN specs (tool-first: test/<tool>/<category>/)
+│   └── bats/
+│       ├── unit/                       # 58 unit specs + test_helper.bash (bats + kcov)
+│       ├── integration/                # init/upgrade end-to-end (5 specs)
+│       └── behavioural/                # Runtime behaviour (opt-in; runtime_test_smoke_spec.bats)
+├── .github/
+│   ├── dependabot.yml
+│   └── workflows/
+│       ├── self-test.yaml              # base CI (ShellCheck + Bats + Kcov coverage gate)
+│       ├── build-worker.yaml           # Reusable build + smoke-test workflow
+│       ├── release-worker.yaml         # Reusable release (source archive) workflow
+│       ├── publish-worker.yaml         # Reusable image publish workflow (opt-in)
+│       ├── multi-distro-build-worker.yaml # Multi-distro build workflow
+│       └── release-test-tools.yaml     # base's own test-tools image release
+├── doc/
+│   ├── readme/                         # README translations (zh-TW / zh-CN / ja)
+│   ├── adr/                            # Architecture Decision Records (00000001 … 00000012)
+│   ├── test/
+│   │   └── TEST.md                     # Test catalog and spec tables
 │   ├── changelog/
-│   │   └── CHANGELOG.md              # Release notes
+│   │   └── CHANGELOG.md
 │   └── deprecations.md
+├── CONTEXT.md
 ├── .gitignore
 ├── LICENSE
 └── README.md

--- a/README.md
+++ b/README.md
@@ -1083,7 +1083,7 @@ See [TEST.md](doc/test/TEST.md) for details.
 │   └── Dockerfile.test-tools           # Pre-built lint/test tools image (shellcheck/hadolint/bats)
 ├── test/                               # base's OWN specs (tool-first: test/<tool>/<category>/)
 │   └── bats/
-│       ├── unit/                       # 58 unit specs + test_helper.bash (bats + kcov)
+│       ├── unit/                       # 56 unit specs + 2 bash helpers (bats + kcov)
 │       ├── integration/                # init/upgrade end-to-end (5 specs)
 │       └── behavioural/                # Runtime behaviour (opt-in; runtime_test_smoke_spec.bats)
 ├── .github/

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -31,13 +31,13 @@
 ## TL;DR
 
 ```bash
-# ゼロからの新規 repo：init + 初回コミット + subtree + init.sh
+# ゼロからの新規 repo：初回コミット + subtree + 初回ブートストラップ
 mkdir <repo_name> && cd <repo_name>
 git init
 git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=.base \
     https://github.com/ycpss91255-docker/base.git v0.30.0 --squash
-./.base/init.sh
+./.base/downstream/script/base/init.sh
 
 # 最新版にアップグレード
 just base update   # 確認
@@ -70,7 +70,8 @@ runner）を介して実行します。`just <verb>` エントリポイントを
 
   全方式は[公式インストールガイド](https://github.com/casey/just#installation)を
   参照。`just` が使えない場合、各 recipe には raw fallback
-  （`./script/<verb>.sh`、`./.base/upgrade.sh`）があります -- [クイックスタート](#クイックスタート)参照。
+  （`./script/<verb>.sh`、`./.base/downstream/script/base/upgrade.sh`）があります
+  -- [クイックスタート](#クイックスタート)参照。
 
 ## 概要
 
@@ -81,22 +82,22 @@ runner）を介して実行します。`just <verb>` エントリポイントを
 ```mermaid
 graph TB
     subgraph base["base（共有 repo）"]
-        scripts[".hadolint.yaml / script/test/justfile.test / compose.yaml"]
-        smoke["test/smoke/<br/>script_help.bats<br/>display_env.bats"]
-        config["config/<br/>bashrc / tmux / terminator / pip"]
+        scripts["downstream/.hadolint.yaml<br/>downstream/script/justfile（consumer エントリ）<br/>downstream/script/docker|base|template/"]
+        smoke["downstream/test/smoke/<br/>script_help.bats<br/>display_env.bats"]
+        config["downstream/config/<br/>bashrc / tmux / terminator"]
         mgmt["downstream/script/docker/wrapper/<br/>build.sh / run.sh / exec.sh / stop.sh / setup.sh"]
         workflows["再利用可能な Workflows<br/>build-worker.yaml<br/>release-worker.yaml"]
     end
 
     subgraph consumer["Docker Repo（例: my_app）"]
-        symlinks["justfile → .base/script/docker/justfile<br/>build.sh → .base/downstream/script/docker/wrapper/build.sh<br/>run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
-        dockerfile["Dockerfile<br/>compose.yaml<br/>script/entrypoint.sh"]
+        symlinks["justfile → script/justfile → .base/downstream/script/justfile<br/>script/docker|base|template/ → .base/downstream/script/.../（per-sub symlink）<br/>script/build.sh → .base/downstream/script/docker/wrapper/build.sh<br/>run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
+        dockerfile["Dockerfile<br/>compose.yaml<br/>script/entrypoint.sh<br/>script/local/justfile.local（repo 所有）"]
         repo_test["test/smoke/<br/>app_env.bats（repo 固有）"]
         main_yaml["main.yaml<br/>→ 再利用可能な workflows を呼び出し"]
     end
 
     base -- "git subtree" --> consumer
-    scripts -. "symlink" .-> symlinks
+    scripts -. "per-sub symlink" .-> symlinks
     smoke -. "Dockerfile COPY" .-> repo_test
     workflows -. "@tag 参照" .-> main_yaml
 ```
@@ -106,14 +107,14 @@ graph TB
 ```mermaid
 flowchart LR
     subgraph local["ローカル"]
-        build_test["./build.sh test"]
-        make_test["just docker build test"]
+        just_test["just test"]
+        just_build["just docker build --stage test-tools"]
     end
 
     subgraph ci_container["CI コンテナ（ghcr.io/ycpss91255-docker/test-tools:latest）"]
         shellcheck["ShellCheck"]
-        hadolint["Hadolint"]
-        bats["Bats smoke tests"]
+        hadolint["Hadolint（just test lint）"]
+        bats["Bats specs"]
     end
 
     subgraph github["GitHub Actions"]
@@ -121,12 +122,12 @@ flowchart LR
         release_worker["release-worker.yaml<br/>（base より）"]
     end
 
-    build_test --> ci_container
-    make_test -->|"script/test/test.sh"| ci_container
+    just_build --> ci_container
+    just_test -->|"script/test/test.sh"| ci_container
     shellcheck --> hadolint --> bats
 
     push["git push / PR"] --> build_worker
-    build_worker -->|"docker build test"| ci_container
+    build_worker -->|"docker build（devel-test stage）"| ci_container
     tag["git tag v*"] --> release_worker
     release_worker -->|"tar.gz + zip"| release["GitHub Release"]
 ```
@@ -160,17 +161,30 @@ flowchart LR
 | `downstream/script/docker/runtime/entrypoint.sh` | テンプレート entrypoint helper |
 | `config/` | コンテナ内部のシェル設定ファイル（bashrc、tmux、terminator、pip） |
 | `setup.conf` | 単一の repo ランタイム設定（image / build / deploy / gui / network / volumes） |
-| `test/smoke/` | 共有 smoke テスト + runtime assertion helpers（下記参照） |
-| `test/unit/` | Template 自身のテスト（bats + kcov） |
-| `test/integration/` | Level-1 `init.sh` 統合テスト |
+| `downstream/test/smoke/` | 共有 smoke テスト + runtime assertion helpers（下記参照） |
+| `test/bats/unit/` | base 自己テスト、ユニット（bats + kcov） |
+| `test/bats/integration/` | base 自己テスト、init/upgrade の end-to-end |
+| `test/bats/behavioural/` | base 自己テスト、runtime 動作（opt-in） |
+
+テスト内容は **tool-first** で配置します — spec は `test/<tool>/<category>/`
+（例：`test/bats/unit/`）、linter は `test/lint/<tool>/` — そのため
+ツールの追加は新しいフォルダの追加であり、新しいコマンド面の追加では
+ありません。[ADR-00000012](../adr/00000012-tool-first-test-layout.md)
+（category-first の ADR-00000004 を置き換え）参照。consumer は自身の
+`test/smoke/` を出荷し、base は自身の
+`test/bats/{unit,integration,behavioural}/` を出荷します。
+
 | `.hadolint.yaml` | 共有 Hadolint ルール |
-| `justfile` | Repo コマンドエントリ（`just docker build`、`just docker run`、`just docker stop` 等）の `just <verb>` recipe。引数は `{{args}}` でそのまま wrapper に渡されます（`just docker build --no-cache test`）。`just` 単独で recipe 一覧を表示。 |
-| `script/test/justfile.test` | Template CI コマンドエントリ（`just test`、`just test lint` 等）。user-facing と CI-facing の分離は意図的。 |
-| `init.sh` | 初回 symlink セットアップ + 新 repo スケルトン生成 |
-| `upgrade.sh` | Subtree バージョンアップグレード |
-| `script/test/test.sh` | CI パイプライン（ローカル + リモート） |
+| `justfile`（→ `script/justfile`） | Repo コマンドエントリ — 階層化された namespace recipe（`just docker build`、`just docker run`、`just test`、`just base upgrade` 等）。サブコマンドと flag は `{{args}}` でそのまま渡されます（`just docker build --no-cache --stage test-tools`）。引数なしの `just` で全 namespace を一覧表示。 |
+| `downstream/script/docker/justfile.docker` | `docker` namespace — コンテナ操作（`just docker build/run/exec/stop/prune/setup/setup-tui`）。 |
+| `downstream/script/base/justfile.base` | `base` namespace — `.base` subtree を管理（`just base init/update/upgrade/completions`）。 |
+| `downstream/script/base/init.sh` | 初回 symlink セットアップ + 新 repo スケルトン生成（ブートストラップ：`./.base/downstream/script/base/init.sh`；以降は `just base init`）。 |
+| `downstream/script/base/upgrade.sh` | Subtree バージョンアップグレード（`just base upgrade [vX.Y.Z]`）。 |
+| `script/test/justfile.test` | base 自己テストのエントリ（`just test`、`just test lint`、`just test coverage`、…）。 |
+| `script/release/justfile.release` | base の `release` namespace（release / publish ツール）。 |
+| `script/test/test.sh` | base 自己テストのディスパッチャ（ローカル + コンテナ内） |
+| `script/test/drivers/` | ツールごとに 1 つの driver — `bats.sh` / `shellcheck.sh` / `hadolint.sh` |
 | `script/test/lint_bare_stderr.sh` | 素の stderr 出力 lint チェッカ |
-| `script/test/lint_mixed_test_layout.sh` | mixed-tool テストレイアウトのバリデータ |
 | `downstream/dockerfile/Dockerfile` | 新 repo のマルチステージ Dockerfile テンプレート |
 | `dockerfile/Dockerfile.test-tools` | プリビルド lint/test ツール image（shellcheck、hadolint、bats、bats-mock） |
 | `.github/workflows/` | 再利用可能な CI workflows（build + release） |
@@ -369,8 +383,8 @@ assertion helpers のセットを提供します。ダウンストリーム repo
            [logging.<svc>] で個別 service に key-level override 可能
 ```
 
-テンプレート既定値は `.base/setup.conf`；repo ごとの上書きは
-`<repo>/setup.conf`。セクションレベル **replace** 戦略：repo ファイルに
+テンプレート既定値は `.base/downstream/config/docker/setup.conf`；repo ごとの上書きは
+`<repo>/config/docker/setup.conf`。セクションレベル **replace** 戦略：repo ファイルに
 section があれば template の section を全置換；無ければ template 既定値を継承。
 
 初回の `setup.sh` 実行時（repo 側の setup.conf がまだ無い状態）、
@@ -383,7 +397,7 @@ template ファイルが repo にコピーされ、検出された workspace が
 ./setup_tui.sh                      # インタラクティブな dialog/whiptail エディタ
 ./setup_tui.sh volumes              # 特定 section に直接ジャンプ
 ./build.sh --setup            # TTY 下では setup_tui.sh を起動、それ以外は setup.sh を実行
-./.base/init.sh --gen-conf # .base/setup.conf を repo ルートに単純コピー
+./.base/downstream/script/base/init.sh --gen-conf # .base/downstream/config/docker/setup.conf を repo ルートに単純コピー
 ```
 
 ### ホスト側へのログ出力
@@ -453,8 +467,8 @@ Main
 `setup.sh` は明示的にトリガーされた時のみ実行されます — build / run
 の度に再実行されることはありません：
 
-- **`./.base/init.sh`** がスケルトン生成後に 1 回自動実行
-- **`just base upgrade` / `./.base/upgrade.sh`** が subtree pull の後に
+- **`just base init` / `./.base/downstream/script/base/init.sh`** がスケルトン生成後に 1 回自動実行
+- **`just base upgrade` / `./.base/downstream/script/base/upgrade.sh`** が subtree pull の後に
   init.sh 経由でもう一度実行されるため、アップグレードは常に新しい
   baseline で `.env` / `compose.yaml` を再生成した状態で着地します
 - **`./build.sh --setup` / `./run.sh --setup`**（または `-s`）— ユーザが
@@ -705,8 +719,9 @@ git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=.base \
     https://github.com/ycpss91255-docker/base.git v0.30.0 --squash
 
-# 3. symlink 初期化（ワンコマンド）
-./.base/init.sh
+# 3. symlink 初期化（初回ブートストラップのみ；裏で setup.sh を実行）。
+#    以降は `just base init`（symlink されたエントリ）を使用。
+./.base/downstream/script/base/init.sh
 ```
 
 > `git subtree add` は `HEAD` の存在を前提とします。`git init` 直後でコミットが無い repo では `ambiguous argument 'HEAD'` と `working tree has modifications` で失敗します。空コミットで `HEAD` を作成しておけば subtree がマージできます。
@@ -732,17 +747,17 @@ just base upgrade v0.3.0
 # してください。
 
 # just が使えない場合のフォールバック
-./.base/upgrade.sh v0.3.0
+./.base/downstream/script/base/upgrade.sh v0.3.0
 ```
 
 `upgrade.sh` は一度に完結します：
 
 1. `git subtree pull --prefix=.base ... --squash`
 2. Post-pull 整合性チェック — subtree マーカー（`.base/.version`、
-   `.base/init.sh`、`.base/downstream/script/docker/wrapper/setup.sh`）が消えた場合は
+   `.base/downstream/script/base/init.sh`、`.base/downstream/script/docker/wrapper/setup.sh`）が消えた場合は
    `git reset --hard` で rollback（旧 `git-subtree.sh` の destructive FF
    対策）
-3. `./.base/init.sh` 再実行：root symlinks（`build.sh` / `run.sh`
+3. `./.base/downstream/script/base/init.sh` 再実行：root symlinks（`build.sh` / `run.sh`
    / `justfile` …）の再同期、`.gitignore` を canonical entry set に
    同期、derived artifact になった旧 tracked ファイル（`.env`、
    `compose.yaml`、…）を `git rm --cached`、最後に `setup.sh apply` を
@@ -839,143 +854,80 @@ just --list  # CI ターゲット表示
 ## ディレクトリ構造
 
 ```
-.base/
-├── init.sh                           # Initialize repo (new or existing)
-├── upgrade.sh                        # Upgrade template subtree version
-├── script/
-│   ├── docker/                       # Docker operation scripts
-│   │   ├── wrapper/                  # User-facing wrapper scripts
-│   │   │   ├── build.sh
-│   │   │   ├── run.sh
-│   │   │   ├── exec.sh
-│   │   │   ├── stop.sh
-│   │   │   ├── prune.sh
-│   │   │   ├── setup.sh              # .env generator
-│   │   │   └── setup_tui.sh          # Interactive setup editor
-│   │   ├── lib/                      # Shared helper modules
-│   │   │   ├── _lib.sh               # Core wrappers library
-│   │   │   ├── bootstrap.sh          # Wrapper initialization
-│   │   │   ├── compose.sh            # Compose generation
-│   │   │   ├── conf.sh               # INI parser
-│   │   │   ├── conf_logging.sh       # Logging config
-│   │   │   ├── env.sh                # Environment setup
-│   │   │   ├── gitignore.sh          # Gitignore management
-│   │   │   ├── hook.sh               # Per-wrapper hooks
-│   │   │   ├── i18n.sh               # Language detection
-│   │   │   ├── log.sh                # Logging utilities
-│   │   │   ├── config_summary.sh     # Config summary
-│   │   │   ├── _tui_backend.sh       # TUI dialog/whiptail wrapper
-│   │   │   ├── _tui_conf.sh          # TUI INI validators
-│   │   │   ├── log-events.txt        # Log event catalog
-│   │   │   └── log.lnav-format.json  # Lnav format definition
-│   │   ├── runtime/                  # Runtime in-container scripts
-│   │   │   ├── entrypoint.sh         # Template entrypoint helper
-│   │   │   ├── logging.sh            # Host-side log tee helper
-│   │   │   └── smoke.sh              # Runtime install-check smoke
-│   │   ├── justfile                  # Docker operations entry (just)
-│   │   └── setup.conf                # Template runtime config defaults
-│   └── ci/                           # CI pipeline scripts
-│       ├── test.sh                     # CI orchestration (local + remote)
-│       ├── lint_bare_stderr.sh       # Bare stderr lint checker
-│       └── lint_mixed_test_layout.sh # Mixed-tool test layout validator
-├── dockerfile/
-│   ├── Dockerfile            # Multi-stage template (sys / devel-base / devel / devel-test / [runtime-base / runtime / runtime-test])
-│   └── Dockerfile.test-tools         # Pre-built lint/test tools image
-├── config/                           # Container-internal shell/tool configs
-│   ├── docker/
-│   │   └── setup.conf                # Runtime config (per-repo override mirror: <repo>/config/docker/setup.conf)
-│   └── shell/
-│       ├── bashrc
-│       ├── bashrc.d/                 # Interactive shell bootstrap drop-ins
-│       │   └── .gitkeep
-│       ├── terminator/
-│       │   ├── setup.sh
-│       │   └── config
-│       └── tmux/
-│           ├── setup.sh
-│           ├── README.adoc
-│           └── tmux.conf
-├── test/
-│   ├── smoke/                        # Shared smoke tests + runtime assertion helpers
-│   │   ├── test_helper.bash          # assert_cmd_installed / _runs / file / dir / owned_by / pip_pkg
-│   │   ├── script_help.bats
-│   │   └── display_env.bats
-│   ├── unit/                         # Template self-tests (bats + kcov)
-│   │   ├── test_helper.bash
-│   │   ├── bashrc_spec.bats
-│   │   ├── build_sh_spec.bats
-│   │   ├── build_sh_prune_spec.bats
-│   │   ├── build_worker_yaml_spec.bats
-│   │   ├── ci_spec.bats
-│   │   ├── compose_gen_spec.bats
-│   │   ├── compose_logging_spec.bats
-│   │   ├── compose_overlay_spec.bats
-│   │   ├── conf_logging_spec.bats
-│   │   ├── deploy_spec.bats
-│   │   ├── entrypoint_logging_spec.bats
-│   │   ├── exec_sh_spec.bats
-│   │   ├── gitignore_spec.bats
-│   │   ├── hook_spec.bats
-│   │   ├── init_spec.bats
-│   │   ├── lib_spec.bats
-│   │   ├── lint_mixed_test_layout_spec.bats
-│   │   ├── log_spec.bats
-│   │   ├── makefile_user_spec.bats
-│   │   ├── multi_distro_build_worker_yaml_spec.bats
-│   │   ├── prune_sh_spec.bats
-│   │   ├── release_test_tools_yaml_spec.bats
-│   │   ├── run_sh_spec.bats
-│   │   ├── runtime_smoke_spec.bats
-│   │   ├── self_test_yaml_spec.bats
-│   │   ├── setup_spec.bats
-│   │   ├── smoke_helper_spec.bats
-│   │   ├── stop_sh_spec.bats
-│   │   ├── template_spec.bats
-│   │   ├── terminator_config_spec.bats
-│   │   ├── terminator_setup_spec.bats
-│   │   ├── tmux_conf_spec.bats
-│   │   ├── tmux_setup_spec.bats
-│   │   ├── tui_backend_spec.bats
-│   │   ├── tui_flow.bats
-│   │   ├── tui_mount_assembler_spec.bats
-│   │   ├── tui_spec.bats
-│   │   ├── upgrade_spec.bats
-│   │   └── wrapper_lib_lookup_spec.bats
-│   ├── integration/                  # Level-1 init.sh end-to-end tests
-│   │   ├── init_new_repo_spec.bats
-│   │   ├── upgrade_spec.bats
-│   │   ├── fresh_clone_portability_spec.bats
-│   │   ├── gitignore_sync_spec.bats
-│   │   └── wrapper_compose_dispatch_spec.bats
-│   └── behavioural/                  # Runtime integration tests
-│       └── runtime_test_smoke_spec.bats
-├── script/test/justfile.test                       # Template CI entry (just test/lint/...)
-├── compose.yaml                      # Docker CI runner
-├── .hadolint.yaml                    # Shared Hadolint rules
-├── .dockerignore
-├── codecov.yml
-├── .github/workflows/
-│   ├── self-test.yaml                # Template CI
-│   ├── build-worker.yaml             # Reusable build + smoke-test workflow
-│   ├── release-worker.yaml           # Reusable release (source archive) workflow
-│   ├── publish-worker.yaml           # Reusable image publish workflow (opt-in)
-│   ├── multi-distro-build-worker.yaml # Multi-distro build workflow
-│   └── release-test-tools.yaml       # Template's own test-tools image release
-├── doc/
-│   ├── readme/                       # README translations
-│   │   ├── README.zh-TW.md
-│   │   ├── README.zh-CN.md
-│   │   └── README.ja.md
-│   ├── adr/                          # Architecture Decision Records
-│   │   ├── 00000001-setup-conf-vs-compose.md
-│   │   ├── 00000002-no-latest-tag.md
-│   │   ├── 00000003-env-vs-workload-param-boundary.md
-│   │   └── 00000004-test-category-tool-subdir-layout.md
+.base/                                  # consumer の <repo>/.base/ に pin された subtree
+├── .version                            # pin された base release tag
+├── justfile                            # base 自身の自己テスト/release エントリ（mods test + release）
+├── compose.yaml                        # base CI runner（test-tools サービス）
+├── .dockerignore                       # canonical な ignore セット（consumer へ同期）
+├── .codecov.yaml                       # カバレッジアップロード設定
+├── downstream/                         # 出荷されるツール + コンテンツ（single source of truth）
+│   ├── .hadolint.yaml                  # 共有 Hadolint ルール（consumer へ symlink）
+│   ├── dockerfile/
+│   │   └── Dockerfile                  # 新 repo 用マルチステージ Dockerfile テンプレート
+│   ├── config/                         # コンテナ内部のシェル/ツール設定
+│   │   ├── docker/
+│   │   │   └── setup.conf              # テンプレートランタイム設定のデフォルト
+│   │   └── shell/
+│   │       ├── bashrc
+│   │       ├── bashrc.d/               # インタラクティブシェル bootstrap drop-in
+│   │       ├── terminator/             # setup.sh + config
+│   │       └── tmux/                   # setup.sh + tmux.conf + README.adoc
+│   ├── script/                         # 汎用ツール（consumer が per-sub で symlink）
+│   │   ├── justfile                    # Consumer コンテナ操作エントリ（mods docker/base/template）
+│   │   ├── docker/                     # `docker` namespace
+│   │   │   ├── justfile.docker         # just docker build/run/exec/stop/prune/setup/setup-tui
+│   │   │   ├── wrapper/                # build.sh / run.sh / exec.sh / stop.sh / prune.sh
+│   │   │   │                           #   / setup.sh / setup_tui.sh
+│   │   │   ├── lib/                    # 共有 helper モジュール（_lib / compose / conf / log
+│   │   │   │                           #   / i18n / hook / wrapper / schema / transcript / ...）
+│   │   │   └── runtime/                # コンテナ内：entrypoint.sh / logging.sh / smoke.sh
+│   │   ├── base/                       # `base` namespace（.base subtree を管理）
+│   │   │   ├── justfile.base           # just base init/update/upgrade/completions
+│   │   │   ├── init.sh                 # 初回ブートストラップ + symlink/.gitignore 再同期
+│   │   │   ├── upgrade.sh              # Subtree バージョンアップグレード（.base root まで遡る）
+│   │   │   └── completions.sh          # opt-in なシェル tab-completion インストーラ
+│   │   └── template/                   # `template` namespace（repo ローカルグループの scaffold）
+│   │       ├── justfile.template       # just template new <name>
+│   │       ├── new.sh
+│   │       └── skel/                   # justfile.skel + skel.sh
+│   └── test/
+│       └── smoke/                      # 共有 smoke テスト + runtime assertion helpers
+│           ├── test_helper.bash        #   assert_cmd_installed / _runs / file / dir / ...
+│           ├── script_help.bats
+│           └── display_env.bats
+├── script/                             # base 自身の自己テスト/release ツール（symlink しない）
 │   ├── test/
-│   │   └── TEST.md                   # Test catalog and spec tables
+│   │   ├── justfile.test               # just test / lint / coverage / behavioural
+│   │   ├── test.sh                     # ディスパッチャ（ローカル + コンテナ内）
+│   │   ├── lint_bare_stderr.sh
+│   │   └── drivers/                    # ツールごとに 1 driver：bats.sh / shellcheck.sh / hadolint.sh
+│   └── release/
+│       └── justfile.release            # just release <recipe>
+├── dockerfile/
+│   └── Dockerfile.test-tools           # プリビルド lint/test ツール image（shellcheck/hadolint/bats）
+├── test/                               # base 自身の spec（tool-first：test/<tool>/<category>/）
+│   └── bats/
+│       ├── unit/                       # 58 unit spec + test_helper.bash（bats + kcov）
+│       ├── integration/                # init/upgrade の end-to-end（5 spec）
+│       └── behavioural/                # runtime 動作（opt-in；runtime_test_smoke_spec.bats）
+├── .github/
+│   ├── dependabot.yml
+│   └── workflows/
+│       ├── self-test.yaml              # base CI（ShellCheck + Bats + Kcov カバレッジゲート）
+│       ├── build-worker.yaml           # 再利用可能な build + smoke-test workflow
+│       ├── release-worker.yaml         # 再利用可能な release（source archive）workflow
+│       ├── publish-worker.yaml         # 再利用可能な image publish workflow（opt-in）
+│       ├── multi-distro-build-worker.yaml # マルチ distro build workflow
+│       └── release-test-tools.yaml     # base 自身の test-tools image release
+├── doc/
+│   ├── readme/                         # README 翻訳（zh-TW / zh-CN / ja）
+│   ├── adr/                            # Architecture Decision Records（00000001 … 00000012）
+│   ├── test/
+│   │   └── TEST.md                     # テストカタログと spec 表
 │   ├── changelog/
-│   │   └── CHANGELOG.md              # Release notes
+│   │   └── CHANGELOG.md
 │   └── deprecations.md
+├── CONTEXT.md
 ├── .gitignore
 ├── LICENSE
 └── README.md

--- a/doc/readme/README.ja.md
+++ b/doc/readme/README.ja.md
@@ -907,7 +907,7 @@ just --list  # CI ターゲット表示
 │   └── Dockerfile.test-tools           # プリビルド lint/test ツール image（shellcheck/hadolint/bats）
 ├── test/                               # base 自身の spec（tool-first：test/<tool>/<category>/）
 │   └── bats/
-│       ├── unit/                       # 58 unit spec + test_helper.bash（bats + kcov）
+│       ├── unit/                       # 56 unit spec + 2 個の bash ヘルパ（bats + kcov）
 │       ├── integration/                # init/upgrade の end-to-end（5 spec）
 │       └── behavioural/                # runtime 動作（opt-in；runtime_test_smoke_spec.bats）
 ├── .github/

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -31,13 +31,13 @@
 ## TL;DR
 
 ```bash
-# 从零开始的新 repo：init + 首个 commit + subtree + init.sh
+# 从零开始的新 repo：首个 commit + subtree + 一次性 bootstrap
 mkdir <repo_name> && cd <repo_name>
 git init
 git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=.base \
     https://github.com/ycpss91255-docker/base.git v0.30.0 --squash
-./.base/init.sh
+./.base/downstream/script/base/init.sh
 
 # 升级到最新版
 just base update   # 检查
@@ -68,7 +68,7 @@ Docker 执行。使用 `just <verb>` 入口前，请先在 host 安装两者：
 
   完整方式见[官方安装指南](https://github.com/casey/just#installation)。若
   `just` 不可用，每个 recipe 都有 raw fallback（`./script/<verb>.sh`、
-  `./.base/upgrade.sh`）-- 见[快速开始](#快速开始)。
+  `./.base/downstream/script/base/upgrade.sh`）-- 见[快速开始](#快速开始)。
 
 ## 概述
 
@@ -79,22 +79,22 @@ Docker 执行。使用 `just <verb>` 入口前，请先在 host 安装两者：
 ```mermaid
 graph TB
     subgraph base["base（共用 repo）"]
-        scripts[".hadolint.yaml / script/test/justfile.test / compose.yaml"]
-        smoke["test/smoke/<br/>script_help.bats<br/>display_env.bats"]
-        config["config/<br/>bashrc / tmux / terminator"]
+        scripts["downstream/.hadolint.yaml<br/>downstream/script/justfile（consumer entry）<br/>downstream/script/docker|base|template/"]
+        smoke["downstream/test/smoke/<br/>script_help.bats<br/>display_env.bats"]
+        config["downstream/config/<br/>bashrc / tmux / terminator"]
         mgmt["downstream/script/docker/wrapper/<br/>build.sh / run.sh / exec.sh / stop.sh / setup.sh"]
         workflows["可重用 Workflows<br/>build-worker.yaml<br/>release-worker.yaml"]
     end
 
     subgraph consumer["Docker Repo（例如 my_app）"]
-        symlinks["justfile → .base/script/docker/justfile<br/>build.sh → .base/downstream/script/docker/wrapper/build.sh<br/>run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
-        dockerfile["Dockerfile<br/>compose.yaml<br/>script/entrypoint.sh"]
+        symlinks["justfile → script/justfile → .base/downstream/script/justfile<br/>script/docker|base|template/ → .base/downstream/script/.../（per-sub symlinks）<br/>script/build.sh → .base/downstream/script/docker/wrapper/build.sh<br/>run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
+        dockerfile["Dockerfile<br/>compose.yaml<br/>script/entrypoint.sh<br/>script/local/justfile.local（repo 自有）"]
         repo_test["test/smoke/<br/>app_env.bats（repo 专属）"]
         main_yaml["main.yaml<br/>→ 调用可重用 workflows"]
     end
 
     base -- "git subtree" --> consumer
-    scripts -. "symlink" .-> symlinks
+    scripts -. "per-sub symlink" .-> symlinks
     smoke -. "Dockerfile COPY" .-> repo_test
     workflows -. "@tag 引用" .-> main_yaml
 ```
@@ -104,14 +104,14 @@ graph TB
 ```mermaid
 flowchart LR
     subgraph local["本地"]
-        build_test["./build.sh test"]
-        make_test["just docker build test"]
+        just_test["just test"]
+        just_build["just docker build --stage test-tools"]
     end
 
     subgraph ci_container["CI 容器（ghcr.io/ycpss91255-docker/test-tools:latest）"]
         shellcheck["ShellCheck"]
-        hadolint["Hadolint"]
-        bats["Bats smoke tests"]
+        hadolint["Hadolint（just test lint）"]
+        bats["Bats specs"]
     end
 
     subgraph github["GitHub Actions"]
@@ -119,12 +119,12 @@ flowchart LR
         release_worker["release-worker.yaml<br/>（来自 base）"]
     end
 
-    build_test --> ci_container
-    make_test -->|"script/test/test.sh"| ci_container
+    just_build --> ci_container
+    just_test -->|"script/test/test.sh"| ci_container
     shellcheck --> hadolint --> bats
 
     push["git push / PR"] --> build_worker
-    build_worker -->|"docker build test"| ci_container
+    build_worker -->|"docker build（devel-test stage）"| ci_container
     tag["git tag v*"] --> release_worker
     release_worker -->|"tar.gz + zip"| release["GitHub Release"]
 ```
@@ -156,20 +156,31 @@ flowchart LR
 | `downstream/script/docker/runtime/entrypoint.sh` | 模板 entrypoint helper |
 | `downstream/script/docker/runtime/logging.sh` | host 端 log tee helper |
 | `downstream/script/docker/runtime/smoke.sh` | runtime 安装检查 smoke |
-| `script/test/test.sh` | CI orchestration（本地 + 远端） |
+| `script/test/test.sh` | base 自测调度器（本地 + container 内） |
+| `script/test/drivers/` | 每个工具一个 driver — `bats.sh` / `shellcheck.sh` / `hadolint.sh` |
 | `script/test/lint_bare_stderr.sh` | Bare stderr lint 检查器 |
-| `script/test/lint_mixed_test_layout.sh` | 混合工具测试布局验证器 |
 | `config/` | Container 内部 shell 配置文件（bashrc、tmux、terminator） |
 | `setup.conf` | 单一 per-repo runtime 配置（image / build / deploy / gui / network / volumes） |
-| `test/smoke/` | 共用 smoke 测试 + runtime assertion helpers（见下方） |
-| `test/unit/` | Template 自身测试（bats + kcov） |
-| `test/integration/` | Level-1 `init.sh` 集成测试 |
-| `test/behavioural/` | Runtime 集成测试 |
+| `downstream/test/smoke/` | 共用 smoke 测试 + runtime assertion helpers（见下方） |
+| `test/bats/unit/` | base 自测，unit（bats + kcov） |
+| `test/bats/integration/` | base 自测，init/upgrade 端到端 |
+| `test/bats/behavioural/` | base 自测，runtime 行为（opt-in） |
+
+测试内容采用 **tool-first** 布局 — spec 放 `test/<tool>/<category>/`
+（如 `test/bats/unit/`），linter 放 `test/lint/<tool>/` — 加一个工具就
+是新增一个目录，而不是新增一个命令面。见
+[ADR-00000012](../adr/00000012-tool-first-test-layout.md)（取代 category-first
+的 ADR-00000004）。consumer 出货自己的 `test/smoke/`；base 出货自己的
+`test/bats/{unit,integration,behavioural}/`。
+
 | `.hadolint.yaml` | 共用 Hadolint 规则 |
-| `justfile` | Repo 命令入口（`just docker build`、`just docker run`、`just docker stop` 等）。各 verb 是 just recipe，参数透过 `{{args}}` 透传：sub-cmd 与 flag 都直接附在后面，不需要 `--` 分隔符（`just docker build --no-cache test`）。`just` 无参列出所有 recipe。 |
-| `script/test/justfile.test` | Template CI 命令入口（`just test`、`just test lint` 等）。user-facing 跟 CI-facing 是有意切割。 |
-| `init.sh` | 首次初始化 symlinks + 新 repo 骨架生成 |
-| `upgrade.sh` | Subtree 版本升级 |
+| `justfile`（→ `script/justfile`） | Repo 命令入口 — 分层 namespace recipe（`just docker build`、`just docker run`、`just test`、`just base upgrade` 等）。sub-cmd 与 flag 透过 `{{args}}` 直接透传（`just docker build --no-cache --stage test-tools`）；裸 `just` 列出所有 namespace。 |
+| `downstream/script/docker/justfile.docker` | `docker` namespace — 容器操作（`just docker build/run/exec/stop/prune/setup/setup-tui`）。 |
+| `downstream/script/base/justfile.base` | `base` namespace — 管理 `.base` subtree（`just base init/update/upgrade/completions`）。 |
+| `downstream/script/base/init.sh` | 首次初始化 symlinks + 新 repo 骨架生成（bootstrap：`./.base/downstream/script/base/init.sh`；之后用 `just base init`）。 |
+| `downstream/script/base/upgrade.sh` | Subtree 版本升级（`just base upgrade [vX.Y.Z]`）。 |
+| `script/test/justfile.test` | base 自测入口（`just test`、`just test lint`、`just test coverage` …）。 |
+| `script/release/justfile.release` | base `release` namespace（release / publish 工具）。 |
 | `downstream/dockerfile/Dockerfile` | 新 repo 的多阶段 Dockerfile 模板 |
 | `dockerfile/Dockerfile.test-tools` | 预构建 lint/test 工具 image（shellcheck、hadolint、bats、bats-mock） |
 | `.github/workflows/` | 可重用 CI workflows（build + release） |
@@ -356,7 +367,7 @@ assertion helpers。下游 repo 应优先使用这些 helper 而非原生的
            [logging.<svc>] 可对单一 service 做 key-level override
 ```
 
-Template default 在 `.base/setup.conf`；per-repo 覆盖放 `<repo>/setup.conf`。
+Template default 在 `.base/downstream/config/docker/setup.conf`；per-repo 覆盖放 `<repo>/config/docker/setup.conf`。
 Section-level **replace** 策略：per-repo 文件若有该 section 就整段取代
 template；没写的 section 则吃 template 默认。
 
@@ -368,7 +379,7 @@ template；没写的 section 则吃 template 默认。
 ./setup_tui.sh                      # 交互式 dialog/whiptail 编辑器
 ./setup_tui.sh volumes              # 直接跳到指定 section
 ./build.sh --setup            # 有 TTY 时启动 setup_tui.sh；无 TTY 时执行 setup.sh
-./.base/init.sh --gen-conf # 单纯复制 .base/setup.conf 到 repo 根目录
+./.base/downstream/script/base/init.sh --gen-conf # 单纯复制 .base/downstream/config/docker/setup.conf 到 <repo>/config/docker/setup.conf
 ```
 
 ### 输出 log 到 host
@@ -431,8 +442,8 @@ Main
 
 `setup.sh` 仅在显式触发时才执行 — 并不会在每次 build / run 都重跑：
 
-- **`./.base/init.sh`** 建完骨架自动运行一次
-- **`just base upgrade` / `./.base/upgrade.sh`** subtree pull 后通过 init.sh
+- **`just base init` / `./.base/downstream/script/base/init.sh`** 建完骨架自动运行一次
+- **`just base upgrade` / `./.base/downstream/script/base/upgrade.sh`** subtree pull 后通过 init.sh
   再跑一次，所以升级总是会用新版 baseline 重新生成 `.env` / `compose.yaml`
 - **`./build.sh --setup` / `./run.sh --setup`**（或 `-s`）— 用户手动触发重跑；
   有 TTY 时先启动 `setup_tui.sh` 让用户修改 `setup.conf`，无 TTY 时直接调用 `setup.sh`
@@ -664,8 +675,9 @@ git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=.base \
     https://github.com/ycpss91255-docker/base.git v0.30.0 --squash
 
-# 3. 初始化 symlinks（一个命令搞定）
-./.base/init.sh
+# 3. 初始化 symlinks（一次性 bootstrap；底层会跑 setup.sh）。
+#    之后改用 `just base init`（symlink 后的入口）。
+./.base/downstream/script/base/init.sh
 ```
 
 > `git subtree add` 需要 `HEAD` 存在。在刚 `git init` 且没有任何 commit 的 repo 上会报错 `ambiguous argument 'HEAD'` 与 `working tree has modifications`。用空 commit 建立 `HEAD`，subtree 才能 merge 进来。
@@ -690,16 +702,16 @@ just base upgrade v0.3.0
 # 行手改 .base/.version。
 
 # 没有 just 时的 fallback
-./.base/upgrade.sh v0.3.0
+./.base/downstream/script/base/upgrade.sh v0.3.0
 ```
 
 `upgrade.sh` 一次完成：
 
 1. `git subtree pull --prefix=.base ... --squash`
 2. Post-pull 完整性检查 — subtree marker（`.base/.version`、
-   `.base/init.sh`、`.base/downstream/script/docker/wrapper/setup.sh`）若不见了会
+   `.base/downstream/script/base/init.sh`、`.base/downstream/script/docker/wrapper/setup.sh`）若不见了会
    `git reset --hard` rollback（防旧版 `git-subtree.sh` destructive FF）
-3. `./.base/init.sh` 重跑：重整 root symlinks（`build.sh` / `run.sh`
+3. `./.base/downstream/script/base/init.sh` 重跑：重整 root symlinks（`build.sh` / `run.sh`
    / `justfile` …）、把 `.gitignore` 同步到 canonical entry set、
    `git rm --cached` 已经变成 derived artifact 的旧 tracked 文件（`.env`、
    `compose.yaml`、…），最后调用 `setup.sh apply` 重新生成 `.env` +
@@ -773,7 +785,7 @@ jobs:
 
 ## 本地运行测试
 
-使用 `script/test/justfile.test`（在 template 根目录）：
+base 自测入口 `just test`：
 ```bash
 just test        # 完整 CI（ShellCheck + Bats + Kcov）通过 docker compose
 just test lint        # 只运行 ShellCheck
@@ -795,143 +807,80 @@ just --list        # 显示 CI 命令
 ## 目录结构
 
 ```
-.base/
-├── init.sh                           # 初始化 repo（新建或既有）
-├── upgrade.sh                        # 升级 template subtree 版本
-├── script/
-│   ├── docker/                       # Docker 操作脚本
-│   │   ├── wrapper/                  # 面向用户的 wrapper 脚本
-│   │   │   ├── build.sh
-│   │   │   ├── run.sh
-│   │   │   ├── exec.sh
-│   │   │   ├── stop.sh
-│   │   │   ├── prune.sh
-│   │   │   ├── setup.sh              # .env 生成器
-│   │   │   └── setup_tui.sh          # 交互式 setup 编辑器
-│   │   ├── lib/                      # 共用 helper 模块
-│   │   │   ├── _lib.sh               # 核心 wrapper 库
-│   │   │   ├── bootstrap.sh          # wrapper 初始化
-│   │   │   ├── compose.sh            # Compose 生成
-│   │   │   ├── conf.sh               # INI 解析器
-│   │   │   ├── conf_logging.sh       # Logging 配置
-│   │   │   ├── env.sh                # 环境设置
-│   │   │   ├── gitignore.sh          # Gitignore 管理
-│   │   │   ├── hook.sh               # 每个 wrapper 的 hook
-│   │   │   ├── i18n.sh               # 语言检测
-│   │   │   ├── log.sh                # 日志 helper
-│   │   │   ├── config_summary.sh     # 配置摘要
-│   │   │   ├── _tui_backend.sh       # TUI dialog/whiptail 包装
-│   │   │   ├── _tui_conf.sh          # TUI INI validators
-│   │   │   ├── log-events.txt        # Log 事件目录
-│   │   │   └── log.lnav-format.json  # Lnav 格式定义
-│   │   ├── runtime/                  # Container 内 runtime 脚本
-│   │   │   ├── entrypoint.sh         # Template entrypoint helper
-│   │   │   ├── logging.sh            # host 端 log tee helper
-│   │   │   └── smoke.sh              # Runtime 安装检查 smoke
-│   │   ├── justfile                  # Docker 操作入口（just）
-│   │   └── setup.conf                # Template runtime 配置默认
-│   └── ci/                           # CI pipeline 脚本
-│       ├── test.sh                     # CI orchestration（本地 + 远端）
-│       ├── lint_bare_stderr.sh       # Bare stderr lint 检查器
-│       └── lint_mixed_test_layout.sh # 混合工具测试布局验证器
-├── dockerfile/
-│   ├── Dockerfile            # 多阶段模板（sys / devel-base / devel / devel-test / [runtime-base / runtime / runtime-test]）
-│   └── Dockerfile.test-tools         # 预构建 lint/test 工具 image
-├── config/                           # Container 内部 shell / 工具配置
-│   ├── docker/
-│   │   └── setup.conf                # Runtime 配置（per-repo override mirror: <repo>/config/docker/setup.conf）
-│   └── shell/
-│       ├── bashrc
-│       ├── bashrc.d/                 # 交互式 shell bootstrap drop-ins
-│       │   └── .gitkeep
-│       ├── terminator/
-│       │   ├── setup.sh
-│       │   └── config
-│       └── tmux/
-│           ├── setup.sh
-│           ├── README.adoc
-│           └── tmux.conf
-├── test/
-│   ├── smoke/                        # 共用 smoke 测试 + runtime assertion helpers
-│   │   ├── test_helper.bash          # assert_cmd_installed / _runs / file / dir / owned_by / pip_pkg
-│   │   ├── script_help.bats
-│   │   └── display_env.bats
-│   ├── unit/                         # Template 自身测试（bats + kcov）
-│   │   ├── test_helper.bash
-│   │   ├── bashrc_spec.bats
-│   │   ├── build_sh_spec.bats
-│   │   ├── build_sh_prune_spec.bats
-│   │   ├── build_worker_yaml_spec.bats
-│   │   ├── ci_spec.bats
-│   │   ├── compose_gen_spec.bats
-│   │   ├── compose_logging_spec.bats
-│   │   ├── compose_overlay_spec.bats
-│   │   ├── conf_logging_spec.bats
-│   │   ├── deploy_spec.bats
-│   │   ├── entrypoint_logging_spec.bats
-│   │   ├── exec_sh_spec.bats
-│   │   ├── gitignore_spec.bats
-│   │   ├── hook_spec.bats
-│   │   ├── init_spec.bats
-│   │   ├── lib_spec.bats
-│   │   ├── lint_mixed_test_layout_spec.bats
-│   │   ├── log_spec.bats
-│   │   ├── makefile_user_spec.bats
-│   │   ├── multi_distro_build_worker_yaml_spec.bats
-│   │   ├── prune_sh_spec.bats
-│   │   ├── release_test_tools_yaml_spec.bats
-│   │   ├── run_sh_spec.bats
-│   │   ├── runtime_smoke_spec.bats
-│   │   ├── self_test_yaml_spec.bats
-│   │   ├── setup_spec.bats
-│   │   ├── smoke_helper_spec.bats
-│   │   ├── stop_sh_spec.bats
-│   │   ├── template_spec.bats
-│   │   ├── terminator_config_spec.bats
-│   │   ├── terminator_setup_spec.bats
-│   │   ├── tmux_conf_spec.bats
-│   │   ├── tmux_setup_spec.bats
-│   │   ├── tui_backend_spec.bats
-│   │   ├── tui_flow.bats
-│   │   ├── tui_mount_assembler_spec.bats
-│   │   ├── tui_spec.bats
-│   │   ├── upgrade_spec.bats
-│   │   └── wrapper_lib_lookup_spec.bats
-│   ├── integration/                  # Level-1 init.sh 端到端测试
-│   │   ├── init_new_repo_spec.bats
-│   │   ├── upgrade_spec.bats
-│   │   ├── fresh_clone_portability_spec.bats
-│   │   ├── gitignore_sync_spec.bats
-│   │   └── wrapper_compose_dispatch_spec.bats
-│   └── behavioural/                  # Runtime 集成测试
-│       └── runtime_test_smoke_spec.bats
-├── script/test/justfile.test                       # Template CI 入口（just test/lint/...）
-├── compose.yaml                      # Docker CI 运行器
-├── .hadolint.yaml                    # 共用 Hadolint 规则
-├── .dockerignore
-├── codecov.yml
-├── .github/workflows/
-│   ├── self-test.yaml                # Template CI
-│   ├── build-worker.yaml             # 可重用 build + smoke-test workflow
-│   ├── release-worker.yaml           # 可重用 release（source archive）workflow
-│   ├── publish-worker.yaml           # 可重用 image publish workflow（opt-in）
-│   ├── multi-distro-build-worker.yaml # Multi-distro build workflow
-│   └── release-test-tools.yaml       # Template 自身的 test-tools image release
-├── doc/
-│   ├── readme/                       # README 翻译
-│   │   ├── README.zh-TW.md
-│   │   ├── README.zh-CN.md
-│   │   └── README.ja.md
-│   ├── adr/                          # Architecture Decision Records
-│   │   ├── 00000001-setup-conf-vs-compose.md
-│   │   ├── 00000002-no-latest-tag.md
-│   │   ├── 00000003-env-vs-workload-param-boundary.md
-│   │   └── 00000004-test-category-tool-subdir-layout.md
+.base/                                  # subtree 固定在 consumer 的 <repo>/.base/
+├── .version                            # 锁定的 base release tag
+├── justfile                            # base 自身的自测/release 入口（mods test + release）
+├── compose.yaml                        # base CI runner（test-tools services）
+├── .dockerignore                       # canonical ignore set（同步进 consumers）
+├── .codecov.yaml                       # 覆盖率上传配置
+├── downstream/                         # 出货的工具 + 内容（单一来源）
+│   ├── .hadolint.yaml                  # 共用 Hadolint 规则（symlink 进 consumers）
+│   ├── dockerfile/
+│   │   └── Dockerfile                  # 新 repo 的多阶段 Dockerfile 模板
+│   ├── config/                         # Container 内部 shell/工具配置
+│   │   ├── docker/
+│   │   │   └── setup.conf              # Template runtime 配置默认
+│   │   └── shell/
+│   │       ├── bashrc
+│   │       ├── bashrc.d/               # 交互式 shell bootstrap drop-ins
+│   │       ├── terminator/             # setup.sh + config
+│   │       └── tmux/                   # setup.sh + tmux.conf + README.adoc
+│   ├── script/                         # 通用工具（consumers 逐 sub symlink）
+│   │   ├── justfile                    # Consumer 容器操作入口（mods docker/base/template）
+│   │   ├── docker/                     # `docker` namespace
+│   │   │   ├── justfile.docker         # just docker build/run/exec/stop/prune/setup/setup-tui
+│   │   │   ├── wrapper/                # build.sh / run.sh / exec.sh / stop.sh / prune.sh
+│   │   │   │                           #   / setup.sh / setup_tui.sh
+│   │   │   ├── lib/                    # 共用 helper 模块（_lib / compose / conf / log
+│   │   │   │                           #   / i18n / hook / wrapper / schema / transcript / ...）
+│   │   │   └── runtime/                # Container 内：entrypoint.sh / logging.sh / smoke.sh
+│   │   ├── base/                       # `base` namespace（管理 .base subtree）
+│   │   │   ├── justfile.base           # just base init/update/upgrade/completions
+│   │   │   ├── init.sh                 # 首次 bootstrap + symlink/.gitignore resync
+│   │   │   ├── upgrade.sh              # Subtree 版本升级（向上找到 .base root）
+│   │   │   └── completions.sh          # opt-in shell tab-completion installer
+│   │   └── template/                   # `template` namespace（scaffold repo-local groups）
+│   │       ├── justfile.template       # just template new <name>
+│   │       ├── new.sh
+│   │       └── skel/                   # justfile.skel + skel.sh
+│   └── test/
+│       └── smoke/                      # 共用 smoke 测试 + runtime assertion helpers
+│           ├── test_helper.bash        #   assert_cmd_installed / _runs / file / dir / ...
+│           ├── script_help.bats
+│           └── display_env.bats
+├── script/                             # base 自身的自测/release 工具（不 symlink）
 │   ├── test/
-│   │   └── TEST.md                   # 测试清单与 spec 表
+│   │   ├── justfile.test               # just test / lint / coverage / behavioural
+│   │   ├── test.sh                     # 调度器（本地 + container 内）
+│   │   ├── lint_bare_stderr.sh
+│   │   └── drivers/                    # 每个工具一个 driver：bats.sh / shellcheck.sh / hadolint.sh
+│   └── release/
+│       └── justfile.release            # just release <recipe>
+├── dockerfile/
+│   └── Dockerfile.test-tools           # 预构建 lint/test 工具 image（shellcheck/hadolint/bats）
+├── test/                               # base 自身的 specs（tool-first：test/<tool>/<category>/）
+│   └── bats/
+│       ├── unit/                       # 58 个 unit spec + test_helper.bash（bats + kcov）
+│       ├── integration/                # init/upgrade 端到端（5 个 spec）
+│       └── behavioural/                # Runtime 行为（opt-in；runtime_test_smoke_spec.bats）
+├── .github/
+│   ├── dependabot.yml
+│   └── workflows/
+│       ├── self-test.yaml              # base CI（ShellCheck + Bats + Kcov 覆盖率 gate）
+│       ├── build-worker.yaml           # 可重用 build + smoke-test workflow
+│       ├── release-worker.yaml         # 可重用 release（source archive）workflow
+│       ├── publish-worker.yaml         # 可重用 image publish workflow（opt-in）
+│       ├── multi-distro-build-worker.yaml # Multi-distro build workflow
+│       └── release-test-tools.yaml     # base 自身的 test-tools image release
+├── doc/
+│   ├── readme/                         # README 翻译（zh-TW / zh-CN / ja）
+│   ├── adr/                            # Architecture Decision Records（00000001 … 00000012）
+│   ├── test/
+│   │   └── TEST.md                     # 测试清单与 spec 表
 │   ├── changelog/
-│   │   └── CHANGELOG.md              # 发布记录
+│   │   └── CHANGELOG.md
 │   └── deprecations.md
+├── CONTEXT.md
 ├── .gitignore
 ├── LICENSE
 └── README.md

--- a/doc/readme/README.zh-CN.md
+++ b/doc/readme/README.zh-CN.md
@@ -860,7 +860,7 @@ just --list        # 显示 CI 命令
 │   └── Dockerfile.test-tools           # 预构建 lint/test 工具 image（shellcheck/hadolint/bats）
 ├── test/                               # base 自身的 specs（tool-first：test/<tool>/<category>/）
 │   └── bats/
-│       ├── unit/                       # 58 个 unit spec + test_helper.bash（bats + kcov）
+│       ├── unit/                       # 56 个 unit spec + 2 个 bash helper（bats + kcov）
 │       ├── integration/                # init/upgrade 端到端（5 个 spec）
 │       └── behavioural/                # Runtime 行为（opt-in；runtime_test_smoke_spec.bats）
 ├── .github/

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -859,7 +859,7 @@ just --list  # 顯示 CI 指令
 │   └── Dockerfile.test-tools           # 預建置 lint/test 工具 image（shellcheck/hadolint/bats）
 ├── test/                               # base 自身 spec（tool-first：test/<tool>/<category>/）
 │   └── bats/
-│       ├── unit/                       # 58 個 unit spec + test_helper.bash（bats + kcov）
+│       ├── unit/                       # 56 個 unit spec + 2 個 bash helper（bats + kcov）
 │       ├── integration/                # init/upgrade 端對端（5 個 spec）
 │       └── behavioural/                # Runtime 行為（opt-in；runtime_test_smoke_spec.bats）
 ├── .github/

--- a/doc/readme/README.zh-TW.md
+++ b/doc/readme/README.zh-TW.md
@@ -31,13 +31,13 @@
 ## TL;DR
 
 ```bash
-# 從零開始的新 repo：init + 首個 commit + subtree + init.sh
+# 從零開始的新 repo：首個 commit + subtree + 一次性 bootstrap
 mkdir <repo_name> && cd <repo_name>
 git init
 git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=.base \
     https://github.com/ycpss91255-docker/base.git vX.Y.Z --squash
-./.base/init.sh
+./.base/downstream/script/base/init.sh
 
 # 升級到最新版
 just base update   # 檢查
@@ -68,7 +68,7 @@ Docker 執行。使用 `just <verb>` 入口前，請先在 host 安裝兩者：
 
   完整方式見[官方安裝指南](https://github.com/casey/just#installation)。若
   `just` 不可用，每個 recipe 都有 raw fallback（`./script/<verb>.sh`、
-  `./.base/upgrade.sh`）-- 見[快速開始](#快速開始)。
+  `./.base/downstream/script/base/upgrade.sh`）-- 見[快速開始](#快速開始)。
 
 ## 概述
 
@@ -79,22 +79,22 @@ Docker 執行。使用 `just <verb>` 入口前，請先在 host 安裝兩者：
 ```mermaid
 graph TB
     subgraph base["base（共用 repo）"]
-        scripts[".hadolint.yaml / script/test/justfile.test / compose.yaml"]
-        smoke["test/smoke/<br/>script_help.bats<br/>display_env.bats"]
-        config["config/<br/>bashrc / tmux / terminator / pip"]
-        mgmt["script/docker/<br/>build.sh / run.sh / exec.sh / stop.sh / setup.sh"]
+        scripts["downstream/.hadolint.yaml<br/>downstream/script/justfile（consumer entry）<br/>downstream/script/docker|base|template/"]
+        smoke["downstream/test/smoke/<br/>script_help.bats<br/>display_env.bats"]
+        config["downstream/config/<br/>bashrc / tmux / terminator"]
+        mgmt["downstream/script/docker/wrapper/<br/>build.sh / run.sh / exec.sh / stop.sh / setup.sh"]
         workflows["可重用 Workflows<br/>build-worker.yaml<br/>release-worker.yaml"]
     end
 
     subgraph consumer["Docker Repo（例如 my_app）"]
-        symlinks["justfile → .base/script/docker/justfile<br/>build.sh → .base/downstream/script/docker/wrapper/build.sh<br/>run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
-        dockerfile["Dockerfile<br/>compose.yaml<br/>script/entrypoint.sh"]
+        symlinks["justfile → script/justfile → .base/downstream/script/justfile<br/>script/docker|base|template/ → .base/downstream/script/.../（per-sub symlinks）<br/>script/build.sh → .base/downstream/script/docker/wrapper/build.sh<br/>run.sh / exec.sh / stop.sh / prune.sh / setup.sh / setup_tui.sh<br/>.hadolint.yaml"]
+        dockerfile["Dockerfile<br/>compose.yaml<br/>script/entrypoint.sh<br/>script/local/justfile.local（repo 自有）"]
         repo_test["test/smoke/<br/>app_env.bats（repo 專屬）"]
         main_yaml["main.yaml<br/>→ 呼叫可重用 workflows"]
     end
 
     base -- "git subtree" --> consumer
-    scripts -. "symlink" .-> symlinks
+    scripts -. "per-sub symlink" .-> symlinks
     smoke -. "Dockerfile COPY" .-> repo_test
     workflows -. "@tag 引用" .-> main_yaml
 ```
@@ -104,14 +104,14 @@ graph TB
 ```mermaid
 flowchart LR
     subgraph local["本地"]
-        build_test["./build.sh test"]
-        make_test["just docker build test"]
+        just_test["just test"]
+        just_build["just docker build --stage test-tools"]
     end
 
     subgraph ci_container["CI 容器（ghcr.io/ycpss91255-docker/test-tools:latest）"]
         shellcheck["ShellCheck"]
-        hadolint["Hadolint"]
-        bats["Bats smoke tests"]
+        hadolint["Hadolint (just test lint)"]
+        bats["Bats specs"]
     end
 
     subgraph github["GitHub Actions"]
@@ -119,12 +119,12 @@ flowchart LR
         release_worker["release-worker.yaml<br/>（來自 base）"]
     end
 
-    build_test --> ci_container
-    make_test -->|"script/test/test.sh"| ci_container
+    just_build --> ci_container
+    just_test -->|"script/test/test.sh"| ci_container
     shellcheck --> hadolint --> bats
 
     push["git push / PR"] --> build_worker
-    build_worker -->|"docker build test"| ci_container
+    build_worker -->|"docker build (devel-test stage)"| ci_container
     tag["git tag v*"] --> release_worker
     release_worker -->|"tar.gz + zip"| release["GitHub Release"]
 ```
@@ -156,20 +156,31 @@ flowchart LR
 | `downstream/script/docker/runtime/logging.sh` | host 端 log tee helper |
 | `downstream/script/docker/runtime/smoke.sh` | runtime install-check smoke |
 | `downstream/script/docker/runtime/entrypoint.sh` | template entrypoint helper |
-| `script/test/test.sh` | CI orchestration（本地 + 遠端） |
+| `script/test/test.sh` | base 自身測試 dispatcher（本地 + 容器內） |
+| `script/test/drivers/` | 每個工具一支 driver — `bats.sh` / `shellcheck.sh` / `hadolint.sh` |
 | `script/test/lint_bare_stderr.sh` | Bare stderr lint 檢查 |
-| `script/test/lint_mixed_test_layout.sh` | Mixed-tool test layout 驗證 |
 | `config/` | Container 內部 shell 設定檔（bashrc、tmux、terminator、pip） |
 | `setup.conf` | 單一 per-repo runtime 配置（image / build / deploy / gui / network / volumes） |
-| `test/smoke/` | 共用 smoke 測試 + runtime assertion helpers（見下方） |
-| `test/unit/` | Template 自身測試（bats + kcov） |
-| `test/integration/` | Level-1 `init.sh` 整合測試 |
-| `test/behavioural/` | Runtime 整合測試 |
+| `downstream/test/smoke/` | 共用 smoke 測試 + runtime assertion helpers（見下方） |
+| `test/bats/unit/` | base 自身測試，unit（bats + kcov） |
+| `test/bats/integration/` | base 自身測試，init/upgrade 端對端 |
+| `test/bats/behavioural/` | base 自身測試，runtime 行為（opt-in） |
+
+測試內容採 **tool-first** 配置 -- spec 走 `test/<tool>/<category>/`
+（例如 `test/bats/unit/`）、linter 走 `test/lint/<tool>/` --
+新增一個工具就是開一個新資料夾，而非新增一個指令面。見
+[ADR-00000012](../adr/00000012-tool-first-test-layout.md)（取代 category-first
+的 ADR-00000004）。consumer 出貨自己的 `test/smoke/`；base 出貨自己的
+`test/bats/{unit,integration,behavioural}/`。
+
 | `.hadolint.yaml` | 共用 Hadolint 規則 |
-| `justfile` | Repo 指令入口（`just docker build`、`just docker run`、`just docker stop` 等 recipe）。Sub-cmd 與 flag 透過 `{{args}}` 直接傳遞，不需要 `--` 分隔符（`just docker build --no-cache test`）。`just` 無參時列出所有 recipe。 |
-| `script/test/justfile.test` | Template CI 指令入口（`just test`、`just test lint` 等）。user-facing 跟 CI-facing 是刻意切割。 |
-| `init.sh` | 首次初始化 symlinks + 新 repo 骨架產生 |
-| `upgrade.sh` | Subtree 版本升級 |
+| `justfile`（→ `script/justfile`） | Repo 指令入口 — 分層 namespace recipe（`just docker build`、`just docker run`、`just test`、`just base upgrade` 等）。Sub-cmd 與 flag 透過 `{{args}}` 直接傳遞（`just docker build --no-cache --stage test-tools`）；無參的 `just` 列出所有 namespace。 |
+| `downstream/script/docker/justfile.docker` | `docker` namespace — 容器操作（`just docker build/run/exec/stop/prune/setup/setup-tui`）。 |
+| `downstream/script/base/justfile.base` | `base` namespace — 管理 `.base` subtree（`just base init/update/upgrade/completions`）。 |
+| `downstream/script/base/init.sh` | 首次初始化 symlinks + 新 repo 骨架產生（bootstrap：`./.base/downstream/script/base/init.sh`；之後改用 `just base init`）。 |
+| `downstream/script/base/upgrade.sh` | Subtree 版本升級（`just base upgrade [vX.Y.Z]`）。 |
+| `script/test/justfile.test` | base 自身測試入口（`just test`、`just test lint`、`just test coverage` …）。 |
+| `script/release/justfile.release` | base `release` namespace（release / publish 工具）。 |
 | `downstream/dockerfile/Dockerfile` | 新 repo 的多階段 Dockerfile 範本 |
 | `dockerfile/Dockerfile.test-tools` | 預建置 lint/test 工具 image（shellcheck、hadolint、bats、bats-mock） |
 | `.github/workflows/` | 可重用 CI workflows（build + release） |
@@ -355,7 +366,7 @@ assertion helpers。下游 repo 應優先使用這些 helper 而非原生的
            [logging.<svc>] 可對單一 service 做 key-level override
 ```
 
-Template default 在 `.base/setup.conf`；per-repo 覆蓋放 `<repo>/setup.conf`。
+Template default 在 `.base/downstream/config/docker/setup.conf`；per-repo 覆蓋放 `<repo>/config/docker/setup.conf`。
 Section-level **replace** 策略：per-repo 檔若有該 section 就整段取代
 template；沒寫的 section 則吃 template 預設。
 
@@ -367,7 +378,7 @@ template；沒寫的 section 則吃 template 預設。
 ./setup_tui.sh                      # 互動式 dialog/whiptail 編輯器
 ./setup_tui.sh volumes              # 直接跳到指定 section
 ./build.sh --setup            # 有 TTY 時啟動 setup_tui.sh；無 TTY 時執行 setup.sh
-./.base/init.sh --gen-conf # 單純複製 .base/setup.conf 到 repo 根目錄
+./.base/downstream/script/base/init.sh --gen-conf # 單純複製 .base/downstream/config/docker/setup.conf 到 <repo>/config/docker/setup.conf
 ```
 
 ### 輸出 log 到 host
@@ -430,8 +441,8 @@ Main
 
 `setup.sh` 只在明確觸發時才執行 — 並不會在每次 build / run 都重跑：
 
-- **`./.base/init.sh`** 建完骨架自動跑一次
-- **`just base upgrade` / `./.base/upgrade.sh`** subtree pull 後透過 init.sh
+- **`just base init` / `./.base/downstream/script/base/init.sh`** 建完骨架自動跑一次
+- **`just base upgrade` / `./.base/downstream/script/base/upgrade.sh`** subtree pull 後透過 init.sh
   再跑一次，所以升級永遠會用新版 baseline 重新產出 `.env` / `compose.yaml`
 - **`./build.sh --setup` / `./run.sh --setup`**（或 `-s`）— 使用者手動觸發重跑；
   有 TTY 時先啟動 `setup_tui.sh` 讓使用者修改 `setup.conf`，無 TTY 時直接呼叫 `setup.sh`
@@ -663,8 +674,9 @@ git commit --allow-empty -m "chore: initial commit"
 git subtree add --prefix=.base \
     https://github.com/ycpss91255-docker/base.git vX.Y.Z --squash
 
-# 3. 初始化 symlinks（一個指令搞定）
-./.base/init.sh
+# 3. 初始化 symlinks（一次性 bootstrap；底層會跑 setup.sh）。
+#    之後改用 `just base init`（symlink 化的入口）。
+./.base/downstream/script/base/init.sh
 ```
 
 > `git subtree add` 需要 `HEAD` 存在。在剛 `git init` 且沒有任何 commit 的 repo 上會報錯 `ambiguous argument 'HEAD'` 與 `working tree has modifications`。用空 commit 建立 `HEAD`，subtree 才能 merge 進來。
@@ -689,16 +701,16 @@ just base upgrade v0.3.0
 # 行手改 .base/.version。
 
 # 沒有 just 時的 fallback
-./.base/upgrade.sh v0.3.0
+./.base/downstream/script/base/upgrade.sh v0.3.0
 ```
 
 `upgrade.sh` 一次完成：
 
 1. `git subtree pull --prefix=.base ... --squash`
 2. Post-pull 完整性檢查 — subtree marker（`.base/.version`、
-   `.base/init.sh`、`.base/downstream/script/docker/wrapper/setup.sh`）若不見了會
+   `.base/downstream/script/base/init.sh`、`.base/downstream/script/docker/wrapper/setup.sh`）若不見了會
    `git reset --hard` rollback（防舊版 `git-subtree.sh` destructive FF）
-3. `./.base/init.sh` 重跑：重整 root symlinks（`build.sh` / `run.sh`
+3. `./.base/downstream/script/base/init.sh` 重跑：重整 root symlinks（`build.sh` / `run.sh`
    / `justfile` …）、把 `.gitignore` 同步到 canonical entry set、
    `git rm --cached` 已經變成 derived artifact 的舊 tracked 檔（`.env`、
    `compose.yaml`、…），最後呼叫 `setup.sh apply` 重生 `.env` +
@@ -772,7 +784,7 @@ jobs:
 
 ## 本地執行測試
 
-使用 `script/test/justfile.test`（在 template 根目錄）：
+base 自身測試入口是 `just test`（由 `script/test/justfile.test` 提供）：
 ```bash
 just test        # 完整 CI（ShellCheck + Bats + Kcov）透過 docker compose
 just test lint        # 只跑 ShellCheck
@@ -794,143 +806,80 @@ just --list  # 顯示 CI 指令
 ## 目錄結構
 
 ```
-.base/
-├── init.sh                           # 初始化 repo（新建或既有）
-├── upgrade.sh                        # 升級 template subtree 版本
-├── script/
-│   ├── docker/                       # Docker 操作腳本
-│   │   ├── wrapper/                  # 使用者面向的 wrapper 腳本
-│   │   │   ├── build.sh
-│   │   │   ├── run.sh
-│   │   │   ├── exec.sh
-│   │   │   ├── stop.sh
-│   │   │   ├── prune.sh
-│   │   │   ├── setup.sh              # .env 產生器
-│   │   │   └── setup_tui.sh          # 互動式 setup 編輯器
-│   │   ├── lib/                      # 共用 helper 模組
-│   │   │   ├── _lib.sh               # 核心 wrapper 函式庫
-│   │   │   ├── bootstrap.sh          # Wrapper 初始化
-│   │   │   ├── compose.sh            # Compose 產生
-│   │   │   ├── conf.sh               # INI 解析器
-│   │   │   ├── conf_logging.sh       # Logging 配置
-│   │   │   ├── env.sh                # 環境設定
-│   │   │   ├── gitignore.sh          # Gitignore 管理
-│   │   │   ├── hook.sh               # 各 wrapper hook
-│   │   │   ├── i18n.sh               # 語言偵測
-│   │   │   ├── log.sh                # Logging 工具
-│   │   │   ├── config_summary.sh     # 配置摘要
-│   │   │   ├── _tui_backend.sh       # TUI dialog/whiptail 包裝
-│   │   │   ├── _tui_conf.sh          # TUI INI validator
-│   │   │   ├── log-events.txt        # Log 事件目錄
-│   │   │   └── log.lnav-format.json  # Lnav format 定義
-│   │   ├── runtime/                  # 容器內 runtime 腳本
-│   │   │   ├── entrypoint.sh         # Template entrypoint helper
-│   │   │   ├── logging.sh            # Host 端 log tee helper
-│   │   │   └── smoke.sh              # Runtime install-check smoke
-│   │   ├── justfile                  # Docker 操作入口（just）
-│   │   └── setup.conf                # Template runtime 配置預設
-│   └── ci/                           # CI pipeline 腳本
-│       ├── test.sh                     # CI orchestration（本地 + 遠端）
-│       ├── lint_bare_stderr.sh       # Bare stderr lint 檢查
-│       └── lint_mixed_test_layout.sh # Mixed-tool test layout 驗證
-├── dockerfile/
-│   ├── Dockerfile            # 多階段範本（sys / devel-base / devel / devel-test / [runtime-base / runtime / runtime-test]）
-│   └── Dockerfile.test-tools         # 預建置 lint/test 工具 image
-├── config/                           # Container 內部 shell / 工具設定
-│   ├── docker/
-│   │   └── setup.conf                # Runtime 配置（per-repo override mirror: <repo>/config/docker/setup.conf）
-│   └── shell/
-│       ├── bashrc
-│       ├── bashrc.d/                 # 互動式 shell bootstrap drop-in
-│       │   └── .gitkeep
-│       ├── terminator/
-│       │   ├── setup.sh
-│       │   └── config
-│       └── tmux/
-│           ├── setup.sh
-│           ├── README.adoc
-│           └── tmux.conf
-├── test/
-│   ├── smoke/                        # 共用 smoke 測試 + runtime assertion helpers
-│   │   ├── test_helper.bash          # assert_cmd_installed / _runs / file / dir / owned_by / pip_pkg
-│   │   ├── script_help.bats
-│   │   └── display_env.bats
-│   ├── unit/                         # 模板自身測試（bats + kcov）
-│   │   ├── test_helper.bash
-│   │   ├── bashrc_spec.bats
-│   │   ├── build_sh_spec.bats
-│   │   ├── build_sh_prune_spec.bats
-│   │   ├── build_worker_yaml_spec.bats
-│   │   ├── ci_spec.bats
-│   │   ├── compose_gen_spec.bats
-│   │   ├── compose_logging_spec.bats
-│   │   ├── compose_overlay_spec.bats
-│   │   ├── conf_logging_spec.bats
-│   │   ├── deploy_spec.bats
-│   │   ├── entrypoint_logging_spec.bats
-│   │   ├── exec_sh_spec.bats
-│   │   ├── gitignore_spec.bats
-│   │   ├── hook_spec.bats
-│   │   ├── init_spec.bats
-│   │   ├── lib_spec.bats
-│   │   ├── lint_mixed_test_layout_spec.bats
-│   │   ├── log_spec.bats
-│   │   ├── makefile_user_spec.bats
-│   │   ├── multi_distro_build_worker_yaml_spec.bats
-│   │   ├── prune_sh_spec.bats
-│   │   ├── release_test_tools_yaml_spec.bats
-│   │   ├── run_sh_spec.bats
-│   │   ├── runtime_smoke_spec.bats
-│   │   ├── self_test_yaml_spec.bats
-│   │   ├── setup_spec.bats
-│   │   ├── smoke_helper_spec.bats
-│   │   ├── stop_sh_spec.bats
-│   │   ├── template_spec.bats
-│   │   ├── terminator_config_spec.bats
-│   │   ├── terminator_setup_spec.bats
-│   │   ├── tmux_conf_spec.bats
-│   │   ├── tmux_setup_spec.bats
-│   │   ├── tui_backend_spec.bats
-│   │   ├── tui_flow.bats
-│   │   ├── tui_mount_assembler_spec.bats
-│   │   ├── tui_spec.bats
-│   │   ├── upgrade_spec.bats
-│   │   └── wrapper_lib_lookup_spec.bats
-│   ├── integration/                  # Level-1 init.sh 端對端測試
-│   │   ├── init_new_repo_spec.bats
-│   │   ├── upgrade_spec.bats
-│   │   ├── fresh_clone_portability_spec.bats
-│   │   ├── gitignore_sync_spec.bats
-│   │   └── wrapper_compose_dispatch_spec.bats
-│   └── behavioural/                  # Runtime 整合測試
-│       └── runtime_test_smoke_spec.bats
-├── script/test/justfile.test                       # 模板 CI 入口（just test/lint/...）
-├── compose.yaml                      # Docker CI 執行器
-├── .hadolint.yaml                    # 共用 Hadolint 規則
-├── .dockerignore
-├── codecov.yml
-├── .github/workflows/
-│   ├── self-test.yaml                # 模板 CI
-│   ├── build-worker.yaml             # 可重用 build + smoke-test workflow
-│   ├── release-worker.yaml           # 可重用 release（source archive）workflow
-│   ├── publish-worker.yaml           # 可重用 image publish workflow（opt-in）
-│   ├── multi-distro-build-worker.yaml # 多 distro build workflow
-│   └── release-test-tools.yaml       # 模板自身的 test-tools image release
-├── doc/
-│   ├── readme/                       # README 翻譯
-│   │   ├── README.zh-TW.md
-│   │   ├── README.zh-CN.md
-│   │   └── README.ja.md
-│   ├── adr/                          # Architecture Decision Records
-│   │   ├── 00000001-setup-conf-vs-compose.md
-│   │   ├── 00000002-no-latest-tag.md
-│   │   ├── 00000003-env-vs-workload-param-boundary.md
-│   │   └── 00000004-test-category-tool-subdir-layout.md
+.base/                                  # subtree 釘在 consumer 的 <repo>/.base/
+├── .version                            # 釘住的 base release tag
+├── justfile                            # base 自身的 self-test/release 入口（mods test + release）
+├── compose.yaml                        # base CI runner（test-tools 服務）
+├── .dockerignore                       # Canonical ignore 集（同步進各 consumer）
+├── .codecov.yaml                       # 覆蓋率上傳設定
+├── downstream/                         # 出貨的工具 + 內容（single source of truth）
+│   ├── .hadolint.yaml                  # 共用 Hadolint 規則（symlink 進各 consumer）
+│   ├── dockerfile/
+│   │   └── Dockerfile                  # 新 repo 的多階段 Dockerfile 範本
+│   ├── config/                         # Container 內部 shell / 工具設定
+│   │   ├── docker/
+│   │   │   └── setup.conf              # Template runtime 配置預設
+│   │   └── shell/
+│   │       ├── bashrc
+│   │       ├── bashrc.d/               # 互動式 shell bootstrap drop-in
+│   │       ├── terminator/             # setup.sh + config
+│   │       └── tmux/                   # setup.sh + tmux.conf + README.adoc
+│   ├── script/                         # 通用工具（consumer 逐 sub symlink）
+│   │   ├── justfile                    # Consumer 容器操作入口（mods docker/base/template）
+│   │   ├── docker/                     # `docker` namespace
+│   │   │   ├── justfile.docker         # just docker build/run/exec/stop/prune/setup/setup-tui
+│   │   │   ├── wrapper/                # build.sh / run.sh / exec.sh / stop.sh / prune.sh
+│   │   │   │                           #   / setup.sh / setup_tui.sh
+│   │   │   ├── lib/                    # 共用 helper 模組（_lib / compose / conf / log
+│   │   │   │                           #   / i18n / hook / wrapper / schema / transcript / ...）
+│   │   │   └── runtime/                # 容器內：entrypoint.sh / logging.sh / smoke.sh
+│   │   ├── base/                       # `base` namespace（管理 .base subtree）
+│   │   │   ├── justfile.base           # just base init/update/upgrade/completions
+│   │   │   ├── init.sh                 # 首次 bootstrap + symlink/.gitignore resync
+│   │   │   ├── upgrade.sh              # Subtree 版本升級（往上找到 .base root）
+│   │   │   └── completions.sh          # 選用的 shell tab-completion 安裝器
+│   │   └── template/                   # `template` namespace（scaffold repo-local group）
+│   │       ├── justfile.template       # just template new <name>
+│   │       ├── new.sh
+│   │       └── skel/                   # justfile.skel + skel.sh
+│   └── test/
+│       └── smoke/                      # 共用 smoke 測試 + runtime assertion helpers
+│           ├── test_helper.bash        #   assert_cmd_installed / _runs / file / dir / ...
+│           ├── script_help.bats
+│           └── display_env.bats
+├── script/                             # base 自身的 self-test/release 工具（不 symlink）
 │   ├── test/
-│   │   └── TEST.md                   # 測試清單與 spec 表
+│   │   ├── justfile.test               # just test / lint / coverage / behavioural
+│   │   ├── test.sh                     # Dispatcher（本地 + 容器內）
+│   │   ├── lint_bare_stderr.sh
+│   │   └── drivers/                    # 每個工具一支 driver：bats.sh / shellcheck.sh / hadolint.sh
+│   └── release/
+│       └── justfile.release            # just release <recipe>
+├── dockerfile/
+│   └── Dockerfile.test-tools           # 預建置 lint/test 工具 image（shellcheck/hadolint/bats）
+├── test/                               # base 自身 spec（tool-first：test/<tool>/<category>/）
+│   └── bats/
+│       ├── unit/                       # 58 個 unit spec + test_helper.bash（bats + kcov）
+│       ├── integration/                # init/upgrade 端對端（5 個 spec）
+│       └── behavioural/                # Runtime 行為（opt-in；runtime_test_smoke_spec.bats）
+├── .github/
+│   ├── dependabot.yml
+│   └── workflows/
+│       ├── self-test.yaml              # base CI（ShellCheck + Bats + Kcov 覆蓋率 gate）
+│       ├── build-worker.yaml           # 可重用 build + smoke-test workflow
+│       ├── release-worker.yaml         # 可重用 release（source archive）workflow
+│       ├── publish-worker.yaml         # 可重用 image publish workflow（opt-in）
+│       ├── multi-distro-build-worker.yaml # 多 distro build workflow
+│       └── release-test-tools.yaml     # base 自身的 test-tools image release
+├── doc/
+│   ├── readme/                         # README 翻譯（zh-TW / zh-CN / ja）
+│   ├── adr/                            # Architecture Decision Records（00000001 … 00000012）
+│   ├── test/
+│   │   └── TEST.md                     # 測試清單與 spec 表
 │   ├── changelog/
-│   │   └── CHANGELOG.md              # 發布記錄
+│   │   └── CHANGELOG.md
 │   └── deprecations.md
+├── CONTEXT.md
 ├── .gitignore
 ├── LICENSE
 └── README.md


### PR DESCRIPTION
## What

Refresh the base README across all four locales to match the shipped
ADR-00000011 namespace command model + the base=origin / downstream
layout (#656, epic #625). **Reduced scope per the 2026-06-23 issue
comment: base-side docs only -- the 17-repo fanout stays in #497.**

Each of `README.md` (en), `doc/readme/README.zh-TW.md`,
`doc/readme/README.zh-CN.md`, `doc/readme/README.ja.md`:
- regenerated the **structure-tree** to match the actual shipped subtree
  (downstream/ real files + base-own `script/{test,release}`, tool-first
  `test/bats/{unit,integration,behavioural}`, etc.) -- verified top-level
  + every listed path against `git ls-files`;
- updated both **mermaid** diagrams (Architecture + CI/CD) to namespaced
  commands;
- rewrote TL;DR / Prerequisites / Quick Start / What's-included tables /
  wrapper cheat-sheet to the new verbs (`just docker build`, `just test`,
  `just release ...`, `just base init|update|upgrade|completions`,
  `just template new`) and new paths (`./.base/downstream/script/base/
  init.sh` bootstrap, then `just base init|upgrade`);
- dropped all stale `just ci` / `just build` / root `init.sh` / old-test-
  layout mentions.

Section structure, anchors, and ToC kept consistent across locales;
mermaid node identifiers stay English with localized annotations.

## Decisions
- Structure-tree follows the **actual tree** where ADR-00000011 §4/§5
  aspiration (per-sub `script/<ns>` symlinks, `test/lint/<tool>/` dirs)
  diverges from what shipped (base has its own `script/{test,release}`;
  base lint runs via drivers) -- prose still cites ADR-00000012 for the
  tool-first intent.
- unit specs listed as a directory + count (56 specs + 2 bash helpers)
  rather than enumerated, to stop the tree drifting.
- Backfilled zh-CN parity gaps (init/upgrade + `setup.conf` paths) so all
  four locales agree.

## Not in this PR
The harness CLAUDE.md command/workflow-row update (different repo,
ack-gated) is handled separately by the main session; this PR ships an
OLD->NEW row list for it.

## Tests
Docs-only, no behaviour change. `just test` 1968 ok (1883 unit + 85
integration); `just test lint` clean.

Refs #656, #625, ADR-00000011, ADR-00000012.
