### PR TITLE
docs(adr): test-files-mirror-source (15) + coverage-tooling-eval (16, proposed)

### DIFF
--- a/doc/adr/00000015-test-files-mirror-source-not-the-reverse.md
+++ b/doc/adr/00000015-test-files-mirror-source-not-the-reverse.md
@@ -1,0 +1,99 @@
+# Test files mirror source files; source structure never follows tests
+
+- **Date:** 2026-06-27
+- **Status:** Accepted
+- **Relates to:** ADR-00000012 (tool-first `test/<tool>/<category>/`
+  layout -- this ADR governs file granularity *within* a category dir),
+  ADR-00000008 (sharded coverage PR gate -- the per-file shard floor this
+  convention helps lower), ADR-00000014 (the setup.sh decomposition that
+  produced the libs these specs now mirror)
+
+## Context
+
+ADR-00000012 fixed *where* test files live (`test/<tool>/<category>/`).
+It did not fix *how a test file maps to the source it covers*. After the
+setup.sh decomposition (ADR-00000014) split one god-source into nine
+subsystem libs, the tests still sat in a handful of god-test-files
+(`setup_spec` 146 tests, `setup_emit_spec`, `compose_gen_spec`, ...) that
+each spanned several libs. Two forces converged on needing a rule:
+
+1. **Navigability / locality.** A reader looking for `resolve.sh`'s tests
+   had to grep inside `setup_spec.bats`; a lib and its spec had no name
+   correspondence.
+2. **The coverage shard floor.** kcov instruments each spec **file** as
+   one atomic unit, so a file cannot be split across shards. The longest
+   single spec file is therefore the hard floor on the slowest coverage
+   shard regardless of shard count (measured: `deploy_spec` 97s set the
+   floor; the slowest shard was ~170s = that floor plus packed
+   neighbours). Finer, source-aligned files give the partitioner smaller,
+   more balanceable units.
+
+The tempting shortcut -- when one source file needs more than one test
+file (for granularity or to test distinct sub-units) -- is to split the
+**source** so each spec gets a 1:1 source file. That lets tests dictate
+source structure. We reject it.
+
+## Decision
+
+**Test files mirror source files. Source structure is decided by design,
+never by the number or shape of test files.**
+
+Concretely, within a `test/<tool>/<category>/` directory:
+
+- **One source file (lib) maps to one spec by default**, with name
+  correspondence: `lib/<name>.sh` <-> `<name>_spec.bats` (flat, mirroring
+  the flat `lib/`).
+- **A lib that genuinely needs multiple sub-unit specs gets a `<name>/`
+  folder** named after the source file; the sub-specs live inside it
+  (`<name>/<subunit>_spec.bats`). The folder -- not a renamed flat file --
+  is what restores alignment when a single source file has several test
+  units. The folder's *presence* signals "this lib has multiple test
+  units"; single-spec libs stay flat (no over-structuring), exactly as
+  pytest / RSpec only foliate a module when it has multiple test files.
+- **Never split a source `.sh` to achieve 1:1 test alignment.** Source
+  structure follows the deep-module principle (a small interface over its
+  private implementation helpers; see the architecture LANGUAGE). Splitting
+  a generator's private `_emit_*` helpers into their own file just to give
+  them their own spec exposes implementation across a file seam and makes
+  the module shallower -- the tail wagging the dog.
+- **Integration / end-to-end tests live with the orchestrator they
+  exercise, not with a leaf lib.** A test that drives a whole pipeline
+  (e.g. `setup apply`: detect -> resolve -> write_env -> drift) belongs in
+  the orchestrator's spec (`setup_spec`), because that *is* what it tests.
+  Only isolated single-unit tests move out to the leaf lib's spec.
+
+The shard partitioner globs specs recursively (`test/<tool>/<cat>/**/*_spec.bats`)
+so foldered sub-specs are first-class shard units -- a `<lib>/` folder
+costs nothing for balancing; each file inside is still its own kcov unit.
+
+## Consequences
+
+- Every subsystem lib has a name-corresponding spec (or `<lib>/` folder),
+  so "where are X's tests" is answerable from the lib name alone.
+- The coverage shard floor drops as god-test-files split into
+  source-aligned units; foldering (not source-splitting) handles libs that
+  need several specs, so coverage granularity never pressures source
+  cohesion.
+- A mild asymmetry remains -- most libs have a flat `<lib>_spec.bats`, a
+  few have a `<lib>/` folder. This is intentional and meaningful (folder ==
+  multiple test units), matching the pytest / RSpec norm.
+- Future test work, in base and downstream, must align to this rule. A
+  lint check that flags a spec whose name matches no source file (or a
+  source file with no spec) is a natural follow-up enforcement.
+
+## Alternatives
+
+- **Split the source file so every spec is 1:1 with a `.sh`.** Rejected:
+  lets test-file count drive source structure, exposing private
+  implementation helpers across file seams and shallowing deep modules.
+  Industry frameworks (pytest, RSpec) explicitly do not require 1:1
+  source<->test and instead foliate a module into a folder of specs when
+  needed -- which is the accepted form of this ADR.
+- **Keep multi-concern god-test-files, balance shards by count/time
+  only.** Rejected: a single oversized file is an irreducible shard floor
+  under kcov's per-file atomicity (ADR-00000008), and the files stay
+  un-navigable (no lib<->spec correspondence). Better partitioning cannot
+  beat the longest-single-file floor.
+- **Always foliate every lib into a `<lib>/` folder for uniformity.**
+  Rejected: over-structuring -- most libs have one cohesive test unit and a
+  flat `<lib>_spec.bats` is clearer. Folder only when multiplicity is real.

--- a/doc/adr/00000016-coverage-tooling-evaluation.md
+++ b/doc/adr/00000016-coverage-tooling-evaluation.md
@@ -1,0 +1,82 @@
+# Coverage tooling: evaluate kcov alternatives to lift the per-file shard floor
+
+- **Date:** 2026-06-27
+- **Status:** Proposed
+- **Relates to:** ADR-00000008 (sharded coverage PR gate, built on kcov),
+  ADR-00000015 (test files mirror source -- the symptom-level lever),
+  issue #758 (lower the coverage critical path)
+
+## Context
+
+Coverage is an enforced PR gate run under **kcov** (ADR-00000008). kcov
+collects coverage via **ptrace**, single-stepping the traced process. That
+has two costs measured in this repo:
+
+1. **Per-run overhead.** kcov roughly +60% wall-clock over plain bats
+   (`deploy_spec` 57s plain -> 92s under kcov).
+2. **Per-file atomicity for sharding.** Because each spec file is run as
+   one kcov invocation (to amortise the ptrace launch cost), a file cannot
+   be split across shards. The longest single spec file is the hard floor
+   on the slowest coverage shard, which sits on the PR critical path.
+
+The dynamic + time-weighted + cached shard work (#725/#724/#733) and the
+conf parse-once perf (#742) halved the critical path (~409s -> ~208s total;
+slowest shard ~381s -> ~176s). ADR-00000015 lowers the per-file floor by
+splitting god-test-files into source-aligned units. Both treat the
+**symptom**. The **root** is the tool: if coverage overhead were near
+zero, coverage could fold back into the normal test pass and the whole
+separate-sharded-coverage architecture could be retired.
+
+## Candidate tools
+
+| tool | mechanism | note |
+|---|---|---|
+| **kcov** (current) | ptrace | cobertura native; language-agnostic; the +60% / per-file constraint above |
+| **bashcov** | bash xtrace (`DEBUG` trap / `PS4` via `BASH_XTRACEFD`), no ptrace | works with bats; auto-merges; SimpleCov-based, so cobertura needs `simplecov-cobertura`; DEBUG-trap has its own per-command overhead and known correctness edges around `set -e`, subshells |
+| **DIY `PS4` + `BASH_XTRACEFD`** | own `DEBUG` trap recording line hits | lightest, fully in our control; must write our own report emitter |
+| **ShellSpec** | own BDD framework with built-in parallelism | its coverage is itself kcov under the hood -- does not remove the root |
+
+## Decision (pending -- this ADR is Proposed)
+
+Before committing to any tool change, run a **time-boxed throwaway spike**
+(the prototype workflow) measuring **bashcov** and a **DIY PS4** tracer
+against kcov on 2-3 representative specs (the heavy `deploy_spec`, a light
+one). The spike must answer three gating questions with numbers:
+
+1. **Speed** -- is it materially faster than kcov's ptrace?
+2. **Reporting** -- can it emit cobertura the existing gate / timings cache
+   consume, or what replaces them?
+3. **Fidelity** -- does it stay accurate under our `set -u`, subshells, and
+   `local -n` patterns (no false coverage gaps / no crashes)?
+
+Decide only on the spike's evidence:
+
+- If a lighter tracer clears all three: adopt it, and re-evaluate whether
+  the separate sharded-coverage job (ADR-00000008) can collapse into the
+  normal test pass.
+- If none clears the bar: keep kcov; ADR-00000015's source-aligned splits
+  remain the available lever, and this ADR is marked Rejected with the
+  spike numbers recorded.
+
+This is intentionally sequenced **after** ADR-00000015's P1 (the
+source-aligned re-split), which is low-regret regardless of the tool
+outcome.
+
+## Consequences (if adopted)
+
+- A coverage tool swap touches the test-tools image (currently bakes
+  kcov), the gate's cobertura parser, and the `.shard-weights` timings
+  cache -- an ADR-00000008-level change, hence the spike-first gate.
+- A near-zero-overhead tracer could remove the dedicated coverage shards
+  entirely, simplifying `self-test.yaml` and erasing the per-file floor as
+  a concern -- the largest available structural win, but the riskiest.
+
+## Alternatives
+
+- **Do nothing; live with kcov.** Viable -- the symptom-level levers
+  (sharding + ADR-00000015) already keep the gate within budget. This ADR
+  exists because the user asked whether the constraint can be removed at
+  the root, not because the gate is currently failing.
+- **Skip the spike, swap to bashcov directly.** Rejected: bashcov's
+  DEBUG-trap overhead and `set -e`/subshell fidelity are unproven for our
+  code; swapping blind risks a slower or less accurate gate.


### PR DESCRIPTION
## What

Two ADRs capturing the design locked in the #758 grill.

**ADR-00000015 (Accepted) -- Test files mirror source files; source structure never follows tests.**
- One lib maps to one `<name>_spec.bats` by default (flat, mirroring flat `lib/`).
- A lib that genuinely needs multiple sub-unit specs gets a `<name>/` folder (not a renamed flat file, and NOT a source split).
- Never split a `.sh` source file to achieve 1:1 test alignment -- source follows the deep-module principle, not test-file count.
- Integration / e2e tests live with the orchestrator they exercise (e.g. `setup apply` pipeline tests stay in `setup_spec`), only isolated unit tests move to the leaf lib's spec.
- Governs future test-file granularity in base + downstream. Relates to ADR-00000012 (dir layout), ADR-00000008 (per-file shard floor), ADR-00000014 (the libs being mirrored).

**ADR-00000016 (Proposed) -- Coverage tooling evaluation.**
- kcov's ptrace gives ~+60% overhead and forces per-file shard atomicity (the longest spec file is the hard shard floor).
- Candidates: bashcov (xtrace/DEBUG-trap), DIY `PS4`+`BASH_XTRACEFD`, ShellSpec (itself kcov-backed).
- Decision gated behind a time-boxed spike that must clear speed + cobertura output + `set -u`/subshell fidelity. Sequenced after ADR-00000015's source-aligned re-split (low-regret).

## Why

The #758 grill established that the coverage critical path is floored by the longest single spec file (kcov per-file atomicity). ADR-00000015 is the symptom-level lever (source-aligned splits); ADR-00000016 records the root-level option (lighter tracer) for later, spike-gated decision. Recording the test-organization rule as an ADR makes future test work align to one convention.

## Verification

Doc-only (two ADR files). `ci-and-stamp.sh` ran the full local CI mirror (`just test` + lint) green and stamped; CONTEXT.md does not enumerate individual ADRs, so no tree-listing update.

Refs #758
