### PR TITLE
ci(classify): add CONTEXT.md to the doc-only allow-list

### DIFF
--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -32,7 +32,7 @@ jobs:
     # Per-PR diff classifier (pure shell, no third-party GHA action — same
     # spirit as #273 Phase 2's build-worker.yaml classifier). Emits two
     # outputs for downstream jobs:
-    #   code_changed         — false if the PR changes only doc/** + README.md + LICENSE
+    #   code_changed         — false if the PR changes only doc/** + README.md + LICENSE + CONTEXT.md
     #   behavioural_relevant — false if the PR does NOT touch any path in the
     #                          behavioural block-list (script/entrypoint.sh,
     #                          compose.yaml, Dockerfile.example,
@@ -91,7 +91,7 @@ jobs:
           BASE="origin/${BASE_REF}"
           # code_changed: anything outside the doc-only allow-list.
           if git diff --quiet "${BASE}"...HEAD \
-               -- ':!doc/**' ':!README.md' ':!LICENSE'; then
+               -- ':!doc/**' ':!README.md' ':!LICENSE' ':!CONTEXT.md'; then
             echo "code_changed=false" >> "${GITHUB_OUTPUT}"
           else
             echo "code_changed=true" >> "${GITHUB_OUTPUT}"

--- a/doc/changelog/CHANGELOG.md
+++ b/doc/changelog/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **doc-only CI short-circuit now also covers `CONTEXT.md`** — the `classify` job's `code_changed` allow-list was `doc/** + README.md + LICENSE`, so a change to the root-level `CONTEXT.md` (tracked domain glossary, pure docs, not under `doc/`) tripped `code_changed=true` and ran the full heavy suite (shellcheck / hadolint / bats / coverage / integration-e2e / behavioural). Added `':!CONTEXT.md'` to the diff allow-list so a glossary-only PR skips them like any other docs change. `self_test_yaml_spec.bats` allow-list assertion updated.
+
 ### Fixed
 - **bump `extractions/setup-just@v3 -> @v4` to clear the last node20 deprecation warning** — #737 cleared the GitHub-owned actions, but the `integration-e2e` job's `setup-just@v3` (third-party) still declared node20 and warned on both arch shards. v4 is the maintainer's current major; the usage is parameterless so it is drop-in. Finishes the node20 cleanup for base.
 - **bump node20 GitHub Actions to node24 majors to clear the runner deprecation warning (#737)** — GitHub deprecated the Node 20 runtime and force-runs node20 actions on node24 (a shim that warns but still passes). Bumped the pinned versions that declared `node20` in their `action.yml`: `actions/upload-artifact@v4 -> @v7`, `actions/download-artifact@v4 -> @v8`, `actions/cache@v4 (save + restore) -> @v6` across `self-test.yaml`, `release-test-tools.yaml`, `publish-worker.yaml` (8 refs). `actions/checkout@v6` already runs node24. Note: `upload-artifact@v5` is STILL node20, so v6+ is required. `self_test_yaml_spec.bats` version assertions updated (@v4 -> @v7/@v8). The artifact upload<->download backend round-trip (coverage shards upload, coverage-gate downloads the `coverage-shard-*` artifacts) is verified by this PR's own CI run. Org-wide fan-out to other repos uses the same version set.

--- a/test/bats/unit/self_test_yaml_spec.bats
+++ b/test/bats/unit/self_test_yaml_spec.bats
@@ -66,12 +66,16 @@ setup() {
   assert_output --partial 'behavioural_relevant: ${{ steps.diff.outputs.behavioural_relevant }}'
 }
 
-@test "self-test.yaml: classify uses doc-only allow-list 'doc/**' + 'README.md' + 'LICENSE' (#317)" {
+@test "self-test.yaml: classify uses doc-only allow-list 'doc/**' + 'README.md' + 'LICENSE' + 'CONTEXT.md' (#317)" {
   run awk '/^  classify:/{flag=1; next} /^  [a-z]/{flag=0} flag' "${WF}"
   assert_success
   assert_output --partial "':!doc/**'"
   assert_output --partial "':!README.md'"
   assert_output --partial "':!LICENSE'"
+  # CONTEXT.md is tracked at the repo root (domain glossary, pure docs) but is
+  # not under doc/, so without this it would trip code_changed=true and run the
+  # full suite for a glossary-only change.
+  assert_output --partial "':!CONTEXT.md'"
 }
 
 @test "self-test.yaml: classify uses behavioural block-list entrypoint + compose + Dockerfile + wrappers + init/upgrade + workflows (#317)" {


### PR DESCRIPTION
## What

The `classify` job's doc-only `code_changed` allow-list was `doc/** + README.md + LICENSE`. The root-level `CONTEXT.md` (tracked domain glossary, pure docs but NOT under `doc/`) therefore tripped `code_changed=true` and ran the full heavy suite (shellcheck / hadolint / bats / coverage / integration-e2e / behavioural) for a glossary-only change.

Added `':!CONTEXT.md'` to the diff allow-list so a CONTEXT.md-only PR short-circuits like other docs.

## Notes

- Verified the gap against the actual tracked files: in base only `CONTEXT.md` is a tracked doc file outside the allow-list (README.zh-TW.md / CLAUDE.md are NOT tracked here). README.md / LICENSE / everything under doc/ (CHANGELOG, ADR, TEST.md) was already covered.
- `self_test_yaml_spec.bats` allow-list assertion updated; actionlint exit 0; full local CI mirror green + stamped.
