### PR TITLE
chore(ci): remove stale QEMU comments now that runners are native arm64

### DIFF
--- a/.github/workflows/build-worker.yaml
+++ b/.github/workflows/build-worker.yaml
@@ -41,8 +41,7 @@ on:
         description: |
           Comma-separated target platforms. Each runs as a parallel job on
           its own native runner (linux/amd64 → ubuntu-latest, linux/arm64
-          → ubuntu-24.04-arm), so arm64 builds avoid QEMU emulation
-          (which would take 30-60 min per run on an amd64 host) and stay
+          → ubuntu-24.04-arm), so arm64 builds run natively and stay
           in the 5-15 min range.
 
           Each matrix shard runs the full pipeline (test-tools build,
@@ -327,9 +326,8 @@ jobs:
           echo "matrix=${json}" >> "${GITHUB_OUTPUT}"
 
   # ────────────────────────────────────────────────────────────────
-  # Per-platform build. Each shard runs on its native runner so
-  # arm64 doesn't pay QEMU emulation cost. Full test + devel +
-  # runtime pipeline runs per platform.
+  # Per-platform build. Each shard runs on its native runner.
+  # Full test + devel + runtime pipeline runs per platform.
   # ────────────────────────────────────────────────────────────────
   build:
     needs: [path-filter, compute-matrix]

--- a/.github/workflows/publish-worker.yaml
+++ b/.github/workflows/publish-worker.yaml
@@ -101,8 +101,7 @@ on:
           MVP supports linux/amd64 + linux/arm64 (publishes a multi-arch
           manifest list). When upstream base images are amd64-only,
           callers should leave this at the default; multi-arch base
-          images publish to linux/arm64 via native arm64 runners (no
-          QEMU emulation).
+          images publish to linux/arm64 via native arm64 runners.
       context_path:
         required: false
         type: string

--- a/.github/workflows/release-test-tools.yaml
+++ b/.github/workflows/release-test-tools.yaml
@@ -23,8 +23,7 @@ name: Release test-tools image to GHCR
 #
 # Multi-arch build model (#587): each architecture builds on its NATIVE
 # runner (linux/amd64 -> ubuntu-latest, linux/arm64 -> ubuntu-24.04-arm),
-# replacing the former single-runner QEMU emulation. Native arm64 is
-# faster and consistent with build-worker / publish-worker. Because the
+# consistent with build-worker / publish-worker. Because the
 # arches build on separate runners, each shard pushes its single-arch
 # image BY DIGEST (no tag), then a `merge` job assembles the tagged
 # multi-arch manifest list from the digests via

--- a/.github/workflows/self-test.yaml
+++ b/.github/workflows/self-test.yaml
@@ -684,7 +684,7 @@ jobs:
     needs: [actionlint, classify]
     if: needs.classify.outputs.code_changed == 'true'
     # A2 (#603): verify the init.sh -> build -> run -> exec -> stop
-    # runnability contract on BOTH arches via native runners (no QEMU).
+    # runnability contract on BOTH arches via native runners.
     # Static 2-entry matrix mirroring the platform->runner convention in
     # build-worker / publish-worker / release-test-tools (#587); a shared
     # platform->runner single-source is a follow-up in that umbrella.


### PR DESCRIPTION
## Resolution

Decision: treat #770 as a comment-only documentation cleanup scoped to
`.github/workflows`. Every inline QEMU reference in the reusable
workflows was confirmed obsolete (all arches build on native runners,
no `setup-qemu-action` remains) and removed or reworded, leaving
`grep -ri qemu .github/workflows` empty. Accurate, intentional QEMU
mentions outside the workflows (downstream `qemu-user-static` host
hooks, ADR/changelog history, test-doc convention notes) were
deliberately left untouched per the acceptance criteria. No workflow
behaviour changed.

## Summary

The org migrated fully to native per-arch runners (`ubuntu-24.04-arm`);
QEMU emulation is no longer used anywhere. Several reusable workflows
still carried inline comment text referring to "former QEMU" / "avoid
QEMU emulation" / "no QEMU", which misleads readers into thinking QEMU
is or was recently in use. This removes those stale comments so the
text matches reality (native per-arch runners).

Comment-only change; no behavioural diff to any workflow. After the
edits `grep -ri qemu .github/workflows` returns nothing.

## References removed

- `.github/workflows/build-worker.yaml` (platforms input description) —
  dropped "so arm64 builds avoid QEMU emulation (which would take 30-60
  min per run on an amd64 host)"; reworded to "so arm64 builds run
  natively". Safe: arm64 runs on `ubuntu-24.04-arm`, never emulated.
- `.github/workflows/build-worker.yaml` (`build` job header) — dropped
  "arm64 doesn't pay QEMU emulation cost". Safe: each shard already runs
  on its native runner.
- `.github/workflows/publish-worker.yaml` (platforms input description)
  — dropped the "(no QEMU emulation)" parenthetical. Safe: native arm64
  runners only.
- `.github/workflows/release-test-tools.yaml` (header comment) — dropped
  "replacing the former single-runner QEMU emulation. Native arm64 is
  faster"; kept "consistent with build-worker / publish-worker". Safe:
  the workflow already builds each arch on its native runner.
- `.github/workflows/self-test.yaml` (`integration-e2e` job comment) —
  dropped the "(no QEMU)" parenthetical. Safe: the matrix maps each
  platform to its native runner.

## Out of scope (intentional / accurate, left unchanged)

- `README*` + `doc/readme/*` `multiarch/qemu-user-static` binfmt
  snippets — real downstream host-hook usage (e.g. `jetson_sdk_manager`
  registering `qemu-aarch64`), not stale.
- `doc/adr/00000016`, `doc/changelog/CHANGELOG.md` historical mentions —
  permitted historical notes per the issue's acceptance criteria.
- `doc/test/*` and `test/bats/*` comments describing the native-runner
  (no-QEMU) convention and the dropped `setup-qemu-action` assertion —
  accurate and intentional.

## Verification

- `grep -ri qemu .github/workflows` -> no matches.
- Local CI stamp (shellcheck + hadolint + bats + issue-ref lint) green
  on the committed HEAD.

Closes #770
