### PR TITLE
docs(adr): mark ADR-00000016 Rejected -- spike disproved lighter-tracer premise

### DIFF
--- a/doc/adr/00000016-coverage-tooling-evaluation.md
+++ b/doc/adr/00000016-coverage-tooling-evaluation.md
@@ -1,7 +1,8 @@
 # Coverage tooling: evaluate kcov alternatives to lift the per-file shard floor
 
 - **Date:** 2026-06-27
-- **Status:** Proposed
+- **Decided:** 2026-06-29
+- **Status:** Rejected (spike below disproved the premise)
 - **Relates to:** ADR-00000008 (sharded coverage PR gate, built on kcov),
   ADR-00000015 (test files mirror source -- the symptom-level lever),
   issue #758 (lower the coverage critical path)
@@ -61,6 +62,46 @@ Decide only on the spike's evidence:
 This is intentionally sequenced **after** ADR-00000015's P1 (the
 source-aligned re-split), which is low-regret regardless of the tool
 outcome.
+
+## Spike result (2026-06-29) -- REJECTED
+
+Ran the time-boxed spike. It disproved the ADR's central premise.
+
+**Environment / versions compared** (the baked `test-tools:main` image):
+
+- image: `ghcr.io/ycpss91255-docker/test-tools:main`
+- `kcov v43`, `Bats 1.13.0`, `GNU bash 5.2.37(1)` (x86_64-alpine-linux-musl)
+- bashcov / DIY-PS4 not benchmarked: the image has **no ruby/gem**, and the
+  mechanism finding below made the benchmark moot.
+
+**Method.** Same test set both ways (`COVERAGE=1` so identical tests run),
+kcov invoked exactly as `_run_coverage` does (`--include-path=<repo>`, the
+same `--exclude-path` set). Single run per cell. plain = `bats --recursive
+<spec>`; kcov = `kcov ... bats --recursive <spec>`.
+
+**Data (kcov tax per spec):**
+
+| spec | plain bats | kcov | overhead |
+|---|---|---|---|
+| `deploy_spec.bats` | 29.7s | 47.4s | **+60%** |
+| `setup_detect_spec.bats` | 15.5s | 23.2s | **+50%** |
+
+- Reporting: `cobertura.xml` is produced fine (Q2 satisfied -- but moot).
+- **Key finding (Q1 answer):** kcov's output dir contained
+  `bash-helper-debug-trap.sh` / `bash-helper.sh` -- **kcov v43 already
+  instruments bash via a `DEBUG` trap, not ptrace.** That is the *same*
+  mechanism bashcov and the DIY-PS4 tracer use. The ADR's framing ("kcov =
+  heavy ptrace, bashcov = light xtrace") is wrong for the bash case.
+
+**Conclusion.** The +50-60% is the intrinsic cost of per-line bash coverage
+(a trap firing on every command), not a kcov-specific ptrace penalty. A
+DEBUG-trap-based alternative (bashcov) runs the same mechanism, would not
+materially beat it, and would add a ruby dependency to the test-tools image
+-- net negative. A DIY-PS4 tracer shares the mechanism and would need a
+hand-written cobertura emitter for single-digit-percent upside -- not worth
+it. **Coverage is at its structural floor; kcov stays.** The remaining
+total-CI lever is the arm64 `integration-e2e` QEMU pole (native runners,
+refs #587/#579), not the coverage tool.
 
 ## Consequences (if adopted)
 


### PR DESCRIPTION
## What

Mark **ADR-00000016 (coverage tooling evaluation) as Rejected**, recording the spike that disproved its premise.

## Spike result (2026-06-29)

Compared on the baked `test-tools:main` image: `kcov v43`, `Bats 1.13.0`, `bash 5.2.37` (Alpine). Same test set both ways (`COVERAGE=1`), kcov invoked as `_run_coverage` does.

| spec | plain bats | kcov | overhead |
|---|---|---|---|
| `deploy_spec.bats` | 29.7s | 47.4s | +60% |
| `setup_detect_spec.bats` | 15.5s | 23.2s | +50% |

- cobertura.xml produced fine.
- **Key finding:** kcov's output carries `bash-helper-debug-trap.sh` -- kcov v43 already instruments bash via a `DEBUG` trap, **not ptrace**. That is the same mechanism bashcov / DIY-PS4 use, so the ADR's "kcov heavy ptrace vs light xtrace" framing is wrong for bash.

## Decision

The +50-60% is the intrinsic cost of per-line bash coverage (trap per command), not a kcov penalty. A DEBUG-trap alternative would not beat it and bashcov adds a ruby dependency -- net negative. **Coverage is at its structural floor; kcov stays.** The remaining total-CI lever is the arm64 `integration-e2e` QEMU pole (native runners, refs #587/#579).

## Verification

Doc-only (ADR status + spike section). `ci-and-stamp.sh` ran the full local CI mirror green and stamped.

Refs #758
